### PR TITLE
Authorization workflow

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,214 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type AuthCode string
+
+type AuthReqData struct {
+	IdData      string `json:"id_data"`
+	TenantToken string `json:"tenant_token"`
+	Pubkey      string `json:"pubkey"`
+	SeqNumber   uint64 `json:"seq_no"`
+}
+
+type AuthRequest struct {
+	// request message data
+	Data []byte
+	// authorization code
+	Code AuthCode
+	// request signature
+	Signature []byte
+}
+
+// handler for authorization message data
+type AuthDataMessenger interface {
+	// build authorization request data, returns auth request or an error
+	MakeAuthRequest() (*AuthRequest, error)
+	// receive authoiriation data response, returns error if response is invalid
+	RecvAuthResponse([]byte) error
+}
+
+type AuthManager interface {
+	// returns true if authorization data is current and valid
+	IsAuthorized() bool
+	// returns device's authoirization code
+	AuthCode() (AuthCode, error)
+	// check if device key is available
+	HasKey() bool
+	// generate device key (will overwrite an already existing key)
+	GenerateKey() error
+
+	AuthDataMessenger
+}
+
+const (
+	authTokenName       = "authtoken"
+	authTenantTokenName = "authtentoken"
+	authSeqName         = "authseq"
+
+	noAuthCode = AuthCode("")
+)
+
+type MenderAuthManager struct {
+	store    Store
+	keyStore *Keystore
+	keyName  string
+	idSrc    IdentityDataGetter
+	seqNum   SeqnumGetter
+}
+
+func NewAuthManager(store Store, keyName string, idSrc IdentityDataGetter) AuthManager {
+	ks := NewKeystore(store)
+	if ks == nil {
+		return nil
+	}
+
+	mgr := &MenderAuthManager{
+		store:    store,
+		keyStore: ks,
+		keyName:  keyName,
+		idSrc:    idSrc,
+		seqNum:   NewFileSeqnum(authSeqName, store),
+	}
+
+	if err := ks.Load(keyName); err != nil && !IsNoKeys(err) {
+		log.Errorf("failed to load device keys from %v: %v", keyName, err)
+		return nil
+	}
+
+	return mgr
+}
+
+func (m *MenderAuthManager) IsAuthorized() bool {
+	adata, err := m.AuthCode()
+	if err != nil {
+		return false
+	}
+
+	if adata == noAuthCode {
+		return false
+	}
+
+	// TODO check if JWT is valid?
+
+	return true
+}
+
+func (m *MenderAuthManager) MakeAuthRequest() (*AuthRequest, error) {
+
+	var err error
+	authd := AuthReqData{}
+
+	idata, err := m.idSrc.Get()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to obtain identity data")
+	}
+
+	authd.IdData = idata
+
+	// fill device public key
+	authd.Pubkey, err = m.keyStore.PublicPEM()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to obtain device public key")
+	}
+
+	tentok, err := m.store.ReadAll(authTenantTokenName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read tenant token")
+	}
+	log.Debugf("tenant token: %s", tentok)
+
+	// fill tenant token
+	authd.TenantToken = string(tentok)
+
+	// fetch sequence number
+	num, err := m.seqNum.Get()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to obtain sequence number")
+	}
+	authd.SeqNumber = num
+
+	log.Debugf("authorization data: %v", authd)
+
+	databuf := &bytes.Buffer{}
+	enc := json.NewEncoder(databuf)
+
+	err = enc.Encode(&authd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to encode auth request")
+	}
+
+	reqdata := databuf.Bytes()
+
+	// generate signature
+	sig, err := m.keyStore.Sign(reqdata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to sign auth request")
+	}
+
+	return &AuthRequest{
+		Data:      reqdata,
+		Code:      AuthCode(tentok),
+		Signature: sig,
+	}, nil
+}
+
+func (m *MenderAuthManager) RecvAuthResponse(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("empty auth response data")
+	}
+
+	if err := m.store.WriteAll(authTokenName, data); err != nil {
+		return errors.Wrapf(err, "failed to save auth token")
+	}
+	return nil
+}
+
+func (m *MenderAuthManager) AuthCode() (AuthCode, error) {
+	data, err := m.store.ReadAll(authTokenName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return noAuthCode, nil
+		}
+		return noAuthCode, errors.Wrapf(err, "failed to read auth token data")
+	}
+
+	return AuthCode(data), nil
+}
+
+func (m *MenderAuthManager) HasKey() bool {
+	return m.keyStore.Private() != nil
+}
+
+func (m *MenderAuthManager) GenerateKey() error {
+	if err := m.keyStore.Generate(); err != nil {
+		log.Errorf("failed to generate device key: %v", err)
+		return errors.Wrapf(err, "failed to generate device key")
+	}
+
+	if err := m.keyStore.Save(m.keyName); err != nil {
+		log.Errorf("failed to save keys to %s: %s", m.keyName, err)
+		return NewFatalError(err)
+	}
+	return nil
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,134 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthManager(t *testing.T) {
+	ms := NewMemStore()
+
+	cmdr := newTestOSCalls("", 0)
+	am := NewAuthManager(ms, "devkey", IdentityDataRunner{
+		cmdr: &cmdr,
+	})
+	assert.IsType(t, &MenderAuthManager{}, am)
+
+	assert.False(t, am.HasKey())
+	assert.NoError(t, am.GenerateKey())
+	assert.True(t, am.HasKey())
+
+	assert.False(t, am.IsAuthorized())
+
+	code, err := am.AuthCode()
+	assert.Equal(t, noAuthCode, code)
+	assert.NoError(t, err)
+
+	ms.WriteAll(authTokenName, []byte("footoken"))
+	// disable store access
+	ms.Disable(true)
+	code, err = am.AuthCode()
+	assert.Error(t, err)
+	ms.Disable(false)
+
+	code, err = am.AuthCode()
+	assert.Equal(t, AuthCode("footoken"), code)
+	assert.NoError(t, err)
+}
+
+func TestAuthManagerRequest(t *testing.T) {
+	ms := NewMemStore()
+
+	var err error
+
+	badcmdr := newTestOSCalls("mac=foobar", -1)
+	am := NewAuthManager(ms, "devkey", IdentityDataRunner{
+		cmdr: &badcmdr,
+	})
+	_, err = am.MakeAuthRequest()
+	assert.Error(t, err, "should fail, cannot obtain identity data")
+	assert.Contains(t, err.Error(), "identity data")
+
+	cmdr := newTestOSCalls("mac=foobar", 0)
+	am = NewAuthManager(ms, "devkey", IdentityDataRunner{
+		cmdr: &cmdr,
+	})
+	_, err = am.MakeAuthRequest()
+	assert.Error(t, err, "should fail, no device keys are present")
+	assert.Contains(t, err.Error(), "device public key")
+
+	// generate key first
+	assert.NoError(t, am.GenerateKey())
+
+	_, err = am.MakeAuthRequest()
+	assert.Error(t, err, "should fail, no tenant token present")
+	assert.Contains(t, err.Error(), "tenant token")
+
+	// setup tenant token
+	ms.WriteAll(authTenantTokenName, []byte("tenant"))
+	// setup sequence number
+	ms.WriteAll(authSeqName, []byte("12"))
+
+	req, err := am.MakeAuthRequest()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, req.Data)
+	assert.Equal(t, AuthCode("tenant"), req.Code)
+	assert.NotEmpty(t, req.Signature)
+
+	var ard AuthReqData
+	err = json.Unmarshal(req.Data, &ard)
+	assert.NoError(t, err)
+
+	mam := am.(*MenderAuthManager)
+	pempub, _ := mam.keyStore.PublicPEM()
+	assert.Equal(t, AuthReqData{
+		IdData:      "{\"mac\":\"foobar\"}",
+		TenantToken: "tenant",
+		Pubkey:      pempub,
+		SeqNumber:   13,
+	}, ard)
+
+	sign, err := mam.keyStore.Sign(req.Data)
+	assert.Equal(t, sign, req.Signature)
+}
+
+func TestAuthManagerResponse(t *testing.T) {
+	ms := NewMemStore()
+
+	cmdr := newTestOSCalls("mac=foobar", 0)
+	am := NewAuthManager(ms, "devkey", IdentityDataRunner{
+		cmdr: &cmdr,
+	})
+
+	var err error
+	err = am.RecvAuthResponse([]byte{})
+	// should fail with empty response
+	assert.Error(t, err)
+
+	// make storage RO
+	ms.ReadOnly(true)
+	err = am.RecvAuthResponse([]byte("fooresp"))
+	assert.Error(t, err)
+
+	ms.ReadOnly(false)
+	err = am.RecvAuthResponse([]byte("fooresp"))
+	tokdata, err := ms.ReadAll(authTokenName)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("fooresp"), tokdata)
+	assert.True(t, am.IsAuthorized())
+}

--- a/client.go
+++ b/client.go
@@ -24,6 +24,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	apiPrefix = "/api/0.0.1/"
+)
+
 var (
 	errorLoadingClientCertificate      = errors.New("Failed to load certificate and key")
 	errorAddingServerCertificateToPool = errors.New("Error adding trusted server certificate to pool.")
@@ -123,4 +127,11 @@ func buildURL(server string) string {
 		return server
 	}
 	return "https://" + server
+}
+
+func buildApiURL(server, url string) string {
+	if strings.HasPrefix(url, "/") {
+		url = url[1:]
+	}
+	return buildURL(server) + apiPrefix + url
 }

--- a/client_auth.go
+++ b/client_auth.go
@@ -1,0 +1,89 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type AuthRequester interface {
+	Request(server string, dataSrc AuthDataMessenger) ([]byte, error)
+}
+
+type AuthClient struct {
+	client *http.Client
+}
+
+func NewAuthClient(conf httpsClientConfig) (*AuthClient, error) {
+	client, err := NewHttpClient(conf)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create auth client HTTP client")
+	}
+
+	ac := AuthClient{
+		client: client,
+	}
+	return &ac, nil
+}
+
+func (u *AuthClient) Request(server string, dataSrc AuthDataMessenger) ([]byte, error) {
+
+	req, err := makeAuthRequest(server, dataSrc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build authorization request")
+	}
+
+	log.Debugf("making authorization request to server %s with req: %s", server, req)
+	rsp, err := u.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to execute authorization request")
+	}
+	defer rsp.Body.Close()
+
+	log.Debugf("receive response data")
+	data, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to receive authorization response data")
+	}
+
+	log.Debugf("received response data %v", data)
+
+	return data, nil
+}
+
+func makeAuthRequest(server string, dataSrc AuthDataMessenger) (*http.Request, error) {
+	url := buildApiURL(server, "/authorization/auth_requests")
+
+	req, err := dataSrc.MakeAuthRequest()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to obtain authorization message data")
+	}
+
+	dataio := bytes.NewBuffer(req.Data)
+	hreq, err := http.NewRequest(http.MethodGet, url, dataio)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create authorization HTTP request")
+	}
+
+	hreq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", req.Code))
+	hreq.Header.Add("X-MEN-Signature", base64.StdEncoding.EncodeToString(req.Signature))
+	return hreq, nil
+}

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeAuthorizer struct {
+	rsp       []byte
+	rspErr    error
+	url       string
+	reqCalled bool
+}
+
+func (f *fakeAuthorizer) Request(url string, adm AuthDataMessenger) ([]byte, error) {
+	fmt.Printf("url: %s\n", url)
+	f.url = url
+	f.reqCalled = true
+	return f.rsp, f.rspErr
+}
+
+type testAuthDataMessenger struct {
+	reqData  []byte
+	sigData  []byte
+	code     AuthCode
+	reqError error
+	rspError error
+	rspData  []byte
+}
+
+func (t *testAuthDataMessenger) MakeAuthRequest() (*AuthRequest, error) {
+	return &AuthRequest{
+		t.reqData,
+		t.code,
+		t.sigData,
+	}, t.reqError
+}
+
+func (t *testAuthDataMessenger) RecvAuthResponse(data []byte) error {
+	t.rspData = data
+	return t.rspError
+}
+
+func TestClientAuthMakeReq(t *testing.T) {
+
+	var req *http.Request
+	var err error
+
+	req, err = makeAuthRequest("foo", &testAuthDataMessenger{
+		reqError: errors.New("req failed"),
+	})
+	assert.Nil(t, req)
+	assert.Error(t, err)
+
+	req, err = makeAuthRequest("mender.io", &testAuthDataMessenger{
+		reqData: []byte("foobar data"),
+		code:    "tenanttoken",
+		sigData: []byte("foobar"),
+	})
+	assert.NotNil(t, req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, req.Method)
+	assert.Equal(t, "https://mender.io/api/0.0.1/authorization/auth_requests", req.URL.String())
+	assert.Equal(t, "Bearer tenanttoken", req.Header.Get("Authorization"))
+	expsignature := base64.StdEncoding.EncodeToString([]byte("foobar"))
+	assert.Equal(t, expsignature, req.Header.Get("X-MEN-Signature"))
+	assert.NotNil(t, req.Body)
+	data, _ := ioutil.ReadAll(req.Body)
+	t.Logf("data: %v", string(data))
+
+	assert.Equal(t, []byte("foobar data"), data)
+}
+
+func TestClientAuth(t *testing.T) {
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, "foobar-token")
+	}))
+	defer ts.Close()
+
+	client, err := NewAuthClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	msger := &testAuthDataMessenger{
+		reqData: []byte("foobar"),
+	}
+	rsp, err := client.Request(ts.URL, msger)
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+	assert.Equal(t, "foobar-token", string(rsp))
+}

--- a/client_test.go
+++ b/client_test.go
@@ -47,4 +47,9 @@ func TestHttpClientUrl(t *testing.T) {
 	u = buildURL("foo.bar")
 	assert.Equal(t, "https://foo.bar", u)
 
+	u = buildApiURL("foo.bar", "/zed")
+	assert.Equal(t, "https://foo.bar/api/0.0.1/zed", u)
+
+	u = buildApiURL("foo.bar", "zed")
+	assert.Equal(t, "https://foo.bar/api/0.0.1/zed", u)
 }

--- a/client_update.go
+++ b/client_update.go
@@ -51,7 +51,7 @@ func NewUpdateClient(conf httpsClientConfig) (*UpdateClient, error) {
 }
 
 func (u *UpdateClient) GetScheduledUpdate(server string, deviceID string) (interface{}, error) {
-	return u.getUpdateInfo(processUpdateResponse, buildURL(server), deviceID)
+	return u.getUpdateInfo(processUpdateResponse, server, deviceID)
 }
 
 func (u *UpdateClient) getUpdateInfo(process RequestProcessingFunc, server string,
@@ -166,7 +166,7 @@ func processUpdateResponse(response *http.Response) (interface{}, error) {
 }
 
 func makeUpdateCheckRequest(server, deviceID string) (*http.Request, error) {
-	url := server + "/api/0.0.1/devices/" + deviceID + "/update"
+	url := buildApiURL(server, "/devices/"+deviceID+"/update")
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ func readConfigFile(config interface{}, fileName string) error {
 	return nil
 }
 
-func (c menderConfig) GetUpdaterConfig() httpsClientConfig {
+func (c menderConfig) GetHttpConfig() httpsClientConfig {
 	return httpsClientConfig{
 		c.HttpsClient.Certificate,
 		c.HttpsClient.Key,

--- a/fileseqnum.go
+++ b/fileseqnum.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"math"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// Numeric sequence generator preserving its state in a file. The file will be
+// saved in 'store' under name 'name'.
+type FileSeqnum struct {
+	name  string
+	store Store
+}
+
+func NewFileSeqnum(name string, store Store) *FileSeqnum {
+	return &FileSeqnum{
+		name:  name,
+		store: store,
+	}
+}
+
+// Obtain next sequence number. In case of errors (read, write, parse etc.)
+// returned value is 0 and error is returned.
+func (fs *FileSeqnum) Get() (uint64, error) {
+
+	d, err := fs.store.ReadAll(fs.name)
+	if err != nil && !os.IsNotExist(err) {
+		return 0, errors.Wrapf(err, "seqnum data read failed")
+	}
+
+	newval := SeqnumStartVal
+
+	if !os.IsNotExist(err) {
+		v, err := strconv.ParseUint(string(d), 10, 64)
+		if err != nil {
+			return 0, errors.Wrapf(err, "seqnum data parse failed")
+		}
+
+		// check for overflow
+		if math.MaxUint64 == v {
+			newval = SeqnumStartVal
+		} else {
+			newval = v + 1
+		}
+	}
+
+	err = fs.store.WriteAll(fs.name, []byte(strconv.FormatUint(newval, 10)))
+	if err != nil {
+		return 0, errors.Wrapf(err, "seqnum data write failed")
+	}
+
+	return newval, nil
+}

--- a/fileseqnum_test.go
+++ b/fileseqnum_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileSeqnum(t *testing.T) {
+	ms := NewMemStore()
+
+	fs := NewFileSeqnum("seqnum", ms)
+
+	// make store disabled
+	ms.Disable(true)
+	v, err := fs.Get()
+	assert.Error(t, err)
+	ms.Disable(false)
+
+	// Get should raise an error with read-only store
+	ms.ReadOnly(true)
+	v, err = fs.Get()
+	assert.Error(t, err)
+	ms.ReadOnly(false)
+
+	// verify that value is generated correctly
+	ms.WriteAll("seqnum", []byte("65535"))
+	v, err = fs.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(65536), v)
+
+	d, err := ms.ReadAll("seqnum")
+	assert.NoError(t, err)
+	assert.Equal(t, "65536", string(d))
+
+	ms.WriteAll("seqnum", []byte("foo"))
+	v, err = fs.Get()
+	assert.Error(t, err)
+
+	// verify that the sequence starts from 1
+	ms.Remove("seqnum")
+	v, err = fs.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, SeqnumStartVal, v)
+
+	d, err = ms.ReadAll("seqnum")
+	assert.NoError(t, err)
+	assert.Equal(t, "1", string(d))
+
+	// verify sequence wrap
+	ms.WriteAll("seqnum", []byte(strconv.FormatUint(math.MaxUint64, 10)))
+	v, err = fs.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, SeqnumStartVal, v)
+
+}

--- a/identity_data.go
+++ b/identity_data.go
@@ -1,0 +1,106 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	identityDataHelper = "/usr/bin/mender-device-identity"
+)
+
+type IdentityDataGetter interface {
+	// obtain identity data as a string or return an error
+	Get() (string, error)
+}
+
+type IdentityDataRunner struct {
+	Helper string
+	cmdr   Commander
+}
+
+func NewIdentityDataGetter() IdentityDataGetter {
+	return &IdentityDataRunner{
+		identityDataHelper,
+		&osCalls{},
+	}
+}
+
+// Obtain identity data by calling a suitable helper tool
+func (id IdentityDataRunner) Get() (string, error) {
+	helper := identityDataHelper
+
+	if id.Helper != "" {
+		helper = id.Helper
+	}
+
+	cmd := id.cmdr.Command(helper)
+	data, err := cmd.Output()
+
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to call %s", helper)
+	}
+
+	idata, err := parseIdentityData(data)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse identity data")
+	}
+
+	encdata, err := json.Marshal(idata)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to encode identity data")
+	}
+
+	return string(encdata), nil
+}
+
+// device identity data content
+type IdentityData map[string]string
+
+func parseIdentityData(data []byte) (interface{}, error) {
+	idata := make(IdentityData)
+
+	in := bufio.NewScanner(bytes.NewBuffer(data))
+	for in.Scan() {
+		line := in.Text()
+
+		if len(line) == 0 {
+			continue
+		}
+
+		val := strings.SplitN(line, "=", 2)
+
+		if len(val) < 2 {
+			return nil, errors.Errorf("incorrect line '%s'", line)
+		}
+
+		if _, ok := idata[val[0]]; ok {
+			log.Warningf("attribute %v already present in identity data", val[0])
+		}
+		idata[val[0]] = val[1]
+	}
+
+	if len(idata) == 0 {
+		return nil, errors.Errorf("no data found")
+	}
+
+	return &idata, nil
+}

--- a/identity_data_test.go
+++ b/identity_data_test.go
@@ -1,0 +1,128 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceIdentityGet(t *testing.T) {
+	td := []struct {
+		data string
+		bad  bool
+		ref  IdentityData
+		code int
+	}{
+		{
+			`
+mac=123;123
+bar=123
+foo=bar
+`,
+			true,
+			IdentityData{},
+			1,
+		},
+		{
+			`
+foo=bar
+key=value=23
+some value=bar
+mac=de:ad:be:ef:00:01
+`,
+			false,
+			IdentityData{
+				"foo":        "bar",
+				"key":        "value=23",
+				"some value": "bar",
+				"mac":        "de:ad:be:ef:00:01",
+			},
+			0,
+		},
+		{
+			"",
+			true,
+			IdentityData{},
+			0,
+		},
+	}
+
+	for _, tc := range td {
+		// t.Logf("test data: %+v", tc)
+
+		r := newTestOSCalls(tc.data, tc.code)
+		ir := IdentityDataRunner{
+			cmdr: &r,
+		}
+		id, err := ir.Get()
+
+		if tc.bad {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotEmpty(t, id)
+
+			refdata, _ := json.Marshal(tc.ref)
+			assert.Equal(t, string(refdata), id)
+		}
+	}
+}
+
+func TestDeviceIdentityParse(t *testing.T) {
+	td := []struct {
+		data string
+		bad  bool
+		ref  IdentityData
+	}{
+		{
+			`
+foo=bar
+key=value=23
+some value=bar
+mac=de:ad:be:ef:00:01
+`,
+			false,
+			IdentityData{
+				"foo":        "bar",
+				"key":        "value=23",
+				"some value": "bar",
+				"mac":        "de:ad:be:ef:00:01",
+			},
+		},
+		{
+			"",
+			true,
+			IdentityData{},
+		},
+	}
+
+	for _, tc := range td {
+		// t.Logf("test data: %+v", tc)
+
+		id, err := parseIdentityData([]byte(tc.data))
+		if tc.bad {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, id)
+
+			val, ok := id.(*IdentityData)
+			assert.True(t, ok)
+			assert.Equal(t, tc.ref, *val)
+		}
+	}
+}

--- a/keystore.go
+++ b/keystore.go
@@ -14,16 +14,18 @@
 package main
 
 import (
+	"bytes"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -107,6 +109,31 @@ func (k *Keystore) Generate() error {
 
 func (k *Keystore) Private() *rsa.PrivateKey {
 	return k.private
+}
+
+func (k *Keystore) Public() crypto.PublicKey {
+	if k.private != nil {
+		return k.private.Public()
+	}
+	return nil
+}
+
+func (k *Keystore) PublicPEM() (string, error) {
+	data, err := x509.MarshalPKIXPublicKey(k.Public())
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to marshal public key")
+	}
+
+	buf := &bytes.Buffer{}
+	err = pem.Encode(buf, &pem.Block{
+		Type:  "PUBLIC KEY", // PKCS1
+		Bytes: data,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to encode public key to PEM")
+	}
+
+	return buf.String(), nil
 }
 
 func IsNoKeys(e error) bool {

--- a/keystore.go
+++ b/keystore.go
@@ -136,6 +136,15 @@ func (k *Keystore) PublicPEM() (string, error) {
 	return buf.String(), nil
 }
 
+func (k *Keystore) Sign(data []byte) ([]byte, error) {
+	hash := crypto.SHA256
+	h := hash.New()
+	h.Write(data)
+	sum := h.Sum(nil)
+
+	return rsa.SignPKCS1v15(rand.Reader, k.private, hash, sum)
+}
+
 func IsNoKeys(e error) bool {
 	return e == errNoKeys
 }

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -15,6 +15,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +110,24 @@ func TestKeystore(t *testing.T) {
 
 	// we should be able to load a saved key
 	assert.NoError(t, k.Load("foo"))
+
+	// check public key
+	pubkey := k.Public()
+	assert.NotNil(t, pubkey)
+
+	// serialize to PEM
+	buf := &bytes.Buffer{}
+	data, err := x509.MarshalPKIXPublicKey(pubkey)
+	assert.NoError(t, err)
+	err = pem.Encode(buf, &pem.Block{
+		Type:  "PUBLIC KEY", // PKCS1
+		Bytes: data,
+	})
+	expectedaspem := buf.String()
+
+	aspem, err := k.PublicPEM()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedaspem, aspem)
 }
 
 func TestKeystoreLoadPem(t *testing.T) {

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -15,6 +15,8 @@ package main
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
@@ -128,6 +130,18 @@ func TestKeystore(t *testing.T) {
 	aspem, err := k.PublicPEM()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedaspem, aspem)
+
+	tosigndata := []byte("foobar")
+	s, err := k.Sign(tosigndata)
+	assert.NoError(t, err)
+	// generate hash of data for verification
+	h := crypto.SHA256.New()
+	h.Write(tosigndata)
+	hashed := h.Sum(nil)
+
+	err = rsa.VerifyPKCS1v15(&k.private.PublicKey, crypto.SHA256, hashed, s)
+	// signature should be valid
+	assert.NoError(t, err)
 }
 
 func TestKeystoreLoadPem(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -294,13 +294,23 @@ func doMain(args []string) error {
 			return errors.New("Cannot initialize daemon. Error instantiating updater. Exiting.")
 		}
 
+		authreq, err := NewAuthClient(config.GetHttpConfig())
+		if err != nil {
+			return errors.New("Cannot initialize daemon. Error instantiating auth client. Exiting.")
+		}
+
 		store := NewDirStore(*runOptions.dataStore)
+
+		authmgr := NewAuthManager(store, config.DeviceKey,
+			NewIdentityDataGetter())
 
 		controller := NewMender(*config, MenderPieces{
 			updater,
 			device,
 			env,
 			store,
+			authmgr,
+			authreq,
 		})
 		if controller == nil {
 			return errors.New("Cannot initialize mender controller")

--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ func doMain(args []string) error {
 		}
 
 	case *runOptions.daemon:
-		updater, err := NewUpdateClient(config.GetUpdaterConfig())
+		updater, err := NewUpdateClient(config.GetHttpConfig())
 		if err != nil {
 			return errors.New("Cannot initialize daemon. Error instantiating updater. Exiting.")
 		}

--- a/mender.go
+++ b/mender.go
@@ -66,6 +66,10 @@ const (
 	MenderStateInit MenderState = iota
 	// client is bootstrapped, i.e. ready to go
 	MenderStateBootstrapped
+	// client has all authorization data available
+	MenderStateAuthorized
+	// wait before authorization attempt
+	MenderStateAuthorizeWait
 	// wait for new update
 	MenderStateUpdateCheckWait
 	// check update

--- a/mender.go
+++ b/mender.go
@@ -24,6 +24,7 @@ import (
 )
 
 type Controller interface {
+	Authorize() menderError
 	Bootstrap() menderError
 	GetCurrentImageID() string
 	GetUpdatePollInterval() time.Duration

--- a/seqnum.go
+++ b/seqnum.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+const (
+	SeqnumStartVal = uint64(1)
+)
+
+// Numeric sequence generator. Sequence starts from 1, 0 is an invalid value and
+// shall never be returned by Get() call.
+type SeqnumGetter interface {
+	Get() (uint64, error)
+}


### PR DESCRIPTION
The series of patches implemens a workflow for client authorization.

The first 5 patches are mostly cleanups/refactoring of things/helpers that were spotted along the way.

Device identity data is obtained using the helper script `support/mender-device-identity`. Right now the script outputs a per line `key=value` of identity data. This is parsed and collected into a single structure. @pasinskim suggested refactoring the script to just produce JSON output without the need for further parsing.

Seqnum is a sequence generator with storage backing. This is needed for authorization requests.

An authorization client is implemented by `AuthManager` interface, with `AuthDataMessenger` being a helper interface that wraps producing/consuming of authorization requests. Tried to make the interface useful for other transports than HTTP as well. 

@pasinskim @kacf 