### PR TITLE
Preserve state data across reboots

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -20,12 +20,16 @@ import "github.com/pkg/errors"
 type menderDaemon struct {
 	mender Controller
 	stop   bool
+	sctx   StateContext
 }
 
-func NewDaemon(mender Controller) *menderDaemon {
+func NewDaemon(mender Controller, store Store) *menderDaemon {
 
 	daemon := menderDaemon{
 		mender: mender,
+		sctx: StateContext{
+			store: store,
+		},
 	}
 	return &daemon
 }
@@ -41,7 +45,7 @@ func (d *menderDaemon) shouldStop() bool {
 func (d *menderDaemon) Run() error {
 	// figure out the state
 	for {
-		state, cancelled := d.mender.GetState().Handle(d.mender)
+		state, cancelled := d.mender.RunState(&d.sctx)
 		if state.Id() == MenderStateError {
 			es, ok := state.(*ErrorState)
 			if ok {

--- a/dirstore.go
+++ b/dirstore.go
@@ -123,3 +123,7 @@ func (d DirStore) CommitFile(name string) error {
 func (df DirFile) Commit() error {
 	return df.dirstore.CommitFile(df.name)
 }
+
+func (d DirStore) Remove(name string) error {
+	return os.Remove(d.getPath(name))
+}

--- a/dirstore_test.go
+++ b/dirstore_test.go
@@ -94,4 +94,11 @@ func TestDirStore(t *testing.T) {
 	out.Commit()
 	assert.False(t, pathExists(d.getTempPath("bar")))
 	assert.True(t, pathExists(d.getPath("bar")))
+
+	err = d.Remove("bar")
+	assert.NoError(t, err)
+	assert.False(t, pathExists(d.getPath("bar")))
+
+	err = d.Remove("foobar")
+	assert.True(t, os.IsNotExist(err))
 }

--- a/main.go
+++ b/main.go
@@ -312,7 +312,7 @@ func initDaemon(config *menderConfig, dev *device, env *uBootEnv,
 		controller.ForceBootstrap()
 	}
 
-	daemon := NewDaemon(controller)
+	daemon := NewDaemon(controller, store)
 	return daemon, nil
 }
 

--- a/mender.go
+++ b/mender.go
@@ -313,3 +313,7 @@ func (m *mender) SetState(s State) {
 func (m *mender) GetState() State {
 	return m.state
 }
+
+func (m *mender) RunState(ctx *StateContext) (State, bool) {
+	return m.state.Handle(ctx, m)
+}

--- a/store.go
+++ b/store.go
@@ -39,4 +39,6 @@ type Store interface {
 	// writing data, once finished, one should call Commit() from
 	// WriteCloserCommitter interface
 	OpenWrite(name string) (WriteCloserCommitter, error)
+	// remove an entry
+	Remove(name string) error
 }

--- a/store_test.go
+++ b/store_test.go
@@ -111,8 +111,9 @@ func (ms *MemStore) Commit(name string, data []byte) error {
 	return nil
 }
 
-func (ms *MemStore) Remove(name string) {
+func (ms *MemStore) Remove(name string) error {
 	delete(ms.data, name)
+	return nil
 }
 
 func (ms *MemStore) ReadOnly(ro bool) {


### PR DESCRIPTION
A proposal of a method for preserving state information across reboots. Update related actions such as reporting of log upload require information on the update that is applied. Since update will normally involve a reboot at some point, we need to capture and preserve update information across reboots, so that it's possible to report update progress after the system was restarted.

The series adds a new entry called `state` to client data store. The `state` file contains JSON serialized `StateData` structure, that captures both the update response and the last state ID. State data is stored when entering a state handler. Loading happens only when entering `UpdateCommitState`. The state entry is removed after an update has been committed.

There are still some open questions about what to do where a reboot happens mid update. For instance, when update is being installed. I expect that the state ID field will come in useful here. Since state data also captures the download URL, we should be able to resume from say, `UpdateFetchState` when needed. Anyways, I expect this to be a starting point for a longer discussion.