### PR TITLE
mender.conf: add example mender config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type logOptionsType struct {
 
 type runOptionsType struct {
 	version   *bool
+	config    *string
 	imageFile *string
 	commit    *bool
 	daemon    *bool
@@ -79,6 +80,9 @@ func argsParse(args []string) (runOptionsType, error) {
 
 	version := parsing.Bool("version", false, "Show mender agent version and exit.")
 
+	config := parsing.String("config", "/etc/mender/mender.conf",
+		"Configuration file location.")
+
 	commit := parsing.Bool("commit", false, "Commit current update.")
 
 	imageFile := parsing.String("rootfs", "",
@@ -104,6 +108,7 @@ func argsParse(args []string) (runOptionsType, error) {
 
 	runOptions := runOptionsType{
 		version,
+		config,
 		imageFile,
 		commit,
 		daemon,
@@ -275,7 +280,7 @@ func doMain(args []string) error {
 
 	case *runOptions.daemon:
 		controler := NewMender(env)
-		if err := controler.LoadConfig("/etc/mender/mender.conf"); err != nil {
+		if err := controler.LoadConfig(*runOptions.config); err != nil {
 			return err
 		}
 		if *runOptions.bootstrap {

--- a/mender.conf.example
+++ b/mender.conf.example
@@ -1,0 +1,12 @@
+{
+  "pollIntervalSeconds": 60,
+  "ServerURL": "localhost:9080",
+  "DeviceID": "ABCD-1234",
+  "ServerCertificate": "",
+  "ClientProtocol": "http",
+  "HttpsClient": {
+    "Certificate": "",
+    "Key": ""
+  }
+}
+


### PR DESCRIPTION
The config is based on mender.conf shipped by meta-mender Yocto
layer. The default server address is points to localhost:9080, so that
the the client will try to access the local services set up with docker.
