### PR TITLE
bootstrap & authorize CLI switches

### DIFF
--- a/identity_data.go
+++ b/identity_data.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
+var (
 	identityDataHelper = "/usr/bin/mender-device-identity"
 )
 

--- a/main.go
+++ b/main.go
@@ -351,19 +351,13 @@ func doMain(args []string) error {
 	switch {
 
 	case *runOptions.imageFile != "":
-		if err := doRootfs(device, runOptions); err != nil {
-			return err
-		}
+		return doRootfs(device, runOptions)
 
 	case *runOptions.commit:
-		if err := device.CommitUpdate(); err != nil {
-			return err
-		}
+		return device.CommitUpdate()
 
 	case *runOptions.bootstrap:
-		if err := doBootstrapAuthorize(config, &runOptions); err != nil {
-			return err
-		}
+		return doBootstrapAuthorize(config, &runOptions)
 
 	case *runOptions.daemon:
 		d, err := initDaemon(config, device, env, &runOptions)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
 )
 
 type logOptionsType struct {
@@ -267,7 +267,7 @@ func doBootstrapAuthorize(config *menderConfig, opts *runOptionsType) error {
 
 	authreq, err := NewAuthClient(config.GetHttpConfig())
 	if err != nil {
-		return errors.New("cannot auth client")
+		return errors.Wrap(err, "error instantiating auth client")
 	}
 
 	authmgr := NewAuthManager(store, config.DeviceKey, NewIdentityDataGetter())
@@ -298,12 +298,12 @@ func initDaemon(config *menderConfig, dev *device, env *uBootEnv,
 
 	updater, err := NewUpdateClient(config.GetHttpConfig())
 	if err != nil {
-		return nil, errors.New("Cannot initialize daemon. Error instantiating updater. Exiting.")
+		return nil, errors.Wrap(err, "error instantiating updater")
 	}
 
 	authreq, err := NewAuthClient(config.GetHttpConfig())
 	if err != nil {
-		return nil, errors.New("Cannot initialize daemon. Error instantiating auth client. Exiting.")
+		return nil, errors.Wrap(err, "error instantiating auth client")
 	}
 
 	store := NewDirStore(*opts.dataStore)
@@ -319,7 +319,7 @@ func initDaemon(config *menderConfig, dev *device, env *uBootEnv,
 		authreq,
 	})
 	if controller == nil {
-		return nil, errors.New("Cannot initialize mender controller")
+		return nil, errors.New("error initializing mender controller")
 	}
 
 	if *opts.bootstrapForce {

--- a/main.go
+++ b/main.go
@@ -34,13 +34,13 @@ type logOptionsType struct {
 }
 
 type runOptionsType struct {
-	version   *bool
-	config    *string
-	dataStore *string
-	imageFile *string
-	commit    *bool
-	daemon    *bool
-	bootstrap *bool
+	version        *bool
+	config         *string
+	dataStore      *string
+	imageFile      *string
+	commit         *bool
+	daemon         *bool
+	bootstrapForce *bool
 	httpsClientConfig
 }
 
@@ -101,7 +101,7 @@ func argsParse(args []string) (runOptionsType, error) {
 	certFile := parsing.String("certificate", "", "Client certificate")
 	certKey := parsing.String("cert-key", "", "Client certificate's private key")
 	serverCert := parsing.String("trusted-certs", "", "Trusted server certificates")
-	bootstrap := parsing.Bool("bootstrap", false, "Force bootstrap")
+	forcebootstrap := parsing.Bool("forcebootstrap", false, "Force bootstrap")
 
 	// add log related command line options
 	logFlags := addLogFlags(parsing)
@@ -113,14 +113,14 @@ func argsParse(args []string) (runOptionsType, error) {
 	}
 
 	runOptions := runOptionsType{
-		version,
-		config,
-		data,
-		imageFile,
-		commit,
-		daemon,
-		bootstrap,
-		httpsClientConfig{
+		version:        version,
+		config:         config,
+		dataStore:      data,
+		imageFile:      imageFile,
+		commit:         commit,
+		daemon:         daemon,
+		bootstrapForce: forcebootstrap,
+		httpsClientConfig: httpsClientConfig{
 			*certFile,
 			*certKey,
 			*serverCert,
@@ -287,7 +287,7 @@ func initDaemon(config *menderConfig, dev *device, env *uBootEnv,
 		return nil, errors.New("Cannot initialize mender controller")
 	}
 
-	if *opts.bootstrap {
+	if *opts.bootstrapForce {
 		controller.ForceBootstrap()
 	}
 

--- a/mender.go
+++ b/mender.go
@@ -216,8 +216,8 @@ func (m *mender) Authorize() menderError {
 }
 
 func (m *mender) doBootstrap() menderError {
-	if !m.authMgr.HasKey() {
-		log.Infof("device keys not present, generating")
+	if !m.authMgr.HasKey() || m.forceBootstrap {
+		log.Infof("device keys not present or bootstrap forced, generating")
 		if err := m.authMgr.GenerateKey(); err != nil {
 			return NewFatalError(err)
 		}

--- a/mender_test.go
+++ b/mender_test.go
@@ -115,11 +115,37 @@ func newDefaultTestMender() *mender {
 }
 
 func Test_ForceBootstrap(t *testing.T) {
-	mender := newDefaultTestMender()
+	// generate valid keys
+	ms := NewMemStore()
+	mender := newTestMender(nil,
+		menderConfig{
+			DeviceKey: "temp.key",
+		},
+		MenderPieces{
+			store: ms,
+		},
+	)
+
+	merr := mender.Bootstrap()
+	assert.NoError(t, merr)
+
+	kdataold, err := ms.ReadAll("temp.key")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, kdataold)
 
 	mender.ForceBootstrap()
 
 	assert.True(t, mender.needsBootstrap())
+
+	merr = mender.Bootstrap()
+	assert.NoError(t, merr)
+
+	// bootstrap should have generated a new key
+	kdatanew, err := ms.ReadAll("temp.key")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, kdatanew)
+	// we should have a new key
+	assert.NotEqual(t, kdatanew, kdataold)
 }
 
 func Test_Bootstrap(t *testing.T) {


### PR DESCRIPTION
It may be reasonable to have separate command line switches for triggering bootstrap and authorization. The series renames the old `-bootstrap` switch to `-forcebootstrap` to make it more meaningful and introduces 2 new switches:
* `-bootstrap` - the client perform boostrap only and exit
* `-authorize` - the client performs a single authorization attempt and exits

Also extra cleanups for `runOptionsType`.

@kacf @pasinskim 

Edit: after review separate authorization and bootstrap switches were replaced with single `-bootstrap`.