### PR TITLE
Update travis go to version 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 # Golang version matrix
 go:
-    - 1.5.1
+    - 1.6
 
 env:
     global:

--- a/main_test.go
+++ b/main_test.go
@@ -112,7 +112,7 @@ func TestBinarySize(t *testing.T) {
 	// so.
 	//
 	// When increasing, use current binary size on amd64 + 1M.
-	const maxSize int64 = 8400000
+	const maxSize int64 = 9525080
 	var programName string = "mender"
 	var built bool = false
 


### PR DESCRIPTION
Some functionalities we are using are introduced in go 1.6. Let's update Travis to use it.