### PR TITLE
Status reporting

### DIFF
--- a/client_status.go
+++ b/client_status.go
@@ -1,0 +1,84 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	statusInstalling  = "installing"
+	statusDownloading = "downloading"
+	statusRebooting   = "rebooting"
+	statusSuccess     = "success"
+	statusFailure     = "failure"
+)
+
+type StatusReporter interface {
+	Report(api ApiRequester, server string, report StatusReport) error
+}
+
+type StatusReport struct {
+	deviceID     string
+	deploymentID string
+	Status       string `json:"status"`
+}
+
+type StatusClient struct {
+}
+
+func NewStatusClient() StatusReporter {
+	return &StatusClient{}
+}
+
+// Report status information to the backend
+func (u *StatusClient) Report(api ApiRequester, url string, report StatusReport) error {
+	req, err := makeStatusReportRequest(url, report)
+	if err != nil {
+		return errors.Wrapf(err, "failed to prepare status report request")
+	}
+
+	r, err := api.Do(req)
+	if err != nil {
+		log.Error("failed to report status: ", err)
+		return errors.Wrapf(err, "reporting status failed")
+	}
+
+	// HTTP 204 No Content
+	if r.StatusCode != http.StatusNoContent {
+		log.Errorf("got unexpected HTTP status when reporting status: %v", r.StatusCode)
+		return errors.Errorf("reporting status failed, bad status %v", r.StatusCode)
+	}
+	log.Debugf("status reported, response %v", r)
+
+	return nil
+}
+
+func makeStatusReportRequest(server string, report StatusReport) (*http.Request, error) {
+	path := fmt.Sprintf("/deployments/devices/%s/deployments/%s/status",
+		report.deviceID, report.deploymentID)
+	url := buildApiURL(server, path)
+
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder(out)
+	enc.Encode(&report)
+
+	return http.NewRequest(http.MethodPut, url, out)
+}

--- a/client_status_test.go
+++ b/client_status_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusClient(t *testing.T) {
+	responder := &struct {
+		httpStatus int
+		recdata    []byte
+		path       string
+	}{
+		http.StatusNoContent, // 204
+		[]byte{},
+		"",
+	}
+
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(responder.httpStatus)
+
+		responder.recdata, _ = ioutil.ReadAll(r.Body)
+		responder.path = r.URL.Path
+	}))
+	defer ts.Close()
+
+	ac, err := NewApiClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, ac)
+	assert.NoError(t, err)
+
+	client := StatusClient{}
+	assert.NotNil(t, client)
+
+	err = client.Report(ac, ts.URL, StatusReport{
+		deviceID:     "foodev",
+		deploymentID: "deployment1",
+		Status:       statusFailure,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, responder.recdata)
+	assert.JSONEq(t, `{"status": "failure"}`, string(responder.recdata))
+	assert.Equal(t, apiPrefix+"deployments/devices/foodev/deployments/deployment1/status", responder.path)
+
+	responder.httpStatus = 401
+	err = client.Report(ac, ts.URL, StatusReport{
+		deviceID:     "foodev",
+		deploymentID: "deployment1",
+		Status:       statusSuccess,
+	})
+	assert.Error(t, err)
+}

--- a/mender.go
+++ b/mender.go
@@ -86,6 +86,8 @@ const (
 	MenderStateReboot
 	// error
 	MenderStateError
+	// update error
+	MenderStateUpdateError
 	// exit state
 	MenderStateDone
 )

--- a/state.go
+++ b/state.go
@@ -179,7 +179,11 @@ func (uc *UpdateCommitState) Handle(c Controller) (State, bool) {
 
 	if merr := c.ReportUpdateStatus(uc.update, statusSuccess); merr != nil {
 		log.Errorf("failed to report success status: %v", err)
-		return NewUpdateErrorState(merr, uc.update), false
+		// TODO: until backend has implemented status reporting, this error cannot
+		// result in update being aborted. Once required API endpoint is available
+		// commend the line below and remove this comment.
+
+		// return NewUpdateErrorState(merr, uc.update), false
 	}
 
 	// done?

--- a/state_test.go
+++ b/state_test.go
@@ -290,7 +290,11 @@ func TestStateUpdateCommit(t *testing.T) {
 	s, c = cs.Handle(&stateTestController{
 		reportError: NewFatalError(errors.New("report failed")),
 	})
-	assert.IsType(t, s, &UpdateErrorState{})
+	// TODO: until backend has implemented status reporting, commit error cannot
+	// result in update being aborted. Once required API endpoint is available,
+	// the state should return an instance of UpdateErrorState
+	assert.IsType(t, s, &UpdateCheckWaitState{})
+	// assert.IsType(t, s, &UpdateErrorState{})
 	assert.False(t, c)
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -36,6 +36,9 @@ type stateTestController struct {
 	updateResp    *UpdateResponse
 	updateRespErr menderError
 	authorize     menderError
+	reportError   menderError
+	reportStatus  string
+	reportUpdate  UpdateResponse
 }
 
 func (s *stateTestController) Bootstrap() menderError {
@@ -72,6 +75,12 @@ func (s *stateTestController) SetState(state State) {
 
 func (s *stateTestController) Authorize() menderError {
 	return s.authorize
+}
+
+func (s *stateTestController) ReportUpdateStatus(update UpdateResponse, status string) menderError {
+	s.reportUpdate = update
+	s.reportStatus = status
+	return s.reportError
 }
 
 func TestStateBase(t *testing.T) {
@@ -139,6 +148,23 @@ func TestStateError(t *testing.T) {
 	assert.Contains(t, errstate.cause.Error(), "general error")
 }
 
+func TestStateUpdateError(t *testing.T) {
+
+	fooerr := NewTransientError(errors.New("foo"))
+
+	es := NewUpdateErrorState(fooerr, UpdateResponse{})
+	assert.Equal(t, MenderStateUpdateError, es.Id())
+	assert.IsType(t, &UpdateErrorState{}, es)
+	errstate, _ := es.(*UpdateErrorState)
+	assert.NotNil(t, errstate)
+	assert.Equal(t, fooerr, errstate.cause)
+
+	sc := &stateTestController{}
+	es = NewUpdateErrorState(fooerr, UpdateResponse{})
+	es.Handle(sc)
+	assert.Equal(t, statusFailure, sc.reportStatus)
+}
+
 func TestStateInit(t *testing.T) {
 	i := InitState{}
 
@@ -193,6 +219,7 @@ func TestStateAuthorized(t *testing.T) {
 	s, c = b.Handle(&stateTestController{
 		hasUpgrade: true,
 	})
+	// TODO verify that update information was restored
 	assert.IsType(t, &UpdateCommitState{}, s)
 	assert.False(t, c)
 
@@ -239,15 +266,17 @@ func TestStateAuthorizeWait(t *testing.T) {
 }
 
 func TestStateUpdateCommit(t *testing.T) {
-	cs := UpdateCommitState{}
+	cs := NewUpdateCommitState(UpdateResponse{})
 
 	var s State
 	var c bool
 
 	// commit without errors
-	s, c = cs.Handle(&stateTestController{})
+	sc := &stateTestController{}
+	s, c = cs.Handle(sc)
 	assert.IsType(t, &UpdateCheckWaitState{}, s)
 	assert.False(t, c)
+	assert.Equal(t, statusSuccess, sc.reportStatus)
 
 	s, c = cs.Handle(&stateTestController{
 		fakeDevice: fakeDevice{
@@ -255,6 +284,13 @@ func TestStateUpdateCommit(t *testing.T) {
 		},
 	})
 	assert.IsType(t, s, &ErrorState{})
+	assert.False(t, c)
+
+	// pretend device commit is success, but reporting failed
+	s, c = cs.Handle(&stateTestController{
+		reportError: NewFatalError(errors.New("report failed")),
+	})
+	assert.IsType(t, s, &UpdateErrorState{})
 	assert.False(t, c)
 }
 
@@ -320,13 +356,13 @@ func TestStateUpdateCheck(t *testing.T) {
 	assert.IsType(t, &UpdateFetchState{}, s)
 	assert.False(t, c)
 	ufs, _ := s.(*UpdateFetchState)
-	assert.Equal(t, update, ufs.update)
+	assert.Equal(t, *update, ufs.update)
 }
 
 func TestStateUpdateFetch(t *testing.T) {
 	// pretend we have an update
 	update := &UpdateResponse{}
-	cs := NewUpdateFetchState(update)
+	cs := NewUpdateFetchState(*update)
 
 	var s State
 	var c bool
@@ -337,20 +373,23 @@ func TestStateUpdateFetch(t *testing.T) {
 			fetchUpdateReturnError: NewTransientError(errors.New("fetch failed")),
 		},
 	})
-	assert.IsType(t, &ErrorState{}, s)
+	assert.IsType(t, &UpdateErrorState{}, s)
 	assert.False(t, c)
 
 	data := "test"
 	stream := ioutil.NopCloser(bytes.NewBufferString(data))
 
-	s, c = cs.Handle(&stateTestController{
+	sc := &stateTestController{
 		updater: fakeUpdater{
 			fetchUpdateReturnReadCloser: stream,
 			fetchUpdateReturnSize:       int64(len(data)),
 		},
-	})
+	}
+	s, c = cs.Handle(sc)
 	assert.IsType(t, &UpdateInstallState{}, s)
 	assert.False(t, c)
+	assert.Equal(t, statusDownloading, sc.reportStatus)
+
 	uis, _ := s.(*UpdateInstallState)
 	assert.Equal(t, stream, uis.imagein)
 	assert.Equal(t, int64(len(data)), uis.size)
@@ -360,7 +399,7 @@ func TestStateUpdateInstall(t *testing.T) {
 	data := "test"
 	stream := ioutil.NopCloser(bytes.NewBufferString(data))
 
-	uis := NewUpdateInstallState(stream, int64(len(data)))
+	uis := NewUpdateInstallState(stream, int64(len(data)), UpdateResponse{})
 
 	var s State
 	var c bool
@@ -371,7 +410,7 @@ func TestStateUpdateInstall(t *testing.T) {
 			retInstallUpdate: NewFatalError(errors.New("install failed")),
 		},
 	})
-	assert.IsType(t, &ErrorState{}, s)
+	assert.IsType(t, &UpdateErrorState{}, s)
 	assert.False(t, c)
 
 	s, c = uis.Handle(&stateTestController{
@@ -379,12 +418,14 @@ func TestStateUpdateInstall(t *testing.T) {
 			retEnablePart: NewFatalError(errors.New("enable failed")),
 		},
 	})
-	assert.IsType(t, &ErrorState{}, s)
+	assert.IsType(t, &UpdateErrorState{}, s)
 	assert.False(t, c)
 
-	s, c = uis.Handle(&stateTestController{})
+	sc := &stateTestController{}
+	s, c = uis.Handle(sc)
 	assert.IsType(t, &RebootState{}, s)
 	assert.False(t, c)
+	assert.Equal(t, statusInstalling, sc.reportStatus)
 }
 
 func TestStateReboot(t *testing.T) {
@@ -400,9 +441,11 @@ func TestStateReboot(t *testing.T) {
 	assert.IsType(t, &ErrorState{}, s)
 	assert.False(t, c)
 
-	s, c = rs.Handle(&stateTestController{})
+	sc := &stateTestController{}
+	s, c = rs.Handle(sc)
 	assert.IsType(t, &FinalState{}, s)
 	assert.False(t, c)
+	assert.Equal(t, statusRebooting, sc.reportStatus)
 }
 
 func TestStateFinal(t *testing.T) {


### PR DESCRIPTION
First take on status reporting.

Sending status over HTTP is captured in `StatusClient`, implemented in the first part of this series. Failure to send a status report results in an error that the caller is expected to handle in some way.

`Controller` interface got a new function `ReportStatusUpdate` that returns a `menderError` or nil.

The fun part is captured in state handling. Basically each 'update' state (commit, install, fetch, reboot) can transition to a new error state - `UpdateErrorState`. Also each of these states carries the update information. This is nice, because we don't need to keep it as part of Controller's internal state. Update information should be saved as soon as we decide to apply an update (ideally when update check returns valid update information) and restored right after (returned from?) `HasUpgrade()`.

@kacf @pasinskim 