### PR TITLE
Log upload

### DIFF
--- a/client_log.go
+++ b/client_log.go
@@ -1,0 +1,82 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type LogUploader interface {
+	Upload(api ApiRequester, server string, logs LogData) error
+}
+
+type LogEntry struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+}
+
+type LogData struct {
+	deviceID     string
+	deploymentID string
+	Messages     []LogEntry `json:"messages"`
+}
+
+type LogUploadClient struct {
+}
+
+func NewLogUploadClient() LogUploader {
+	return &LogUploadClient{}
+}
+
+// Report status information to the backend
+func (u *LogUploadClient) Upload(api ApiRequester, url string, logs LogData) error {
+	req, err := makeLogUploadRequest(url, &logs)
+	if err != nil {
+		return errors.Wrapf(err, "failed to prepare log upload request")
+	}
+
+	r, err := api.Do(req)
+	if err != nil {
+		log.Error("failed to upload logs: ", err)
+		return errors.Wrapf(err, "uploading logs failed")
+	}
+
+	// HTTP 204 No Content
+	if r.StatusCode != http.StatusNoContent {
+		log.Errorf("got unexpected HTTP status when uploading log: %v", r.StatusCode)
+		return errors.Errorf("uploading logs failed, bad status %v", r.StatusCode)
+	}
+	log.Debugf("logs uploaded, response %v", r)
+
+	return nil
+}
+
+func makeLogUploadRequest(server string, logs *LogData) (*http.Request, error) {
+	path := fmt.Sprintf("/deployments/devices/%s/deployments/%s/log",
+		logs.deviceID, logs.deploymentID)
+	url := buildApiURL(server, path)
+
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder(out)
+	enc.Encode(&logs)
+
+	return http.NewRequest(http.MethodPut, url, out)
+}

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -1,0 +1,89 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogUploadClient(t *testing.T) {
+	responder := &struct {
+		httpStatus int
+		recdata    []byte
+		path       string
+	}{
+		http.StatusNoContent, // 204
+		[]byte{},
+		"",
+	}
+
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(responder.httpStatus)
+
+		responder.recdata, _ = ioutil.ReadAll(r.Body)
+		responder.path = r.URL.Path
+	}))
+	defer ts.Close()
+
+	ac, err := NewApiClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+	)
+	assert.NotNil(t, ac)
+	assert.NoError(t, err)
+
+	client := LogUploadClient{}
+	assert.NotNil(t, client)
+
+	err = client.Upload(ac, ts.URL, LogData{
+		deviceID:     "foodev",
+		deploymentID: "deployment1",
+		Messages: []LogEntry{
+			LogEntry{"12:12:12", "error", "log foo"},
+			LogEntry{"12:12:13", "debug", "log bar"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, responder.recdata)
+	assert.JSONEq(t, `{
+    "messages": [
+        {
+            "timestamp": "12:12:12",
+            "level": "error",
+            "message": "log foo"
+        },
+        {
+            "timestamp": "12:12:13",
+            "level": "debug",
+            "message": "log bar"
+        }
+     ]}`, string(responder.recdata))
+	assert.Equal(t, apiPrefix+"deployments/devices/foodev/deployments/deployment1/log", responder.path)
+
+	responder.httpStatus = 401
+	err = client.Upload(ac, ts.URL, LogData{
+		deviceID:     "foodev",
+		deploymentID: "deployment1",
+		Messages: []LogEntry{
+			LogEntry{"12:12:12", "error", "log foo"},
+			LogEntry{"12:12:13", "debug", "log bar"},
+		},
+	})
+	assert.Error(t, err)
+}

--- a/state.go
+++ b/state.go
@@ -397,6 +397,16 @@ func NewUpdateErrorState(err menderError, update UpdateResponse) State {
 func (ue *UpdateErrorState) Handle(c Controller) (State, bool) {
 	// TODO error handling
 	c.ReportUpdateStatus(ue.update, statusFailure)
+
+	// TODO fetch logs from logger
+	c.UploadLog(ue.update, []LogEntry{
+		LogEntry{
+			Timestamp: time.Now().Format(time.RFC3339),
+			Level:     "error",
+			Message:   "update failed",
+		},
+	})
+
 	return initState, false
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -39,6 +39,8 @@ type stateTestController struct {
 	reportError   menderError
 	reportStatus  string
 	reportUpdate  UpdateResponse
+	logUpdate     UpdateResponse
+	logs          []LogEntry
 }
 
 func (s *stateTestController) Bootstrap() menderError {
@@ -80,6 +82,12 @@ func (s *stateTestController) Authorize() menderError {
 func (s *stateTestController) ReportUpdateStatus(update UpdateResponse, status string) menderError {
 	s.reportUpdate = update
 	s.reportStatus = status
+	return s.reportError
+}
+
+func (s *stateTestController) UploadLog(update UpdateResponse, logs []LogEntry) menderError {
+	s.logUpdate = update
+	s.logs = logs
 	return s.reportError
 }
 
@@ -163,6 +171,7 @@ func TestStateUpdateError(t *testing.T) {
 	es = NewUpdateErrorState(fooerr, UpdateResponse{})
 	es.Handle(sc)
 	assert.Equal(t, statusFailure, sc.reportStatus)
+	assert.NotEmpty(t, sc.logs)
 }
 
 func TestStateInit(t *testing.T) {


### PR DESCRIPTION
A series of patches that adds support for uploading logs in case of update failure. For now there's a single 'update failed' log being reported.

@kacf @pasinskim 