### PR TITLE
support/mender-device-identity: example platform integration script

### DIFF
--- a/support/mender-device-identity
+++ b/support/mender-device-identity
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Example script called by Mender agent to collect device identity
+# data. The script needs to be located at
+# $(bindir)/mender-device-identity path for the agent to find it.
+# The script shall exit with non-0 status on errors. In this case the
+# agent will discard any output the script may have produced.
+#
+# The script shall output identity data in <key>=<value> format, one
+# entry per line. Example
+#
+# $ ./mender-device-identity
+# mac=de:ad:ca:fe:00:01
+# cpuid=1112233
+#
+# The example script collects the MAC address of a network interface
+# with the lowest ifindex, other than the loopback device 'lo'. The
+# identity data is output in the following format:
+#
+# mac=00:01:02:03:04:05
+#
+
+set -ueo pipefail
+
+SCN=/sys/class/net
+min=65535
+ifdev=
+
+# find iface with lowest ifindex, except loopback
+for dev in $SCN/*; do
+    if [ $dev = "$SCN/lo" ]; then
+        continue
+    fi
+
+    idx=$(cat $dev/ifindex)
+    if [ $idx -lt $min ]; then
+        min=$idx
+        ifdev=$dev
+    fi
+done
+
+if [ -z "$ifdev" ]; then
+    echo "no suitable interfaces found" >&2
+    exit 1
+else
+    echo "using interface $ifdev" >&2
+    # grab MAC address
+    echo "mac=$(cat $ifdev/address)"
+
+fi


### PR DESCRIPTION
The patch adds an example ntegration script for producing device
identity data. The script looks up a network interface with the lowest
ifindex, other than loopback interface, and grabs its MAC address. It is
assumed that /sys/class/net is available in the system.

The identity data is output to stdout and has a form of:
<key>=<value>

The script may produce some information to stderr, make sure that it's
accounted for by whoever is reading the output.