### PR TITLE
Setup authorization data for API requests

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type AuthCode string
+type AuthToken string
 
 type AuthReqData struct {
 	IdData      string `json:"id_data"`
@@ -34,8 +34,8 @@ type AuthReqData struct {
 type AuthRequest struct {
 	// request message data
 	Data []byte
-	// authorization code
-	Code AuthCode
+	// authorization token
+	Token AuthToken
 	// request signature
 	Signature []byte
 }
@@ -51,8 +51,8 @@ type AuthDataMessenger interface {
 type AuthManager interface {
 	// returns true if authorization data is current and valid
 	IsAuthorized() bool
-	// returns device's authoirization code
-	AuthCode() (AuthCode, error)
+	// returns device's authorization token
+	AuthToken() (AuthToken, error)
 	// check if device key is available
 	HasKey() bool
 	// generate device key (will overwrite an already existing key)
@@ -66,7 +66,7 @@ const (
 	authTenantTokenName = "authtentoken"
 	authSeqName         = "authseq"
 
-	noAuthCode = AuthCode("")
+	noAuthToken = AuthToken("")
 )
 
 type MenderAuthManager struct {
@@ -100,12 +100,12 @@ func NewAuthManager(store Store, keyName string, idSrc IdentityDataGetter) AuthM
 }
 
 func (m *MenderAuthManager) IsAuthorized() bool {
-	adata, err := m.AuthCode()
+	adata, err := m.AuthToken()
 	if err != nil {
 		return false
 	}
 
-	if adata == noAuthCode {
+	if adata == noAuthToken {
 		return false
 	}
 
@@ -168,7 +168,7 @@ func (m *MenderAuthManager) MakeAuthRequest() (*AuthRequest, error) {
 
 	return &AuthRequest{
 		Data:      reqdata,
-		Code:      AuthCode(tentok),
+		Token:     AuthToken(tentok),
 		Signature: sig,
 	}, nil
 }
@@ -184,16 +184,16 @@ func (m *MenderAuthManager) RecvAuthResponse(data []byte) error {
 	return nil
 }
 
-func (m *MenderAuthManager) AuthCode() (AuthCode, error) {
+func (m *MenderAuthManager) AuthToken() (AuthToken, error) {
 	data, err := m.store.ReadAll(authTokenName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return noAuthCode, nil
+			return noAuthToken, nil
 		}
-		return noAuthCode, errors.Wrapf(err, "failed to read auth token data")
+		return noAuthToken, errors.Wrapf(err, "failed to read auth token data")
 	}
 
-	return AuthCode(data), nil
+	return AuthToken(data), nil
 }
 
 func (m *MenderAuthManager) HasKey() bool {

--- a/auth_test.go
+++ b/auth_test.go
@@ -35,19 +35,19 @@ func TestAuthManager(t *testing.T) {
 
 	assert.False(t, am.IsAuthorized())
 
-	code, err := am.AuthCode()
-	assert.Equal(t, noAuthCode, code)
+	code, err := am.AuthToken()
+	assert.Equal(t, noAuthToken, code)
 	assert.NoError(t, err)
 
 	ms.WriteAll(authTokenName, []byte("footoken"))
 	// disable store access
 	ms.Disable(true)
-	code, err = am.AuthCode()
+	code, err = am.AuthToken()
 	assert.Error(t, err)
 	ms.Disable(false)
 
-	code, err = am.AuthCode()
-	assert.Equal(t, AuthCode("footoken"), code)
+	code, err = am.AuthToken()
+	assert.Equal(t, AuthToken("footoken"), code)
 	assert.NoError(t, err)
 }
 
@@ -87,7 +87,7 @@ func TestAuthManagerRequest(t *testing.T) {
 	req, err := am.MakeAuthRequest()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, req.Data)
-	assert.Equal(t, AuthCode("tenant"), req.Code)
+	assert.Equal(t, AuthToken("tenant"), req.Token)
 	assert.NotEmpty(t, req.Signature)
 
 	var ard AuthReqData

--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ type ApiClient struct {
 }
 
 // Return a new ApiRequest sharing this ApiClient helper
-func (a *ApiClient) Request(code AuthCode) *ApiRequest {
+func (a *ApiClient) Request(code AuthToken) *ApiRequest {
 	return &ApiRequest{
 		api:  a,
 		auth: code,
@@ -64,7 +64,7 @@ func (a *ApiClient) Request(code AuthCode) *ApiRequest {
 type ApiRequest struct {
 	api *ApiClient
 	// authorization code to use for requests
-	auth AuthCode
+	auth AuthToken
 }
 
 func (ar *ApiRequest) Do(req *http.Request) (*http.Response, error) {

--- a/client_auth.go
+++ b/client_auth.go
@@ -83,7 +83,7 @@ func makeAuthRequest(server string, dataSrc AuthDataMessenger) (*http.Request, e
 	}
 
 	hreq.Header.Add("Content-Type", "application/json")
-	hreq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", req.Code))
+	hreq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", req.Token))
 	hreq.Header.Add("X-MEN-Signature", base64.StdEncoding.EncodeToString(req.Signature))
 	return hreq, nil
 }

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -42,7 +42,7 @@ func (f *fakeAuthorizer) Request(api ApiRequester, url string, adm AuthDataMesse
 type testAuthDataMessenger struct {
 	reqData  []byte
 	sigData  []byte
-	code     AuthCode
+	code     AuthToken
 	reqError error
 	rspError error
 	rspData  []byte

--- a/mender.go
+++ b/mender.go
@@ -99,7 +99,7 @@ type mender struct {
 	forceBootstrap bool
 	authReq        AuthRequester
 	authMgr        AuthManager
-	api            ApiRequester
+	api            *ApiClient
 	authCode       AuthCode
 }
 
@@ -254,7 +254,7 @@ func (m *mender) doBootstrap() menderError {
 }
 
 func (m *mender) FetchUpdate(url string) (io.ReadCloser, int64, error) {
-	return m.updater.FetchUpdate(m.api, url)
+	return m.updater.FetchUpdate(m.api.Request(m.authCode), url)
 }
 
 // Check if new update is available. In case of errors, returns nil and error
@@ -266,7 +266,8 @@ func (m *mender) CheckUpdate() (*UpdateResponse, menderError) {
 	// 	return errors.New("")
 	// }
 
-	haveUpdate, err := m.updater.GetScheduledUpdate(m.api, m.config.ServerURL, m.config.DeviceID)
+	haveUpdate, err := m.updater.GetScheduledUpdate(m.api.Request(m.authCode),
+		m.config.ServerURL, m.config.DeviceID)
 	if err != nil {
 		log.Error("Error receiving scheduled update data: ", err)
 		return nil, NewTransientError(err)


### PR DESCRIPTION
Add authorization data to outgoing API requests. The series add an `ApiClient` helper with a convenience method `Request()` for creating request wrappers. Request wrapper `ApiRequest` implements `ApiRequester` interface and automatically append authorization data to the outgoing request if none is present.

Mender controller has been updated to cache authorization code so that we don't waste time/cycles for reloading it each time it's needed.

@pasinskim @kacf 