### PR TITLE
MEN-341: Switch to "mender_boot_part" U-Boot environment variable.

### DIFF
--- a/device.go
+++ b/device.go
@@ -107,7 +107,7 @@ func (d *device) EnableUpdatedPartition() error {
 
 	log.Info("Enabling partition with new image installed to be a boot candidate: ", string(partitionNumber))
 	// For now we are only setting boot variables
-	err = d.WriteEnv(BootVars{"upgrade_available": "1", "boot_part": partitionNumber, "bootcount": "0"})
+	err = d.WriteEnv(BootVars{"upgrade_available": "1", "mender_boot_part": partitionNumber, "bootcount": "0"})
 	if err != nil {
 		return err
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -221,18 +221,18 @@ func (p *partitions) getAndCacheActivePartition(rootChecker func(StatCommander, 
 		return p.active, nil
 	}
 
-	log.Error("Mounted root '" + activePartition + "' does not match boot enviromnent boot_part: " + bootEnvBootPart)
+	log.Error("Mounted root '" + activePartition + "' does not match boot environment mender_boot_part: " + bootEnvBootPart)
 	return "", ErrorNoMatchBootPartRootPart
 }
 
 func getBootEnvActivePartition(env BootEnvReadWriter) (string, error) {
-	bootEnv, err := env.ReadEnv("boot_part")
+	bootEnv, err := env.ReadEnv("mender_boot_part")
 	if err != nil {
 		log.Error(err)
 		return "", ErrorNoMatchBootPartRootPart
 	}
 
-	return bootEnv["boot_part"], nil
+	return bootEnv["mender_boot_part"], nil
 }
 
 func checkBootEnvAndRootPartitionMatch(bootPartNum string, rootPart string) bool {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -177,15 +177,15 @@ func Test_getActivePartition_noActiveInactiveSet(t *testing.T) {
 		expectedActive string
 	}{
 		// have mount candidate to return
-		{"/dev/mmcblk0p2 on / type ext4 (rw,errors=remount-ro)", "boot_part=1", 0, trueChecker, nil, nil, nil, "/dev/mmcblk0p2"},
-		{"/dev/mmcblk0p2 on / type ext4 (rw,errors=remount-ro)", "boot_part=1", 0, falseChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
+		{"/dev/mmcblk0p2 on / type ext4 (rw,errors=remount-ro)", "mender_boot_part=1", 0, trueChecker, nil, nil, nil, "/dev/mmcblk0p2"},
+		{"/dev/mmcblk0p2 on / type ext4 (rw,errors=remount-ro)", "mender_boot_part=1", 0, falseChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
 		// no mount candidate
-		{"", "boot_part=1", 0, falseChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
-		{"", "boot_part=1", 0, trueChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
-		{"", "boot_part=1", 0, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, nil, "/dev/mmc1"},
-		{"", "boot_part=1", 0, falseChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, RootPartitionDoesNotMatchMount, ""},
-		{"", "boot_part=2", 0, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, ErrorNoMatchBootPartRootPart, ""},
-		{"", "boot_part=2", 1, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, ErrorNoMatchBootPartRootPart, ""},
+		{"", "mender_boot_part=1", 0, falseChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
+		{"", "mender_boot_part=1", 0, trueChecker, nil, nil, RootPartitionDoesNotMatchMount, ""},
+		{"", "mender_boot_part=1", 0, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, nil, "/dev/mmc1"},
+		{"", "mender_boot_part=1", 0, falseChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, RootPartitionDoesNotMatchMount, ""},
+		{"", "mender_boot_part=2", 0, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, ErrorNoMatchBootPartRootPart, ""},
+		{"", "mender_boot_part=2", 1, trueChecker, []string{"/dev/mmc1", "/dev/mmc2"}, nil, ErrorNoMatchBootPartRootPart, ""},
 	}
 
 	for _, test := range testData {


### PR DESCRIPTION
The intention is to avoid conflicts with similarly named variables
being used in various U-Boot implementations. It's also the variable
being used by the new generic U-Boot patch for Mender in meta-mender.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>