### PR TITLE
mender: handle empty check update response

### DIFF
--- a/device.go
+++ b/device.go
@@ -14,13 +14,13 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 
 	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
 )
 
 type UInstaller interface {
@@ -88,8 +88,8 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		}
 		return nil
 	}
-	return errors.New("Can not install image to partition. " +
-		"Size of inactive partition is smaller than image size")
+	return errors.Errorf("inactive partition %s too small, partition: %v image %v",
+		inactivePartition, partitionSize, size)
 }
 
 func (d *device) EnableUpdatedPartition() error {

--- a/mender.go
+++ b/mender.go
@@ -260,12 +260,16 @@ func (m *mender) CheckUpdate() (*UpdateResponse, menderError) {
 		return nil, NewTransientError(err)
 	}
 
-	log.Debug("Received correct response for update request.")
-
+	if haveUpdate == nil {
+		log.Debug("no updates available")
+		return nil, nil
+	}
 	update, ok := haveUpdate.(UpdateResponse)
 	if !ok {
 		return nil, NewTransientError(errors.Errorf("not an update response?"))
 	}
+
+	log.Debugf("received update response: %v", update)
 
 	if update.Image.YoctoID == currentImageID {
 		return nil, nil

--- a/mender_test.go
+++ b/mender_test.go
@@ -268,6 +268,12 @@ func Test_CheckUpdateSimple(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, up)
 
+	// pretend that we got 204 No Content from the server, i.e empty response body
+	updaterIface.GetScheduledUpdateReturnIface = nil
+	up, err = mender.CheckUpdate()
+	assert.NoError(t, err)
+	assert.Nil(t, up)
+
 	// make image ID different from current
 	update.Image.YoctoID = currID + "-fake"
 	updaterIface.GetScheduledUpdateReturnIface = update


### PR DESCRIPTION
Interpret empty check update response as no update avaialble.