### PR TITLE
API client cleanup

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,10 +33,19 @@ var (
 	errorAddingServerCertificateToPool = errors.New("Error adding trusted server certificate to pool.")
 )
 
+// Mender API Client wrapper. A standard http.Client is compatible with this
+// interface and can be used without further configuration where ApiRequester is
+// expected. Instead of instantiating the client by yourself, one can also use a
+// wrapper call NewApiClient() that sets up TLS handling according to passed
+// configuration.
+type ApiRequester interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 type RequestProcessingFunc func(response *http.Response) (interface{}, error)
 
 // Client initialization
-func NewHttpClient(conf httpsClientConfig) (*http.Client, error) {
+func NewApiClient(conf httpsClientConfig) (*http.Client, error) {
 
 	if conf == (httpsClientConfig{}) {
 		return newHttpClient(), nil

--- a/client_auth.go
+++ b/client_auth.go
@@ -25,26 +25,19 @@ import (
 )
 
 type AuthRequester interface {
-	Request(server string, dataSrc AuthDataMessenger) ([]byte, error)
+	Request(api ApiRequester, server string, dataSrc AuthDataMessenger) ([]byte, error)
 }
 
+// Auth client wrapper. Instantiate by yourself or use `NewAuthClient()` helper
 type AuthClient struct {
-	client *http.Client
 }
 
-func NewAuthClient(conf httpsClientConfig) (*AuthClient, error) {
-	client, err := NewHttpClient(conf)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create auth client HTTP client")
-	}
-
-	ac := AuthClient{
-		client: client,
-	}
-	return &ac, nil
+func NewAuthClient() *AuthClient {
+	ac := AuthClient{}
+	return &ac
 }
 
-func (u *AuthClient) Request(server string, dataSrc AuthDataMessenger) ([]byte, error) {
+func (u *AuthClient) Request(api ApiRequester, server string, dataSrc AuthDataMessenger) ([]byte, error) {
 
 	req, err := makeAuthRequest(server, dataSrc)
 	if err != nil {
@@ -52,7 +45,7 @@ func (u *AuthClient) Request(server string, dataSrc AuthDataMessenger) ([]byte, 
 	}
 
 	log.Debugf("making authorization request to server %s with req: %s", server, req)
-	rsp, err := u.client.Do(req)
+	rsp, err := api.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to execute authorization request")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -20,17 +20,17 @@ import (
 )
 
 func TestHttpClient(t *testing.T) {
-	cl, err := NewHttpClient(
+	cl, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
 	assert.NotNil(t, cl)
 
 	// no https config, we should obtain a httpClient
-	cl, err = NewHttpClient(httpsClientConfig{})
+	cl, err = NewApiClient(httpsClientConfig{})
 	assert.NotNil(t, cl)
 
 	// incomplete config should yield an error
-	cl, err = NewHttpClient(
+	cl, err = NewApiClient(
 		httpsClientConfig{"foobar", "client.key", "", true},
 	)
 	assert.Nil(t, cl)

--- a/client_update_test.go
+++ b/client_update_test.go
@@ -127,15 +127,18 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
+	ac, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
+
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
 
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, errors.New("") }
 
-	_, err = client.getUpdateInfo(fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL, "")
 	assert.Error(t, err)
 }
 
@@ -149,14 +152,17 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
+	ac, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
+
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, nil }
 
-	_, err = client.getUpdateInfo(fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL, "")
 	assert.NoError(t, err)
 }
 
@@ -170,13 +176,16 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
+	ac, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
 
-	data, err := client.GetScheduledUpdate(ts.URL, "")
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
+
+	data, err := client.GetScheduledUpdate(ac, ts.URL, "")
 	assert.NoError(t, err)
 	update, ok := data.(UpdateResponse)
 	assert.True(t, ok)
@@ -193,13 +202,16 @@ func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
+	ac, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
 
-	_, _, err = client.FetchUpdate(ts.URL)
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
+
+	_, _, err = client.FetchUpdate(ac, ts.URL)
 	assert.Error(t, err)
 }
 
@@ -213,13 +225,16 @@ func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
+	ac, err := NewApiClient(
 		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
 
-	_, _, err = client.FetchUpdate("broken-request")
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
+
+	_, _, err = client.FetchUpdate(ac, "broken-request")
 	assert.Error(t, err)
 }
 
@@ -233,13 +248,16 @@ func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewUpdateClient(
-		httpsClientConfig{"", "", "server.crt", true},
+	ac, err := NewApiClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
 	)
-	assert.NotNil(t, client)
+	assert.NotNil(t, ac)
 	assert.NoError(t, err)
+
+	client := NewUpdateClient()
+	assert.NotNil(t, client)
 	client.minImageSize = 1
 
-	_, _, err = client.FetchUpdate(ts.URL)
+	_, _, err = client.FetchUpdate(ac, ts.URL)
 	assert.NoError(t, err)
 }

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -53,10 +53,10 @@ type fakeUpdater struct {
 	fetchUpdateReturnError        error
 }
 
-func (f fakeUpdater) GetScheduledUpdate(url string, device string) (interface{}, error) {
+func (f fakeUpdater) GetScheduledUpdate(api ApiRequester, url string, device string) (interface{}, error) {
 	return f.GetScheduledUpdateReturnIface, f.GetScheduledUpdateReturnError
 }
-func (f fakeUpdater) FetchUpdate(url string) (io.ReadCloser, int64, error) {
+func (f fakeUpdater) FetchUpdate(api ApiRequester, url string) (io.ReadCloser, int64, error) {
 	return f.fetchUpdateReturnReadCloser, f.fetchUpdateReturnSize, f.fetchUpdateReturnError
 }
 

--- a/rootfs.go
+++ b/rootfs.go
@@ -40,15 +40,15 @@ func doRootfs(device UInstaller, args runOptionsType) error {
 		log.Infof("Perfroming remote update from: [%s].", updateLocation)
 
 		// we are having remote update
-		client, err = NewUpdateClient(args.httpsClientConfig)
-
+		ac, err := NewApiClient(args.httpsClientConfig)
 		if err != nil {
 			return errors.New("Can not initialize client for performing network update.")
 		}
+		client = NewUpdateClient()
 
 		log.Debug("Client initialized. Start downloading image.")
 
-		image, imageSize, err = client.FetchUpdate(updateLocation)
+		image, imageSize, err = client.FetchUpdate(ac, updateLocation)
 		log.Debugf("Image downloaded: %d [%v] [%v]", imageSize, image, err)
 	} else {
 		// perform update from local file


### PR DESCRIPTION
Cleanup of API client handling. Until now both `UpdateClient` and `AuthClient` created an instance of `http.Client` for requests. This has been replaced by a single instance of `ApiClient` interface kept by mender controller. `ApiClient` is limited to a single call `Do(*http.Request) (*http.Response, error)` that allows for using vanilla `http.Client` instance or one created by `NewApiClient()` helper call.

@kacf @pasinskim 