### PR TITLE
Update travis go to version 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 # Golang version matrix
 go:
-    - 1.5.1
+    - 1.6
 
 env:
     global:


### PR DESCRIPTION
Some functionalities we are using are introduced in go 1.6. Let's update Travis to use it.