### PR TITLE
client state refactoring & basic authorization setup

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,6 +30,11 @@
 			"Rev": "feb2f3f2bec86824d6ac1963e934c790c51b2776"
 		},
 		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.5.1-2-g431554f",
+			"Rev": "431554f80b8ecf5058547f6c65b87fad81d90b03"
+		},
+		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "792786c7400a136282c1664665ae0a8db921c6c2"
 		},

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,9 +1,12 @@
+# These are identical to Apache-2.0 license.
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  LICENSE
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/mendertesting/LICENSE
 3591f687e2d6f49c83b1ec69577e8110afbde80be5ec81791bd86d2838ccd3de  vendor/github.com/mendersoftware/log/LICENSE
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/log/COPYING
 3591f687e2d6f49c83b1ec69577e8110afbde80be5ec81791bd86d2838ccd3de  vendor/github.com/mendersoftware/scopestack/LICENSE
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/scopestack/COPYING
+
+# These are identical to BSD 2 Clause license.
 192def682f6846c6a57e20cf044e224fa467948358163a18dd37bfe14578e6ab  vendor/github.com/pkg/errors/LICENSE
 
 # These are all identical to MIT license.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -4,6 +4,7 @@ bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/log/COPYING
 3591f687e2d6f49c83b1ec69577e8110afbde80be5ec81791bd86d2838ccd3de  vendor/github.com/mendersoftware/scopestack/LICENSE
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/scopestack/COPYING
+192def682f6846c6a57e20cf044e224fa467948358163a18dd37bfe14578e6ab  vendor/github.com/pkg/errors/LICENSE
 
 # These are all identical to MIT license.
 51a0c9ec7f8b7634181b8d4c03e5b5d204ac21d6e72f46c313973424664b2e6b  vendor/github.com/Sirupsen/logrus/LICENSE

--- a/client.go
+++ b/client.go
@@ -81,13 +81,6 @@ type httpsClientConfig struct {
 	isHttps    bool
 }
 
-type httpsClientAuthCreds struct {
-	// Cert+privkey that authenticates this client
-	clientCert tls.Certificate
-	// Trusted server certificates
-	trustedCerts x509.CertPool
-}
-
 func loadServerTrust(conf httpsClientConfig) (*x509.CertPool, error) {
 	if conf.serverCert == "" {
 		// TODO: this is for pre-production version only to simplify tests.

--- a/client.go
+++ b/client.go
@@ -16,14 +16,12 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
-	"errors"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -31,78 +29,47 @@ var (
 	errorAddingServerCertificateToPool = errors.New("Error adding trusted server certificate to pool.")
 )
 
-const (
-	minimumImageSize int64 = 4096 //kB
-)
-
 type RequestProcessingFunc func(response *http.Response) (interface{}, error)
 
-type Updater interface {
-	GetScheduledUpdate(processFunc RequestProcessingFunc, server string, deviceID string) (interface{}, error)
-	FetchUpdate(url string) (io.ReadCloser, int64, error)
-}
-
-// Client represents the http(s) client used for network communication.
-//
-type httpClient struct {
-	HTTPClient   *http.Client
-	minImageSize int64
-}
-
-type httpsClient struct {
-	httpClient
-	httpsClientAuthCreds
-}
-
 // Client initialization
-
-func NewUpdater(conf httpsClientConfig) (Updater, error) {
+func NewHttpClient(conf httpsClientConfig) (*http.Client, error) {
 
 	if conf == (httpsClientConfig{}) {
-		client := NewHttpClient()
-		if client == nil {
-			return nil, errors.New("Can not instantialte updater.")
-		}
-		return client, nil
+		return newHttpClient(), nil
 	}
-	client := NewHttpsClient(conf)
-	if client == nil {
-		return nil, errors.New("Can not instantialte updater.")
-	}
-	return client, nil
+
+	return newHttpsClient(conf)
 }
 
-func NewHttpClient() *httpClient {
-	var client httpClient
-	client.minImageSize = minimumImageSize
-	client.HTTPClient = &http.Client{}
-
-	return &client
+func newHttpClient() *http.Client {
+	return &http.Client{}
 }
 
-func NewHttpsClient(conf httpsClientConfig) *httpsClient {
-	var client httpsClient
-	client.httpClient = *NewHttpClient()
+func newHttpsClient(conf httpsClientConfig) (*http.Client, error) {
+	client := newHttpClient()
 
-	if err := client.initServerTrust(conf); err != nil {
-		log.Error("Can not initialize server trust: ", err)
-		return nil
+	trustedcerts, err := loadServerTrust(conf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot initialize server trust")
 	}
 
-	if err := client.initClientCert(conf); err != nil {
-		log.Error("Can not initialize client certificate: ", err)
-		return nil
+	clientcerts, err := loadClientCert(conf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "can not load client certificate")
 	}
 
 	transport := http.Transport{
 		TLSClientConfig: &tls.Config{
-			RootCAs:      &client.trustedCerts,
-			Certificates: []tls.Certificate{client.clientCert},
+			RootCAs: trustedcerts,
 		},
 	}
 
-	client.HTTPClient.Transport = &transport
-	return &client
+	if clientcerts != nil {
+		transport.TLSClientConfig.Certificates = []tls.Certificate{*clientcerts}
+	}
+
+	client.Transport = &transport
+	return client, nil
 }
 
 // Client configuration
@@ -121,172 +88,46 @@ type httpsClientAuthCreds struct {
 	trustedCerts x509.CertPool
 }
 
-func (c *httpsClient) initServerTrust(conf httpsClientConfig) error {
+func loadServerTrust(conf httpsClientConfig) (*x509.CertPool, error) {
 	if conf.serverCert == "" {
 		// TODO: this is for pre-production version only to simplify tests.
 		// Make sure to remove in production version.
 		log.Warn("Server certificate not provided. Trusting all servers.")
-		return nil
+		return nil, nil
 	}
 
-	c.trustedCerts = *x509.NewCertPool()
+	certs := x509.NewCertPool()
 	// Read certificate file.
 	cacert, err := ioutil.ReadFile(conf.serverCert)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	c.trustedCerts.AppendCertsFromPEM(cacert)
+	certs.AppendCertsFromPEM(cacert)
 
-	if len(c.trustedCerts.Subjects()) == 0 {
-		return errorAddingServerCertificateToPool
+	if len(certs.Subjects()) == 0 {
+		return nil, errorAddingServerCertificateToPool
 	}
-	return nil
+	return certs, nil
 }
 
-func (c *httpsClient) initClientCert(conf httpsClientConfig) error {
+func loadClientCert(conf httpsClientConfig) (*tls.Certificate, error) {
 	if conf.certFile == "" || conf.certKey == "" {
 		// TODO: this is for pre-production version only to simplify tests.
 		// Make sure to remove in production version.
 		log.Warn("No client key and certificate provided. Using system default.")
-		return nil
+		return nil, nil
 	}
 
 	clientCert, err := tls.LoadX509KeyPair(conf.certFile, conf.certKey)
 	if err != nil {
-		return errorLoadingClientCertificate
+		return nil, errorLoadingClientCertificate
 	}
-	c.clientCert = clientCert
-	return nil
+	return &clientCert, nil
 }
 
-func (c *httpClient) GetScheduledUpdate(process RequestProcessingFunc,
-	server string, deviceID string) (interface{}, error) {
-	// http client should be able to perform https requests
-	if strings.HasPrefix(server, "http://") || strings.HasPrefix(server, "https://") {
-		return c.getUpdateInfo(process, server, deviceID)
+func buildURL(server string) string {
+	if strings.HasPrefix(server, "https://") || strings.HasPrefix(server, "http://") {
+		return server
 	}
-	return c.getUpdateInfo(process, "http://"+server, deviceID)
-}
-
-func (c *httpsClient) GetScheduledUpdate(process RequestProcessingFunc,
-	server string, deviceID string) (interface{}, error) {
-	if strings.HasPrefix(server, "https://") {
-		return c.getUpdateInfo(process, server, deviceID)
-	}
-	return c.getUpdateInfo(process, "https://"+server, deviceID)
-}
-
-func (c *httpClient) getUpdateInfo(process RequestProcessingFunc, server string,
-	deviceID string) (interface{}, error) {
-	request := server + "/api/0.0.1/devices/" + deviceID + "/update"
-	r, err := c.makeAndSendRequest(http.MethodGet, request)
-	if err != nil {
-		log.Debug("Sending request error: ", err)
-		return nil, err
-	}
-
-	defer r.Body.Close()
-
-	return process(r)
-}
-
-// Returns a byte stream which is a download of the given link.
-func (c *httpClient) FetchUpdate(url string) (io.ReadCloser, int64, error) {
-	r, err := c.makeAndSendRequest(http.MethodGet, url)
-	if err != nil {
-		log.Error("Can not fetch update image: ", err)
-		return nil, -1, err
-	}
-
-	log.Debugf("Received fetch update response %v+", r)
-
-	if r.StatusCode != http.StatusOK {
-		log.Errorf("Error fetching shcheduled update info: code (%d)", r.StatusCode)
-		return nil, -1, errors.New("Error receiving scheduled update information.")
-	}
-
-	if r.ContentLength < 0 {
-		return nil, -1, errors.New("Will not continue with unknown image size.")
-	} else if r.ContentLength < c.minImageSize {
-		log.Errorf("Image smaller than expected. Expected: %d, received: %d", c.minImageSize, r.ContentLength)
-		return nil, -1, errors.New("Image size is smaller than expected. Aborting.")
-	}
-
-	return r.Body, r.ContentLength, nil
-}
-
-func (client *httpClient) makeAndSendRequest(method, url string) (*http.Response, error) {
-
-	res, err := http.NewRequest(method, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Debug("Sending HTTP [", method, "] request: ", url)
-	return client.HTTPClient.Do(res)
-}
-
-// possible API responses received for update request
-const (
-	updateResponseHaveUpdate = 200
-	updateResponseNoUpdates  = 204
-	updateResponseError      = 404
-)
-
-// have update for the client
-type UpdateResponse struct {
-	Image struct {
-		URI      string
-		Checksum string
-		YoctoID  string `json:"yocto_id"`
-		ID       string
-	}
-	ID string
-}
-
-func validateGetUpdate(update UpdateResponse) error {
-	// check if we have JSON data correctky decoded
-	if update.ID != "" && update.Image.ID != "" &&
-		update.Image.URI != "" && update.Image.YoctoID != "" {
-		log.Info("Correct request for getting image from: " + update.Image.URI)
-		return nil
-	}
-	return errors.New("Missing parameters in encoded JSON response")
-}
-
-func processUpdateResponse(response *http.Response) (interface{}, error) {
-	log.Debug("Received response:", response.Status)
-
-	respBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	switch response.StatusCode {
-	case updateResponseHaveUpdate:
-		log.Debug("Have update available")
-
-		data := UpdateResponse{}
-		if err := json.Unmarshal(respBody, &data); err != nil {
-			switch err.(type) {
-			case *json.SyntaxError:
-				return nil, errors.New("Error parsing data syntax")
-			}
-			return nil, errors.New("Error parsing data: " + err.Error())
-		}
-		if err := validateGetUpdate(data); err != nil {
-			return nil, err
-		}
-		return data, nil
-
-	case updateResponseNoUpdates:
-		log.Debug("No update available")
-		return nil, nil
-
-	case updateResponseError:
-		return nil, errors.New("Client not authorized to get update schedule.")
-
-	default:
-		return nil, errors.New("Invalid response received from server")
-	}
+	return "https://" + server
 }

--- a/client_test.go
+++ b/client_test.go
@@ -24,12 +24,10 @@ func TestHttpClient(t *testing.T) {
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
 	assert.NotNil(t, cl)
-	// assert.NotNil(t, cl.Transport.TLSClientConfig)
 
 	// no https config, we should obtain a httpClient
 	cl, err = NewHttpClient(httpsClientConfig{})
 	assert.NotNil(t, cl)
-	// assert.Nil(t, cl.Transport.TLSClientConfig)
 
 	// incomplete config should yield an error
 	cl, err = NewHttpClient(

--- a/client_update.go
+++ b/client_update.go
@@ -174,8 +174,8 @@ func makeUpdateCheckRequest(server, deviceID string) (*http.Request, error) {
 	return req, nil
 }
 
-func makeUpdateFetchRequest(server string) (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, server, nil)
+func makeUpdateFetchRequest(url string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client_update.go
+++ b/client_update.go
@@ -28,7 +28,7 @@ const (
 )
 
 type Updater interface {
-	GetScheduledUpdate(processFunc RequestProcessingFunc, server string, deviceID string) (interface{}, error)
+	GetScheduledUpdate(server string, deviceID string) (interface{}, error)
 	FetchUpdate(url string) (io.ReadCloser, int64, error)
 }
 
@@ -50,9 +50,8 @@ func NewUpdateClient(conf httpsClientConfig) (*UpdateClient, error) {
 	return &up, nil
 }
 
-func (u *UpdateClient) GetScheduledUpdate(process RequestProcessingFunc,
-	server string, deviceID string) (interface{}, error) {
-	return u.getUpdateInfo(process, buildURL(server), deviceID)
+func (u *UpdateClient) GetScheduledUpdate(server string, deviceID string) (interface{}, error) {
+	return u.getUpdateInfo(processUpdateResponse, buildURL(server), deviceID)
 }
 
 func (u *UpdateClient) getUpdateInfo(process RequestProcessingFunc, server string,

--- a/client_update.go
+++ b/client_update.go
@@ -1,0 +1,184 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	minimumImageSize int64 = 4096 //kB
+)
+
+type Updater interface {
+	GetScheduledUpdate(processFunc RequestProcessingFunc, server string, deviceID string) (interface{}, error)
+	FetchUpdate(url string) (io.ReadCloser, int64, error)
+}
+
+type UpdateClient struct {
+	client       *http.Client
+	minImageSize int64
+}
+
+func NewUpdateClient(conf httpsClientConfig) (*UpdateClient, error) {
+	client, err := NewHttpClient(conf)
+	if client == nil {
+		return nil, errors.Wrap(err, "failed to create updater HTTP client")
+	}
+
+	up := UpdateClient{
+		client:       client,
+		minImageSize: minimumImageSize,
+	}
+	return &up, nil
+}
+
+func (u *UpdateClient) GetScheduledUpdate(process RequestProcessingFunc,
+	server string, deviceID string) (interface{}, error) {
+	return u.getUpdateInfo(process, buildURL(server), deviceID)
+}
+
+func (u *UpdateClient) getUpdateInfo(process RequestProcessingFunc, server string,
+	deviceID string) (interface{}, error) {
+	req, err := makeUpdateCheckRequest(server, deviceID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create update check request")
+	}
+
+	r, err := u.client.Do(req)
+	if err != nil {
+		log.Debug("Sending request error: ", err)
+		return nil, errors.Wrapf(err, "update check request failed")
+	}
+
+	defer r.Body.Close()
+
+	return process(r)
+}
+
+// Returns a byte stream which is a download of the given link.
+func (u *UpdateClient) FetchUpdate(url string) (io.ReadCloser, int64, error) {
+	req, err := makeUpdateFetchRequest(url)
+	if err != nil {
+		return nil, -1, errors.Wrapf(err, "failed to create update fetch request")
+	}
+
+	r, err := u.client.Do(req)
+	if err != nil {
+		log.Error("Can not fetch update image: ", err)
+		return nil, -1, errors.Wrapf(err, "update fetch request failed")
+	}
+
+	log.Debugf("Received fetch update response %v+", r)
+
+	if r.StatusCode != http.StatusOK {
+		log.Errorf("Error fetching shcheduled update info: code (%d)", r.StatusCode)
+		return nil, -1, errors.New("Error receiving scheduled update information.")
+	}
+
+	if r.ContentLength < 0 {
+		return nil, -1, errors.New("Will not continue with unknown image size.")
+	} else if r.ContentLength < u.minImageSize {
+		log.Errorf("Image smaller than expected. Expected: %d, received: %d", u.minImageSize, r.ContentLength)
+		return nil, -1, errors.New("Image size is smaller than expected. Aborting.")
+	}
+
+	return r.Body, r.ContentLength, nil
+}
+
+// possible API responses received for update request
+const (
+	updateResponseHaveUpdate = 200
+	updateResponseNoUpdates  = 204
+	updateResponseError      = 404
+)
+
+// have update for the client
+type UpdateResponse struct {
+	Image struct {
+		URI      string
+		Checksum string
+		YoctoID  string `json:"yocto_id"`
+		ID       string
+	}
+	ID string
+}
+
+func validateGetUpdate(update UpdateResponse) error {
+	// check if we have JSON data correctky decoded
+	if update.ID != "" && update.Image.ID != "" &&
+		update.Image.URI != "" && update.Image.YoctoID != "" {
+		log.Info("Correct request for getting image from: " + update.Image.URI)
+		return nil
+	}
+	return errors.New("Missing parameters in encoded JSON response")
+}
+
+func processUpdateResponse(response *http.Response) (interface{}, error) {
+	log.Debug("Received response:", response.Status)
+
+	respBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch response.StatusCode {
+	case updateResponseHaveUpdate:
+		log.Debug("Have update available")
+
+		var data UpdateResponse
+		if err := json.Unmarshal(respBody, &data); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse response")
+		}
+
+		if err := validateGetUpdate(data); err != nil {
+			return nil, err
+		}
+
+		return data, nil
+
+	case updateResponseNoUpdates:
+		log.Debug("No update available")
+		return nil, nil
+
+	case updateResponseError:
+		return nil, errors.New("Client not authorized to get update schedule.")
+
+	default:
+		return nil, errors.New("Invalid response received from server")
+	}
+}
+
+func makeUpdateCheckRequest(server, deviceID string) (*http.Request, error) {
+	url := server + "/api/0.0.1/devices/" + deviceID + "/update"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func makeUpdateFetchRequest(server string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, server, nil)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/client_update_test.go
+++ b/client_update_test.go
@@ -135,7 +135,7 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, errors.New("") }
 
-	_, err = client.GetScheduledUpdate(fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(fakeProcessUpdate, ts.URL, "")
 	assert.Error(t, err)
 }
 
@@ -156,7 +156,7 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	assert.NoError(t, err)
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, nil }
 
-	_, err = client.GetScheduledUpdate(fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(fakeProcessUpdate, ts.URL, "")
 	assert.NoError(t, err)
 }
 
@@ -176,7 +176,7 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 
-	data, err := client.GetScheduledUpdate(processUpdateResponse, ts.URL, "")
+	data, err := client.GetScheduledUpdate(ts.URL, "")
 	assert.NoError(t, err)
 	update, ok := data.(UpdateResponse)
 	assert.True(t, ok)

--- a/client_update_test.go
+++ b/client_update_test.go
@@ -1,0 +1,245 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const correctUpdateResponse = `{
+"image": {
+"uri": "https://menderupdate.com",
+"checksum": "checksum",
+"yocto_id": "core-image-base",
+"id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+},
+"id": "13876-123132-321123"
+}`
+
+const malformedUpdateResponse = `{
+"image": {
+"non_existing": "https://menderupdate.com",
+"checksum": "Hello, world!",
+},
+"bad_field": "13876-123132-321123"
+}`
+
+const brokenUpdateResponse = `{
+"image": {
+"uri": "https://menderupdate
+"checksum": "Hello, world!",
+"id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+},
+"id": "13876-123132-321123"
+}`
+
+const missingFieldsUpdateResponse = `{
+"image": {
+"uri": "https://menderupdate.com",
+"id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+},
+"id": "13876-123132-321123"
+}`
+
+var updateTest = []struct {
+	responseStatusCode    int
+	responseBody          []byte
+	shoulReturnError      bool
+	shouldCheckReturnCode bool
+	returnCode            int
+}{
+	{200, []byte(correctUpdateResponse), false, true, updateResponseHaveUpdate},
+	{204, []byte(""), false, true, updateResponseNoUpdates},
+	{404, []byte(`{
+	 "error": "Not found"
+	 }`), true, true, updateResponseError},
+	{500, []byte(`{
+	"error": "Invalid request"
+	}`), true, false, 0},
+	{200, []byte(malformedUpdateResponse), true, false, 0},
+	{200, []byte(brokenUpdateResponse), true, false, 0},
+	{200, []byte(missingFieldsUpdateResponse), true, false, 0},
+}
+
+type testReadCloser struct {
+	body io.ReadSeeker
+}
+
+func (d *testReadCloser) Read(p []byte) (n int, err error) {
+	n, err = d.body.Read(p)
+	if err == io.EOF {
+		d.body.Seek(0, 0)
+	}
+	return n, err
+}
+
+func (d *testReadCloser) Close() error {
+	return nil
+}
+
+func TestParseUpdateResponse(t *testing.T) {
+
+	for _, tt := range updateTest {
+
+		response := &http.Response{
+			StatusCode: tt.responseStatusCode,
+			Body:       &testReadCloser{strings.NewReader(string(tt.responseBody))},
+		}
+
+		_, err := processUpdateResponse(response)
+		if tt.shoulReturnError {
+			assert.Error(t, err)
+		} else if !tt.shoulReturnError {
+			assert.NoError(t, err)
+		}
+		if tt.shouldCheckReturnCode {
+			assert.Equal(t, tt.returnCode, response.StatusCode)
+		}
+	}
+}
+
+func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "")
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, errors.New("") }
+
+	_, err = client.GetScheduledUpdate(fakeProcessUpdate, ts.URL, "")
+	assert.Error(t, err)
+}
+
+func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "")
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, nil }
+
+	_, err = client.GetScheduledUpdate(fakeProcessUpdate, ts.URL, "")
+	assert.NoError(t, err)
+}
+
+func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, correctUpdateResponse)
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	data, err := client.GetScheduledUpdate(processUpdateResponse, ts.URL, "")
+	assert.NoError(t, err)
+	update, ok := data.(UpdateResponse)
+	assert.True(t, ok)
+	assert.Equal(t, "https://menderupdate.com", update.Image.URI)
+}
+
+func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "")
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	_, _, err = client.FetchUpdate(ts.URL)
+	assert.Error(t, err)
+}
+
+func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "")
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	_, _, err = client.FetchUpdate("broken-request")
+	assert.Error(t, err)
+}
+
+func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "some content to be fetched")
+	}))
+	defer ts.Close()
+
+	client, err := NewUpdateClient(
+		httpsClientConfig{"", "", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+	client.minImageSize = 1
+
+	_, _, err = client.FetchUpdate(ts.URL)
+	assert.NoError(t, err)
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"time"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type menderConfig struct {
+	ClientProtocol string
+	DeviceKey      string
+	DeviceID       string
+	HttpsClient    struct {
+		Certificate string
+		Key         string
+	}
+	RootfsPartA         string
+	RootfsPartB         string
+	PollIntervalSeconds int
+	ServerURL           string
+	ServerCertificate   string
+}
+
+func LoadConfig(configFile string) (*menderConfig, error) {
+	var confFromFile menderConfig
+
+	if err := readConfigFile(&confFromFile, configFile); err != nil {
+		// Some error occured while loading config file.
+		// Use default configuration.
+		log.Infof("Error loading configuration from file: %s (%s)", configFile, err.Error())
+		return nil, err
+	}
+
+	if confFromFile.DeviceKey == "" {
+		log.Infof("device key path not configured, fallback to default %s",
+			defaultKeyFile)
+		confFromFile.DeviceKey = defaultKeyFile
+	}
+
+	return &confFromFile, nil
+}
+
+func readConfigFile(config interface{}, fileName string) error {
+	log.Debug("Reading Mender configuration from file " + fileName)
+	conf, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(conf, &config); err != nil {
+		switch err.(type) {
+		case *json.SyntaxError:
+			return errors.New("Error parsing mender configuration file: " + err.Error())
+		}
+		return errors.New("Error parsing config file: " + err.Error())
+	}
+	return nil
+}
+
+func (c menderConfig) GetUpdaterConfig() httpsClientConfig {
+	return httpsClientConfig{
+		c.HttpsClient.Certificate,
+		c.HttpsClient.Key,
+		c.ServerCertificate,
+		c.ClientProtocol == "https",
+	}
+}
+
+func (c menderConfig) GetDaemonConfig() daemonConfig {
+	return daemonConfig{
+		time.Duration(c.PollIntervalSeconds) * time.Second,
+		c.ServerURL,
+		c.DeviceID,
+	}
+}
+
+func (c menderConfig) GetDeviceConfig() deviceConfig {
+	return deviceConfig{
+		rootfsPartA: c.RootfsPartA,
+		rootfsPartB: c.RootfsPartB,
+	}
+}

--- a/config.go
+++ b/config.go
@@ -16,7 +16,6 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
-	"time"
 
 	"github.com/mendersoftware/log"
 	"github.com/pkg/errors"
@@ -79,14 +78,6 @@ func (c menderConfig) GetUpdaterConfig() httpsClientConfig {
 		c.HttpsClient.Key,
 		c.ServerCertificate,
 		c.ClientProtocol == "https",
-	}
-}
-
-func (c menderConfig) GetDaemonConfig() daemonConfig {
-	return daemonConfig{
-		time.Duration(c.PollIntervalSeconds) * time.Second,
-		c.ServerURL,
-		c.DeviceID,
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,132 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testConfig = `{
+  "ClientProtocol": "https",
+  "HttpsClient": {
+    "Certificate": "/data/client.crt",
+    "Key": "/data/client.key"
+  },
+  "RootfsPartA": "/dev/mmcblk0p2",
+  "RootfsPartB": "/dev/mmcblk0p3",
+  "PollIntervalSeconds": 60,
+  "ServerURL": "mender.io",
+  "DeviceID": "1234-ABCD",
+  "ServerCertificate": "/data/server.crt"
+}`
+
+var testConfigDevKey = `{
+  "ClientProtocol": "https",
+  "DeviceKey": "/foo/bar",
+  "HttpsClient": {
+    "Certificate": "/data/client.crt",
+    "Key": "/data/client.key"
+  },
+  "RootfsPartA": "/dev/mmcblk0p2",
+  "RootfsPartB": "/dev/mmcblk0p3",
+  "PollIntervalSeconds": 60,
+  "ServerURL": "mender.io",
+  "DeviceID": "1234-ABCD",
+  "ServerCertificate": "/data/server.crt"
+}`
+
+var testBrokenConfig = `{
+  "ClientProtocol": "https",
+  "HttpsClient": {
+    "Certificate": "/data/client.crt",
+    "Key": "/data/client.key"
+  },
+  "RootfsPartA": "/dev/mmcblk0p2",
+  "RootfsPartB": "/dev/mmcblk0p3",
+  "PollIntervalSeconds": 60,
+  "ServerURL": "mender
+  "DeviceID": "1234-ABCD",
+  "ServerCertificate": "/data/server.crt"
+}`
+
+func Test_readConfigFile_noFile_returnsError(t *testing.T) {
+	err := readConfigFile(nil, "non-existing-file")
+	assert.Error(t, err)
+}
+
+func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
+	configFile, _ := os.Create("mender.config")
+	defer os.Remove("mender.config")
+
+	configFile.WriteString(testBrokenConfig)
+	var confFromFile menderConfig
+
+	err := readConfigFile(&confFromFile, "mender.config")
+	assert.Error(t, err)
+
+	assert.Equal(t, menderConfig{}, confFromFile)
+}
+
+func validateConfiguration(t *testing.T, actual *menderConfig) {
+	expectedConfig := menderConfig{
+		ClientProtocol: "https",
+		DeviceID:       "1234-ABCD",
+		DeviceKey:      defaultKeyFile,
+		HttpsClient: struct {
+			Certificate string
+			Key         string
+		}{
+			Certificate: "/data/client.crt",
+			Key:         "/data/client.key",
+		},
+		RootfsPartA:         "/dev/mmcblk0p2",
+		RootfsPartB:         "/dev/mmcblk0p3",
+		PollIntervalSeconds: 60,
+		ServerURL:           "mender.io",
+		ServerCertificate:   "/data/server.crt",
+	}
+	if !assert.True(t, reflect.DeepEqual(actual, &expectedConfig)) {
+		t.Logf("got:      %+v", actual)
+		t.Logf("expected: %+v", expectedConfig)
+	}
+}
+
+func Test_loadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
+	configFile, _ := os.Create("mender.config")
+	defer os.Remove("mender.config")
+
+	configFile.WriteString(testConfig)
+
+	config, err := LoadConfig("mender.config")
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+
+	validateConfiguration(t, config)
+}
+
+func Test_loadConfig_correctConfFile_returnsConfigurationDeviceKey(t *testing.T) {
+	configFile, _ := os.Create("mender.config")
+	defer os.Remove("mender.config")
+
+	configFile.WriteString(testConfigDevKey)
+
+	config, err := LoadConfig("mender.config")
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, "/foo/bar", config.DeviceKey)
+}

--- a/daemon.go
+++ b/daemon.go
@@ -45,9 +45,12 @@ func (d *menderDaemon) Run() error {
 		if state.Id() == MenderStateError {
 			es, ok := state.(*ErrorState)
 			if ok {
-				return es.cause
+				if es.IsFatal() {
+					return es.cause
+				}
+			} else {
+				return errors.New("failed")
 			}
-			return errors.New("failed")
 		}
 		if cancelled || state.Id() == MenderStateDone {
 			break

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -156,7 +156,9 @@ func Test_checkPeriodicDaemonUpdate_haveServerAndCorrectResponse_FetchesUpdate(t
 	}))
 	defer ts.Close()
 
-	client := NewHttpsClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
+	client, err := NewUpdateClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
 	device := NewDevice(nil, nil, deviceConfig{"/dev/mmcblk0p2", "/dev/mmcblk0p3"})
 	runner := newTestOSCalls("", 0)
 	controler := newTestMender(&runner)

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -14,13 +14,9 @@
 package main
 
 import (
-	// "errors"
-	// "fmt"
 	"io"
 	"net/http"
-	// "net/http/httptest"
 	"testing"
-	// "time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -88,117 +84,3 @@ func TestDaemon(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// func Test_checkUpdate_errorAskingForUpdate_returnsNoUpdate(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnError = errors.New("fake error")
-
-// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
-// 	assert.False(t, haveUpdate)
-// }
-
-// func Test_checkUpdate_askingForUpdateReturnsEmpty_returnsNoUpdate(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = ""
-
-// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
-// 	assert.False(t, haveUpdate)
-// }
-
-// func Test_checkUpdate_askingForUpdateReturnsUpdate_returnsHaveUpdate(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = UpdateResponse{}
-// 	update := UpdateResponse{}
-
-// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, &update, "", "")
-// 	assert.True(t, haveUpdate)
-// }
-
-// func Test_fetchAndInstallUpdate_updateFetchError_returnsNotInstalled(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-// 	updater.fetchUpdateReturnError = errors.New("")
-// 	daemon := menderDaemon{}
-// 	daemon.Updater = updater
-
-// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-// }
-
-// func Test_fetchAndInstallUpdate_installError_returnsNotInstalled(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-// 	device := fakeDevice{}
-// 	device.retInstallUpdate = errors.New("")
-// 	daemon := menderDaemon{}
-// 	daemon.Updater = updater
-// 	daemon.UInstallCommitRebooter = device
-
-// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-// }
-
-// func Test_fetchAndInstallUpdate_updatePartitionError_returnsNotInstalled(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-// 	device := fakeDevice{}
-// 	device.retEnablePart = errors.New("")
-// 	daemon := menderDaemon{}
-// 	daemon.Updater = updater
-// 	daemon.UInstallCommitRebooter = device
-
-// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-// }
-
-// func Test_fetchAndInstallUpdate_noErrors_returnsInstalled(t *testing.T) {
-// 	updater := fakeUpdater{}
-// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-// 	device := fakeDevice{}
-// 	daemon := menderDaemon{}
-// 	daemon.Updater = updater
-// 	daemon.UInstallCommitRebooter = device
-
-// 	assert.True(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-// }
-
-// func Test_checkPeriodicDaemonUpdate_haveServerAndCorrectResponse_FetchesUpdate(t *testing.T) {
-
-// 	if testing.Short() {
-// 		t.Skip("skipping periodic update check in short tests")
-// 	}
-
-// 	reqHandlingCnt := 0
-// 	pollInterval := time.Duration(10) * time.Millisecond
-
-// 	// Test server that always responds with 200 code, and specific payload
-// 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-// 		w.WriteHeader(204)
-// 		w.Header().Set("Content-Type", "application/json")
-// 		fmt.Fprintln(w, correctUpdateResponse)
-// 		reqHandlingCnt++
-// 	}))
-// 	defer ts.Close()
-
-// 	client, err := NewUpdateClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
-// 	assert.NotNil(t, client)
-// 	assert.NoError(t, err)
-
-// 	device := NewDevice(nil, nil, "")
-// 	runner := newTestOSCalls("", 0)
-// 	controler := newTestMender(&runner)
-// 	if controler == nil {
-// 		t.Fatalf("failed to create mender")
-// 	}
-// 	controler.changeState(MenderStateBootstrapped)
-
-// 	daemon := NewDaemon(client, device, controler)
-// 	daemon.config = daemonConfig{serverpollInterval: pollInterval, serverURL: ts.URL}
-
-// 	go daemon.Run()
-
-// 	timespolled := 5
-// 	time.Sleep(time.Duration(timespolled) * pollInterval)
-// 	daemon.StopDaemon()
-
-// 	if reqHandlingCnt < (timespolled - 1) {
-// 		assert.Fail(t, "Expected to receive at least %v requests - %v received",
-// 			timespolled-1, reqHandlingCnt)
-// 	}
-// }

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -14,13 +14,13 @@
 package main
 
 import (
-	"errors"
-	"fmt"
+	// "errors"
+	// "fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
+	// "net/http/httptest"
 	"testing"
-	"time"
+	// "time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -56,8 +56,7 @@ type fakeUpdater struct {
 	fetchUpdateReturnError        error
 }
 
-func (f fakeUpdater) GetScheduledUpdate(process RequestProcessingFunc,
-	url string, device string) (interface{}, error) {
+func (f fakeUpdater) GetScheduledUpdate(url string, device string) (interface{}, error) {
 	return f.GetScheduledUpdateReturnIface, f.GetScheduledUpdateReturnError
 }
 func (f fakeUpdater) FetchUpdate(url string) (io.ReadCloser, int64, error) {
@@ -68,116 +67,138 @@ func fakeProcessUpdate(response *http.Response) (interface{}, error) {
 	return nil, nil
 }
 
-func Test_checkUpdate_errorAskingForUpdate_returnsNoUpdate(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnError = errors.New("fake error")
-
-	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
-	assert.False(t, haveUpdate)
+type fakePreDoneState struct {
+	BaseState
 }
 
-func Test_checkUpdate_askingForUpdateReturnsEmpty_returnsNoUpdate(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = ""
-
-	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
-	assert.False(t, haveUpdate)
+func (f *fakePreDoneState) Handle(c Controller) (State, bool) {
+	return doneState, false
 }
 
-func Test_checkUpdate_askingForUpdateReturnsUpdate_returnsHaveUpdate(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = UpdateResponse{}
-	update := UpdateResponse{}
+func TestDaemon(t *testing.T) {
+	mender := newDefaultTestMender()
+	d := NewDaemon(mender)
 
-	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, &update, "", "")
-	assert.True(t, haveUpdate)
-}
-
-func Test_fetchAndInstallUpdate_updateFetchError_returnsNotInstalled(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-	updater.fetchUpdateReturnError = errors.New("")
-	daemon := menderDaemon{}
-	daemon.Updater = updater
-
-	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-}
-
-func Test_fetchAndInstallUpdate_installError_returnsNotInstalled(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-	device := fakeDevice{}
-	device.retInstallUpdate = errors.New("")
-	daemon := menderDaemon{}
-	daemon.Updater = updater
-	daemon.UInstallCommitRebooter = device
-
-	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-}
-
-func Test_fetchAndInstallUpdate_updatePartitionError_returnsNotInstalled(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-	device := fakeDevice{}
-	device.retEnablePart = errors.New("")
-	daemon := menderDaemon{}
-	daemon.Updater = updater
-	daemon.UInstallCommitRebooter = device
-
-	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-}
-
-func Test_fetchAndInstallUpdate_noErrors_returnsInstalled(t *testing.T) {
-	updater := fakeUpdater{}
-	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
-	device := fakeDevice{}
-	daemon := menderDaemon{}
-	daemon.Updater = updater
-	daemon.UInstallCommitRebooter = device
-
-	assert.True(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
-}
-
-func Test_checkPeriodicDaemonUpdate_haveServerAndCorrectResponse_FetchesUpdate(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping periodic update check in short tests")
-	}
-
-	reqHandlingCnt := 0
-	pollInterval := time.Duration(10) * time.Millisecond
-
-	// Test server that always responds with 200 code, and specific payload
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(204)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, correctUpdateResponse)
-		reqHandlingCnt++
-	}))
-	defer ts.Close()
-
-	client, err := NewUpdateClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
-	assert.NotNil(t, client)
+	mender.SetState(&fakePreDoneState{
+		BaseState{
+			MenderStateInit,
+		},
+	})
+	err := d.Run()
 	assert.NoError(t, err)
-	device := NewDevice(nil, nil, deviceConfig{"/dev/mmcblk0p2", "/dev/mmcblk0p3"})
-	runner := newTestOSCalls("", 0)
-	controler := newTestMender(&runner)
-	if controler == nil {
-		t.Fatalf("failed to create mender")
-	}
-	controler.changeState(MenderStateBootstrapped)
-
-	daemon := NewDaemon(client, device, controler)
-	daemon.config = daemonConfig{serverpollInterval: pollInterval, serverURL: ts.URL}
-
-	go daemon.Run()
-
-	timespolled := 5
-	time.Sleep(time.Duration(timespolled) * pollInterval)
-	daemon.StopDaemon()
-
-	if reqHandlingCnt < (timespolled - 1) {
-		assert.Fail(t, "Expected to receive at least %v requests - %v received",
-			timespolled-1, reqHandlingCnt)
-	}
 }
+
+// func Test_checkUpdate_errorAskingForUpdate_returnsNoUpdate(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnError = errors.New("fake error")
+
+// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
+// 	assert.False(t, haveUpdate)
+// }
+
+// func Test_checkUpdate_askingForUpdateReturnsEmpty_returnsNoUpdate(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = ""
+
+// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, nil, "", "")
+// 	assert.False(t, haveUpdate)
+// }
+
+// func Test_checkUpdate_askingForUpdateReturnsUpdate_returnsHaveUpdate(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = UpdateResponse{}
+// 	update := UpdateResponse{}
+
+// 	_, haveUpdate := checkScheduledUpdate(updater, fakeProcessUpdate, &update, "", "")
+// 	assert.True(t, haveUpdate)
+// }
+
+// func Test_fetchAndInstallUpdate_updateFetchError_returnsNotInstalled(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
+// 	updater.fetchUpdateReturnError = errors.New("")
+// 	daemon := menderDaemon{}
+// 	daemon.Updater = updater
+
+// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
+// }
+
+// func Test_fetchAndInstallUpdate_installError_returnsNotInstalled(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
+// 	device := fakeDevice{}
+// 	device.retInstallUpdate = errors.New("")
+// 	daemon := menderDaemon{}
+// 	daemon.Updater = updater
+// 	daemon.UInstallCommitRebooter = device
+
+// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
+// }
+
+// func Test_fetchAndInstallUpdate_updatePartitionError_returnsNotInstalled(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
+// 	device := fakeDevice{}
+// 	device.retEnablePart = errors.New("")
+// 	daemon := menderDaemon{}
+// 	daemon.Updater = updater
+// 	daemon.UInstallCommitRebooter = device
+
+// 	assert.False(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
+// }
+
+// func Test_fetchAndInstallUpdate_noErrors_returnsInstalled(t *testing.T) {
+// 	updater := fakeUpdater{}
+// 	updater.GetScheduledUpdateReturnIface = new(UpdateResponse)
+// 	device := fakeDevice{}
+// 	daemon := menderDaemon{}
+// 	daemon.Updater = updater
+// 	daemon.UInstallCommitRebooter = device
+
+// 	assert.True(t, fetchAndInstallUpdate(&daemon, UpdateResponse{}))
+// }
+
+// func Test_checkPeriodicDaemonUpdate_haveServerAndCorrectResponse_FetchesUpdate(t *testing.T) {
+
+// 	if testing.Short() {
+// 		t.Skip("skipping periodic update check in short tests")
+// 	}
+
+// 	reqHandlingCnt := 0
+// 	pollInterval := time.Duration(10) * time.Millisecond
+
+// 	// Test server that always responds with 200 code, and specific payload
+// 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		w.WriteHeader(204)
+// 		w.Header().Set("Content-Type", "application/json")
+// 		fmt.Fprintln(w, correctUpdateResponse)
+// 		reqHandlingCnt++
+// 	}))
+// 	defer ts.Close()
+
+// 	client, err := NewUpdateClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	device := NewDevice(nil, nil, "")
+// 	runner := newTestOSCalls("", 0)
+// 	controler := newTestMender(&runner)
+// 	if controler == nil {
+// 		t.Fatalf("failed to create mender")
+// 	}
+// 	controler.changeState(MenderStateBootstrapped)
+
+// 	daemon := NewDaemon(client, device, controler)
+// 	daemon.config = daemonConfig{serverpollInterval: pollInterval, serverURL: ts.URL}
+
+// 	go daemon.Run()
+
+// 	timespolled := 5
+// 	time.Sleep(time.Duration(timespolled) * pollInterval)
+// 	daemon.StopDaemon()
+
+// 	if reqHandlingCnt < (timespolled - 1) {
+// 		assert.Fail(t, "Expected to receive at least %v requests - %v received",
+// 			timespolled-1, reqHandlingCnt)
+// 	}
+// }

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -159,8 +159,10 @@ func Test_checkPeriodicDaemonUpdate_haveServerAndCorrectResponse_FetchesUpdate(t
 	client := NewHttpsClient(httpsClientConfig{"client.crt", "client.key", "server.crt", true})
 	device := NewDevice(nil, nil, deviceConfig{"/dev/mmcblk0p2", "/dev/mmcblk0p3"})
 	runner := newTestOSCalls("", 0)
-	fakeEnv := uBootEnv{&runner}
-	controler := NewMender(&fakeEnv)
+	controler := newTestMender(&runner)
+	if controler == nil {
+		t.Fatalf("failed to create mender")
+	}
 	controler.changeState(MenderStateBootstrapped)
 
 	daemon := NewDaemon(client, device, controler)

--- a/dirstore.go
+++ b/dirstore.go
@@ -1,0 +1,125 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/mendersoftware/log"
+)
+
+type DirStore struct {
+	basepath string
+}
+
+type DirFile struct {
+	io.WriteCloser
+	name     string
+	dirstore *DirStore
+}
+
+func NewDirStore(path string) *DirStore {
+	return &DirStore{
+		basepath: path,
+	}
+}
+
+func (d DirStore) ReadAll(name string) ([]byte, error) {
+	in, err := d.OpenRead(name)
+	if err != nil {
+		return nil, err
+	}
+	defer in.Close()
+	return ioutil.ReadAll(in)
+}
+
+func (d DirStore) WriteAll(name string, data []byte) error {
+	out, err := d.OpenWrite(name)
+	if err != nil {
+		return err
+	}
+	// we should not call/defer out.Close() here as we'll be committing the file
+	// later on, although it's most of the time ok to rename(3) a file while it's
+	// opened, don't assume that it works always
+
+	_, err = out.Write(data)
+	if err != nil {
+		out.Close()
+		return err
+	}
+
+	// this could return an error in theory
+	out.Close()
+
+	return out.Commit()
+}
+
+// Open an entry for reading.
+func (d DirStore) OpenRead(name string) (io.ReadCloser, error) {
+	f, err := os.Open(path.Join(d.basepath, name))
+	if err != nil {
+		log.Errorf("I/O read error for entry %v: %v", name, err)
+		return nil, err
+	}
+	return f, nil
+}
+
+// Open an entry for writing. Under the hood, opens a temporary file (with
+// 'name~' name) using os.O_WRONLY|os.O_CREAT flags, with default mode 0600.
+// Once writing to temp file is done, the caller should run Commit() method of
+// the WriteCloserCommitter interface.
+func (d DirStore) OpenWrite(name string) (WriteCloserCommitter, error) {
+	f, err := os.OpenFile(d.getTempPath(name), os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		log.Errorf("I/O write error for entry %v: %v", name, err)
+		return nil, err
+	}
+
+	wrc := &DirFile{
+		WriteCloser: f,
+		name:        name,
+		dirstore:    &d,
+	}
+	return wrc, nil
+}
+
+// Return an actual path in DirStore
+func (d DirStore) getPath(name string) string {
+	return path.Join(d.basepath, name)
+}
+
+// Return a temporary path in DirStore
+func (d DirStore) getTempPath(name string) string {
+	return d.getPath(name) + "~"
+}
+
+// Commit a file from temporary copy to the actual name. Under the hood, does a
+// os.Rename() from a temp file (one with ~ suffix) to the actual name
+func (d DirStore) CommitFile(name string) error {
+	from := d.getTempPath(name)
+	to := d.getPath(name)
+
+	err := os.Rename(from, to)
+	if err != nil {
+		log.Errorf("I/O commit error for entry %v: %v", name, err)
+	}
+	return err
+}
+
+func (df DirFile) Commit() error {
+	return df.dirstore.CommitFile(df.name)
+}

--- a/dirstore_test.go
+++ b/dirstore_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func pathExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func TestDirStore(t *testing.T) {
+
+	tmppath, err := ioutil.TempDir("", "mendertest-")
+	defer os.RemoveAll(tmppath)
+
+	d := NewDirStore(tmppath)
+
+	// no file, should fail
+	_, err = d.ReadAll("foo")
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	var data string
+	// do write/read cycle with changing data
+	for i := 0; i < 2; i++ {
+		data = fmt.Sprintf("foobar-%v", i)
+		err := d.WriteAll("foo", []byte(data))
+		assert.NoError(t, err)
+
+		osi, err := os.Open(d.getPath("foo"))
+		assert.NoError(t, err)
+		indata, err := ioutil.ReadAll(osi)
+		osi.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(data), indata)
+	}
+
+	// read data written in last iteration of read/write cycle
+	_, err = d.ReadAll("foo")
+	assert.NoError(t, err)
+	osi, err := os.Open(d.getPath("foo"))
+	assert.NoError(t, err)
+	indata, err := ioutil.ReadAll(osi)
+	osi.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(data), indata)
+
+	// not the same using io.ReadCloser interface
+	in, err := d.OpenRead("foo")
+	assert.NoError(t, err)
+	indata, err = ioutil.ReadAll(in)
+	in.Close()
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(data), indata)
+
+	// check writer
+	out, err := d.OpenWrite("bar")
+	assert.NoError(t, err)
+	// there should be a temp path already, but no the actual target path
+	assert.True(t, pathExists(d.getTempPath("bar")))
+	assert.False(t, pathExists(d.getPath("bar")))
+
+	_, err = out.Write([]byte("zed"))
+	assert.NoError(t, err)
+	// the same
+	assert.True(t, pathExists(d.getTempPath("bar")))
+	assert.False(t, pathExists(d.getPath("bar")))
+	out.Close()
+
+	// commit the file now
+	out.Commit()
+	assert.False(t, pathExists(d.getTempPath("bar")))
+	assert.True(t, pathExists(d.getPath("bar")))
+}

--- a/dirstore_test.go
+++ b/dirstore_test.go
@@ -78,7 +78,8 @@ func TestDirStore(t *testing.T) {
 	// check writer
 	out, err := d.OpenWrite("bar")
 	assert.NoError(t, err)
-	// there should be a temp path already, but no the actual target path
+	// there should be a temp path already, but the actual target path should not
+	// exist yet
 	assert.True(t, pathExists(d.getTempPath("bar")))
 	assert.False(t, pathExists(d.getPath("bar")))
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"github.com/pkg/errors"
+)
+
+// mender specific error
+type menderError interface {
+	// cause of the error
+	Cause() error
+	// true if error is fatal
+	IsFatal() bool
+	// implements error interface
+	error
+}
+
+type MenderError struct {
+	cause error
+	fatal bool
+}
+
+func (m *MenderError) Cause() error {
+	return m.cause
+}
+
+func (m *MenderError) IsFatal() bool {
+	return m.fatal
+}
+
+func (m *MenderError) Error() string {
+	var err error
+	if m.fatal {
+		err = errors.Wrapf(m.cause, "fatal error")
+	} else {
+		err = errors.Wrapf(m.cause, "transient error")
+	}
+	return err.Error()
+}
+
+// create a new fatal error
+func NewFatalError(err error) menderError {
+	return &MenderError{
+		cause: err,
+		fatal: true,
+	}
+}
+
+// create a new transient error
+func NewTransientError(err error) menderError {
+	return &MenderError{
+		cause: err,
+		fatal: false,
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMenderError(t *testing.T) {
+	err := errors.New("foo")
+
+	te := NewFatalError(err)
+	assert.NotNil(t, te)
+	assert.True(t, te.IsFatal())
+	assert.Equal(t, err, te.Cause())
+
+	tt := NewTransientError(err)
+	assert.NotNil(t, tt)
+	assert.False(t, tt.IsFatal())
+	assert.Equal(t, err, tt.Cause())
+}

--- a/keystore.go
+++ b/keystore.go
@@ -82,6 +82,9 @@ func (k *Keystore) Save(privPath string) error {
 
 	err = saveToPem(outf, k.private)
 	if err != nil {
+		// make sure to close the file
+		outf.Close()
+
 		log.Errorf("failed to save key: %s", err)
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func doMain(args []string) error {
 			controller.ForceBootstrap()
 		}
 
-		updater, err := NewUpdater(controller.GetUpdaterConfig())
+		updater, err := NewUpdateClient(controller.GetUpdaterConfig())
 		if err != nil {
 			return errors.New("Can not initialize daemon. Error instantiating updater. Exiting.")
 		}

--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ func doMain(args []string) error {
 			controller.ForceBootstrap()
 		}
 
-		daemon := NewDaemon(controller, config.GetDaemonConfig())
+		daemon := NewDaemon(controller)
 		return daemon.Run()
 
 	case *runOptions.imageFile == "" && !*runOptions.commit &&

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ type logOptionsType struct {
 type runOptionsType struct {
 	version   *bool
 	config    *string
+	dataStore *string
 	imageFile *string
 	commit    *bool
 	daemon    *bool
@@ -85,6 +86,9 @@ func argsParse(args []string) (runOptionsType, error) {
 	config := parsing.String("config", defaultConfFile,
 		"Configuration file location.")
 
+	data := parsing.String("data", defaultDataStore,
+		"Mender state data location.")
+
 	commit := parsing.Bool("commit", false, "Commit current update.")
 
 	imageFile := parsing.String("rootfs", "",
@@ -111,6 +115,7 @@ func argsParse(args []string) (runOptionsType, error) {
 	runOptions := runOptionsType{
 		version,
 		config,
+		data,
 		imageFile,
 		commit,
 		daemon,
@@ -272,6 +277,7 @@ func doMain(args []string) error {
 	}
 
 	device := NewDevice(env, new(osCalls), controller.GetDeviceConfig())
+	store := NewDirStore(*runOptions.dataStore)
 
 	switch {
 

--- a/main.go
+++ b/main.go
@@ -276,8 +276,6 @@ func doMain(args []string) error {
 
 	env := NewEnvironment(new(osCalls))
 	device := NewDevice(env, new(osCalls), config.GetDeviceConfig())
-	store := NewDirStore(*runOptions.dataStore)
-
 	switch {
 
 	case *runOptions.imageFile != "":
@@ -295,6 +293,8 @@ func doMain(args []string) error {
 		if err != nil {
 			return errors.New("Cannot initialize daemon. Error instantiating updater. Exiting.")
 		}
+
+		store := NewDirStore(*runOptions.dataStore)
 
 		controller := NewMender(*config, MenderPieces{
 			updater,

--- a/mender.go
+++ b/mender.go
@@ -71,10 +71,22 @@ const (
 	// update applied, waiting for commit
 	MenderStateRunningWithFreshUpdate
 	// wait for new update
-	MenderStateWaitForUpdate
+	MenderStateUpdateCheckWait
+	// check update
+	MenderStateUpdateCheck
+	// update fetch
+	MenderStateUpdateFetch
+	// update install
+	MenderStateUpdateInstall
+	// commit needed
+	MenderStateUpdateCommit
+	// reboot
+	MenderStateReboot
 	// error occurred, call Controller.LastError() to obtain the
 	// error
 	MenderStateError
+	// exit state
+	MenderStateDone
 )
 
 type mender struct {
@@ -201,7 +213,7 @@ func (m *mender) updateState() {
 			if upg {
 				newstate = MenderStateRunningWithFreshUpdate
 			} else {
-				newstate = MenderStateWaitForUpdate
+				newstate = MenderStateUpdateCheckWait
 			}
 		}
 	}

--- a/mender.go
+++ b/mender.go
@@ -204,7 +204,7 @@ func (m *mender) doBootstrap() error {
 		}
 
 		if err := m.deviceKey.Save(m.config.DeviceKey); err != nil {
-			log.Errorf("faiiled to save keys to %s: %s",
+			log.Errorf("failed to save keys to %s: %s",
 				m.config.DeviceKey, err)
 			return err
 		}

--- a/mender.go
+++ b/mender.go
@@ -94,6 +94,11 @@ func NewMender(env BootEnvReadWriter, store Store) *mender {
 		state:             MenderStateInit,
 	}
 
+	if err := m.deviceKey.Load(m.config.DeviceKey); err != nil && IsNoKeys(err) == false {
+		log.Errorf("failed to load device keys: %s", err)
+		return nil
+	}
+
 	return m
 }
 

--- a/mender.go
+++ b/mender.go
@@ -37,7 +37,8 @@ type Controller interface {
 
 const (
 	defaultManifestFile = "/etc/build_mender"
-	defaultKeyFile      = "/data/mender/mender-agent.pem"
+	defaultKeyFile      = "mender-agent.pem"
+	defaultDataStore    = "/var/lib/mender"
 )
 
 type MenderState int
@@ -85,12 +86,17 @@ type mender struct {
 	lastError      error
 }
 
-func NewMender(env BootEnvReadWriter) *mender {
+func NewMender(env BootEnvReadWriter, store Store) *mender {
+
+	ks := NewKeystore(store)
+	if ks == nil {
+		return nil
+	}
 
 	m := &mender{
 		BootEnvReadWriter: env,
 		manifestFile:      defaultManifestFile,
-		deviceKey:         NewKeystore(),
+		deviceKey:         NewKeystore(store),
 		state:             MenderStateInit,
 	}
 

--- a/mender.go
+++ b/mender.go
@@ -26,6 +26,7 @@ type Controller interface {
 	Bootstrap() error
 	TransitionState() MenderState
 	GetCurrentImageID() string
+	GetUpdatePollInterval() time.Duration
 	LastError() error
 }
 
@@ -241,4 +242,8 @@ func (m *mender) doBootstrap() error {
 
 func (m *mender) LastError() error {
 	return m.lastError
+}
+
+func (m mender) GetUpdatePollInterval() time.Duration {
+	return time.Duration(m.config.PollIntervalSeconds) * time.Second
 }

--- a/rootfs.go
+++ b/rootfs.go
@@ -40,7 +40,7 @@ func doRootfs(device UInstaller, args runOptionsType) error {
 		log.Infof("Perfroming remote update from: [%s].", updateLocation)
 
 		// we are having remote update
-		client, err = NewUpdater(args.httpsClientConfig)
+		client, err = NewUpdateClient(args.httpsClientConfig)
 
 		if err != nil {
 			return errors.New("Can not initialize client for performing network update.")

--- a/state.go
+++ b/state.go
@@ -1,0 +1,301 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io"
+	"time"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type State interface {
+	// Perform state action, returns next state and boolean flag indicating if
+	// execution was cancelled or not
+	Handle(c Controller) (State, bool)
+	// Cancel state action, returns true if action was cancelled
+	Cancel() bool
+	// Return numeric state ID
+	Id() MenderState
+}
+
+type StateRunner interface {
+	// Set runner's state to 's'
+	SetState(s State)
+	// Obtain runner's state
+	GetState() State
+	// TODO generic state run action
+}
+
+var (
+	initState = &InitState{
+		BaseState{
+			id: MenderStateInit,
+		},
+	}
+
+	bootstrappedState = &BootstrappedState{
+		BaseState{
+			id: MenderStateBootstrapped,
+		},
+	}
+
+	updateCheckWaitState = NewUpdateCheckWaitState()
+
+	updateCheckState = &UpdateCheckState{
+		BaseState{
+			id: MenderStateUpdateCheck,
+		},
+	}
+
+	updateCommitState = &UpdateCommitState{
+		BaseState{
+			id: MenderStateUpdateCommit,
+		},
+	}
+
+	rebootState = &RebootState{
+		BaseState{
+			id: MenderStateReboot,
+		},
+	}
+
+	doneState = &FinalState{
+		BaseState{
+			id: MenderStateDone,
+		},
+	}
+)
+
+// Helper base state with some convenience methods
+type BaseState struct {
+	id MenderState
+}
+
+func (b *BaseState) Id() MenderState {
+	return b.id
+}
+
+func (b *BaseState) Cancel() bool {
+	return false
+}
+
+type InitState struct {
+	BaseState
+}
+
+func (i *InitState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle init state")
+	if err := c.Bootstrap(); err != nil {
+		log.Errorf("bootstrap failed: %s", err)
+		return NewErrorState(err), false
+	}
+	return bootstrappedState, false
+}
+
+type BootstrappedState struct {
+	BaseState
+}
+
+func (b *BootstrappedState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle bootstrapped state")
+	has, err := c.HasUpgrade()
+	if err != nil {
+		log.Errorf("has upgrade check failed: %s", err)
+		return NewErrorState(err), false
+	}
+	if has {
+		return updateCommitState, false
+	}
+
+	return updateCheckWaitState, false
+
+}
+
+type UpdateCommitState struct {
+	BaseState
+}
+
+func (uc *UpdateCommitState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle update commit state")
+	err := c.CommitUpdate()
+	if err != nil {
+		log.Errorf("update commit failed: %s", err)
+		return NewErrorState(err), false
+	}
+	// done?
+	return updateCheckWaitState, false
+}
+
+type UpdateCheckState struct {
+	BaseState
+}
+
+func (u *UpdateCheckState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle update check state")
+	update, err := c.CheckUpdate()
+	if err != nil {
+		log.Errorf("update check failed: %s", err)
+		// maybe transient error?
+		return NewErrorState(err), false
+	}
+
+	if update != nil {
+		// custom state data?
+		return NewUpdateFetchState(update), false
+	}
+
+	return updateCheckWaitState, false
+}
+
+type UpdateFetchState struct {
+	BaseState
+	update *UpdateResponse
+}
+
+func NewUpdateFetchState(update *UpdateResponse) State {
+	return &UpdateFetchState{
+		BaseState{
+			id: MenderStateUpdateFetch,
+		},
+		update,
+	}
+}
+
+func (u *UpdateFetchState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle update fetch state")
+	in, size, err := c.FetchUpdate(u.update.Image.URI)
+	if err != nil {
+		log.Errorf("update fetch failed: %s", err)
+		return NewErrorState(err), false
+	}
+
+	return NewUpdateInstallState(in, size), false
+}
+
+type UpdateInstallState struct {
+	BaseState
+	// reader for obtaining image data
+	imagein io.ReadCloser
+	// expected image size
+	size int64
+}
+
+func NewUpdateInstallState(in io.ReadCloser, size int64) State {
+	return &UpdateInstallState{
+		BaseState{
+			id: MenderStateUpdateInstall,
+		},
+		in,
+		size,
+	}
+}
+
+func (u *UpdateInstallState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle update install state")
+	if err := c.InstallUpdate(u.imagein, u.size); err != nil {
+		log.Errorf("update install failed: %s", err)
+		return NewErrorState(err), false
+	}
+
+	if err := c.EnableUpdatedPartition(); err != nil {
+		log.Errorf("enabling updated partition failed: %s", err)
+		return NewErrorState(err), false
+	}
+
+	return rebootState, false
+}
+
+type UpdateCheckWaitState struct {
+	BaseState
+	cancel chan (bool)
+}
+
+func NewUpdateCheckWaitState() State {
+	return &UpdateCheckWaitState{
+		BaseState{
+			id: MenderStateUpdateCheckWait,
+		},
+		make(chan bool),
+	}
+}
+
+func (u *UpdateCheckWaitState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle update check wait state")
+
+	intvl := c.GetUpdatePollInterval()
+	log.Debugf("wait %v before next poll", intvl)
+	ticker := time.NewTicker(intvl)
+
+	select {
+	case <-ticker.C:
+		log.Debugf("poll interval complete")
+		return updateCheckState, false
+	case <-u.cancel:
+		log.Infof("update wait canceled")
+	}
+
+	return u, true
+}
+
+// Cancel wait state
+func (u *UpdateCheckWaitState) Cancel() bool {
+	u.cancel <- true
+	return true
+}
+
+type ErrorState struct {
+	BaseState
+	cause error
+}
+
+func NewErrorState(err error) State {
+	if err == nil {
+		err = errors.New("general error")
+	}
+
+	return &ErrorState{
+		BaseState{
+			id: MenderStateError,
+		},
+		err,
+	}
+}
+
+func (e *ErrorState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle error state")
+	// decide if error is transient, exit for now
+	return doneState, false
+}
+
+type RebootState struct {
+	BaseState
+}
+
+func (e *RebootState) Handle(c Controller) (State, bool) {
+	log.Debugf("handle reboot state")
+	if err := c.Reboot(); err != nil {
+		return NewErrorState(err), false
+	}
+	return doneState, false
+}
+
+type FinalState struct {
+	BaseState
+}
+
+func (f *FinalState) Handle(c Controller) (State, bool) {
+	panic("reached final state")
+}

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,307 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type stateTestController struct {
+	fakeDevice
+	fakeUpdater
+	bootstrapErr  error
+	imageID       string
+	pollIntvl     time.Duration
+	hasUpgrade    bool
+	hasUpgradeErr error
+	state         State
+	updateResp    *UpdateResponse
+	updateRespErr error
+}
+
+func (s *stateTestController) Bootstrap() error {
+	return s.bootstrapErr
+}
+
+func (s *stateTestController) GetCurrentImageID() string {
+	return s.imageID
+}
+
+func (s *stateTestController) GetUpdatePollInterval() time.Duration {
+	return s.pollIntvl
+}
+
+func (s *stateTestController) HasUpgrade() (bool, error) {
+	return s.hasUpgrade, s.hasUpgradeErr
+}
+
+func (s *stateTestController) CheckUpdate() (*UpdateResponse, error) {
+	return s.updateResp, s.updateRespErr
+}
+
+func (s *stateTestController) GetState() State {
+	return s.state
+}
+
+func (s *stateTestController) SetState(state State) {
+	s.state = state
+}
+
+func TestStateBase(t *testing.T) {
+	bs := BaseState{
+		MenderStateInit,
+	}
+
+	assert.Equal(t, MenderStateInit, bs.Id())
+	assert.False(t, bs.Cancel())
+}
+
+func TestStateError(t *testing.T) {
+
+	fooerr := errors.New("foo")
+
+	es := NewErrorState(fooerr)
+	assert.Equal(t, MenderStateError, es.Id())
+	assert.IsType(t, &ErrorState{}, es)
+	errstate, _ := es.(*ErrorState)
+	assert.NotNil(t, errstate)
+	assert.Equal(t, fooerr, errstate.cause)
+
+	es = NewErrorState(nil)
+	errstate, _ = es.(*ErrorState)
+	assert.NotNil(t, errstate)
+	assert.Contains(t, errstate.cause.Error(), "general error")
+}
+
+func TestStateInit(t *testing.T) {
+	i := InitState{}
+
+	var s State
+	var c bool
+	s, c = i.Handle(&stateTestController{
+		bootstrapErr: errors.New("fake err"),
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	s, c = i.Handle(&stateTestController{})
+	assert.IsType(t, &BootstrappedState{}, s)
+	assert.False(t, c)
+}
+
+func TestStateBootstrapped(t *testing.T) {
+	b := BootstrappedState{}
+
+	var s State
+	var c bool
+
+	s, c = b.Handle(&stateTestController{
+		hasUpgrade: false,
+	})
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.False(t, c)
+
+	s, c = b.Handle(&stateTestController{
+		hasUpgrade: true,
+	})
+	assert.IsType(t, &UpdateCommitState{}, s)
+	assert.False(t, c)
+
+	s, c = b.Handle(&stateTestController{
+		hasUpgradeErr: errors.New("upgrade err"),
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+}
+
+func TestStateUpdateCommit(t *testing.T) {
+	cs := UpdateCommitState{}
+
+	var s State
+	var c bool
+
+	// commit without errors
+	s, c = cs.Handle(&stateTestController{})
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.False(t, c)
+
+	s, c = cs.Handle(&stateTestController{
+		fakeDevice: fakeDevice{
+			retCommit: errors.New("commit fail"),
+		},
+	})
+	assert.IsType(t, s, &ErrorState{})
+	assert.False(t, c)
+}
+
+func TestStateUpdateCheckWait(t *testing.T) {
+	cws := NewUpdateCheckWaitState()
+
+	var s State
+	var c bool
+
+	// no update
+	var tstart, tend time.Time
+
+	tstart = time.Now()
+	s, c = cws.Handle(&stateTestController{
+		pollIntvl: 100 * time.Millisecond,
+	})
+	tend = time.Now()
+	assert.IsType(t, &UpdateCheckState{}, s)
+	assert.False(t, c)
+	assert.WithinDuration(t, tend, tstart, 105*time.Millisecond)
+
+	// asynchronously cancel state operation
+	go func() {
+		c := cws.Cancel()
+		assert.True(t, c)
+	}()
+	// should finish right away
+	tstart = time.Now()
+	s, c = cws.Handle(&stateTestController{
+		pollIntvl: 100 * time.Millisecond,
+	})
+	tend = time.Now()
+	// canceled state should return itself
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.True(t, c)
+	assert.WithinDuration(t, tend, tstart, 5*time.Millisecond)
+}
+
+func TestStateUpdateCheck(t *testing.T) {
+	cs := UpdateCheckState{}
+
+	var s State
+	var c bool
+
+	// no update
+	s, c = cs.Handle(&stateTestController{})
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.False(t, c)
+
+	// pretend update check failed
+	s, c = cs.Handle(&stateTestController{
+		updateRespErr: errors.New("check failed"),
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	// pretend we have an update
+	update := &UpdateResponse{}
+
+	s, c = cs.Handle(&stateTestController{
+		updateResp: update,
+	})
+	assert.IsType(t, &UpdateFetchState{}, s)
+	assert.False(t, c)
+	ufs, _ := s.(*UpdateFetchState)
+	assert.Equal(t, update, ufs.update)
+}
+
+func TestStateUpdateFetch(t *testing.T) {
+	// pretend we have an update
+	update := &UpdateResponse{}
+	cs := NewUpdateFetchState(update)
+
+	var s State
+	var c bool
+
+	// pretend update check failed
+	s, c = cs.Handle(&stateTestController{
+		fakeUpdater: fakeUpdater{
+			fetchUpdateReturnError: errors.New("fetch failed"),
+		},
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	data := "test"
+	stream := ioutil.NopCloser(bytes.NewBufferString(data))
+
+	s, c = cs.Handle(&stateTestController{
+		fakeUpdater: fakeUpdater{
+			fetchUpdateReturnReadCloser: stream,
+			fetchUpdateReturnSize:       int64(len(data)),
+		},
+	})
+	assert.IsType(t, &UpdateInstallState{}, s)
+	assert.False(t, c)
+	uis, _ := s.(*UpdateInstallState)
+	assert.Equal(t, stream, uis.imagein)
+	assert.Equal(t, int64(len(data)), uis.size)
+}
+
+func TestStateUpdateInstall(t *testing.T) {
+	data := "test"
+	stream := ioutil.NopCloser(bytes.NewBufferString(data))
+
+	uis := NewUpdateInstallState(stream, int64(len(data)))
+
+	var s State
+	var c bool
+
+	// pretend update check failed
+	s, c = uis.Handle(&stateTestController{
+		fakeDevice: fakeDevice{
+			retInstallUpdate: errors.New("install failed"),
+		},
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	s, c = uis.Handle(&stateTestController{
+		fakeDevice: fakeDevice{
+			retEnablePart: errors.New("enable failed"),
+		},
+	})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	s, c = uis.Handle(&stateTestController{})
+	assert.IsType(t, &RebootState{}, s)
+	assert.False(t, c)
+}
+
+func TestStateReboot(t *testing.T) {
+	rs := RebootState{}
+
+	var s State
+	var c bool
+
+	s, c = rs.Handle(&stateTestController{
+		fakeDevice: fakeDevice{
+			retReboot: errors.New("reboot failed"),
+		}})
+	assert.IsType(t, &ErrorState{}, s)
+	assert.False(t, c)
+
+	s, c = rs.Handle(&stateTestController{})
+	assert.IsType(t, &FinalState{}, s)
+	assert.False(t, c)
+}
+
+func TestStateFinal(t *testing.T) {
+	rs := FinalState{}
+
+	assert.Panics(t, func() {
+		rs.Handle(&stateTestController{})
+	}, "final state Handle() should panic")
+}

--- a/store.go
+++ b/store.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io"
+)
+
+// wrapper for io.WriteCloser with extra Commit() method
+type WriteCloserCommitter interface {
+	io.WriteCloser
+	// commit written data to data store
+	Commit() error
+}
+
+// Store is a wrapper for data store exposing a common set of methods. Errors
+// returned by Store methods should preserve semantics of os I/O errors, for
+// instance, OpenRead() on an entry that does not exist shall return
+// os.ErrNotExist
+type Store interface {
+	// read in contents of entry 'name'
+	ReadAll(name string) ([]byte, error)
+	// write all of data to entry 'name'
+	WriteAll(name string, data []byte) error
+	// open entry 'name' for reading
+	OpenRead(name string) (io.ReadCloser, error)
+	// open entry 'name' for writing, this may create a temporary entry for
+	// writing data, once finished, one should call Commit() from
+	// WriteCloserCommitter interface
+	OpenWrite(name string) (WriteCloserCommitter, error)
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,130 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	errDisabled = errors.New("disabled")
+	errReadOnly = errors.New("read only")
+)
+
+type MemStoreWriter struct {
+	bytes.Buffer
+	ms   *MemStore
+	name string
+}
+
+func (msw *MemStoreWriter) Commit() error {
+	msw.ms.Commit(msw.name, msw.Bytes())
+	return nil
+}
+
+func (msw *MemStoreWriter) Close() error {
+	return nil
+}
+
+type MemStoreData struct {
+	data []byte
+}
+
+// in-memory store for testing purposes
+type MemStore struct {
+	data     map[string]*MemStoreData
+	readonly bool
+	disable  bool
+}
+
+func (ms *MemStore) OpenRead(name string) (io.ReadCloser, error) {
+	if ms.disable {
+		return nil, errDisabled
+	}
+	v, ok := ms.data[name]
+	if ok == false {
+		return nil, os.ErrNotExist
+	}
+
+	return ioutil.NopCloser(bytes.NewBuffer(v.data)), nil
+}
+
+func (ms *MemStore) OpenWrite(name string) (WriteCloserCommitter, error) {
+	if ms.disable {
+		return nil, errDisabled
+	}
+
+	if ms.readonly {
+		return nil, errReadOnly
+	}
+
+	ms.data[name] = &MemStoreData{}
+
+	msw := &MemStoreWriter{
+		bytes.Buffer{},
+		ms,
+		name,
+	}
+	return msw, nil
+}
+
+func (ms *MemStore) ReadAll(name string) ([]byte, error) {
+	in, err := ms.OpenRead(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadAll(in)
+}
+
+func (ms *MemStore) WriteAll(name string, data []byte) error {
+	out, err := ms.OpenWrite(name)
+	if err != nil {
+		return err
+	}
+
+	_, err = out.Write(data)
+	return out.Commit()
+}
+
+func (ms *MemStore) Commit(name string, data []byte) error {
+	if ms.readonly {
+		return errReadOnly
+	}
+	d := ms.data[name]
+	d.data = data
+	return nil
+}
+
+func (ms *MemStore) Remove(name string) {
+	delete(ms.data, name)
+}
+
+func (ms *MemStore) ReadOnly(ro bool) {
+	ms.readonly = ro
+}
+
+func (ms *MemStore) Disable(disable bool) {
+	ms.disable = disable
+}
+
+func NewMemStore() *MemStore {
+	return &MemStore{
+		data: make(map[string]*MemStoreData),
+	}
+}

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,59 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the stack trace of an error or wrapper
+
+`New`, `Errorf`, `Wrap`, and `Wrapf` record a stack trace at the point they are invoked.
+This information can be retrieved with the following interface.
+```go
+type Stack interface {
+        Stack() []uintptr
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to recurse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+Would you like to know more? Read the [blog post](http://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+MIT

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,259 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//      if err != nil {
+//              return err
+//      }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//      _, err := ioutil.ReadAll(r)
+//      if err != nil {
+//              return errors.Wrap(err, "read failed")
+//      }
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type Stack interface {
+//             Stack() []uintptr
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type Causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+)
+
+// stack represents a stack of programm counters.
+type stack []uintptr
+
+func (s *stack) Stack() []uintptr { return *s }
+
+func (s *stack) Location() (string, int) {
+	return location((*s)[0] - 1)
+}
+
+// New returns an error that formats as the given text.
+func New(text string) error {
+	return struct {
+		error
+		*stack
+	}{
+		errors.New(text),
+		callers(),
+	}
+}
+
+type cause struct {
+	cause   error
+	message string
+}
+
+func (c cause) Error() string   { return c.Message() + ": " + c.Cause().Error() }
+func (c cause) Cause() error    { return c.cause }
+func (c cause) Message() string { return c.message }
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	return struct {
+		error
+		*stack
+	}{
+		fmt.Errorf(format, args...),
+		callers(),
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return struct {
+		cause
+		*stack
+	}{
+		cause{
+			cause:   err,
+			message: message,
+		},
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return struct {
+		cause
+		*stack
+	}{
+		cause{
+			cause:   err,
+			message: fmt.Sprintf(format, args...),
+		},
+		callers(),
+	}
+}
+
+type causer interface {
+	Cause() error
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type Causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}
+
+// Fprint prints the error to the supplied writer.
+// If the error implements the Causer interface described in Cause
+// Print will recurse into the error's cause.
+// If the error implements the inteface:
+//
+//     type Location interface {
+//            Location() (file string, line int)
+//     }
+//
+// Print will also print the file and line of the error.
+// If err is nil, nothing is printed.
+func Fprint(w io.Writer, err error) {
+	type location interface {
+		Location() (string, int)
+	}
+	type message interface {
+		Message() string
+	}
+
+	for err != nil {
+		if err, ok := err.(location); ok {
+			file, line := err.Location()
+			fmt.Fprintf(w, "%s:%d: ", file, line)
+		}
+		switch err := err.(type) {
+		case message:
+			fmt.Fprintln(w, err.Message())
+		default:
+			fmt.Fprintln(w, err.Error())
+		}
+
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// location returns the source file and line matching pc.
+func location(pc uintptr) (string, int) {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return "unknown", 0
+	}
+
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(fn.Name(), sep) + 2
+	file, line := fn.FileLine(pc)
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file, line
+}


### PR DESCRIPTION
While working on authorization implementation it turned out that the client code needs a refactoring, otherwise it would be hard to go through authorization steps in a clean manner.

The patch series introduces some major changes to the agent code, in rough detail these are:
* do away with inheritance (or struct/interface embeddeding) in favor of composition where possible; for instance `menderDaemon` does not need to export any interfaces, while `mender` should only export minimal set of interfaces
* introduce a single `Controler` interface
* split `Client` and `UpdateClient` to separate interfaces
* use a state pattern to implement client states, separates controler from actual state execution; operations on controler have been nicely moved to states
* introduction of `menderError` interface; this extends the `error` with extra methods for querying whether an error is fatal or not (used by error state handler)
 
Introuce some helpers/interfaces for implementation of authorization flow, these are:
* `IdentityDataGetter` for obtaining device identity information
* `AuthClient` actual client to the authorization service
* `FileSeqnum`, `Seqnum` number sequence generators with file storage (required for keeping track of auth request sequence numbers)
* `Store` a  generic storage wrapper

Since the authorization work is kind of separate from the rest, I can put that into a different branch and open a PR from that branch after we've merged the generic changes form this PR.

@pasinskim @kacf 