### PR TITLE
Allow for skipping SSL certificate validation

### DIFF
--- a/client.go
+++ b/client.go
@@ -108,10 +108,15 @@ func newHttpsClient(conf httpsClientConfig) (*http.Client, error) {
 		return nil, errors.Wrapf(err, "can not load client certificate")
 	}
 
+	if conf.noVerify {
+		log.Warnf("certificate verification skipped..")
+	}
+	tlsc := tls.Config{
+		RootCAs:            trustedcerts,
+		InsecureSkipVerify: conf.noVerify,
+	}
 	transport := http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs: trustedcerts,
-		},
+		TLSClientConfig: &tlsc,
 	}
 
 	if clientcerts != nil {
@@ -129,6 +134,7 @@ type httpsClientConfig struct {
 	certKey    string
 	serverCert string
 	isHttps    bool
+	noVerify   bool
 }
 
 func loadServerTrust(conf httpsClientConfig) (*x509.CertPool, error) {

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -112,7 +112,7 @@ func TestClientAuth(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -43,7 +43,7 @@ func TestLogUploadClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client_status_test.go
+++ b/client_status_test.go
@@ -43,7 +43,7 @@ func TestStatusClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestHttpClient(t *testing.T) {
 	cl, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, cl)
 
@@ -33,7 +33,7 @@ func TestHttpClient(t *testing.T) {
 
 	// incomplete config should yield an error
 	cl, err = NewApiClient(
-		httpsClientConfig{"foobar", "client.key", "", true},
+		httpsClientConfig{"foobar", "client.key", "", true, false},
 	)
 	assert.Nil(t, cl)
 	assert.NotNil(t, err)
@@ -41,7 +41,7 @@ func TestHttpClient(t *testing.T) {
 
 func TestApiClientRequest(t *testing.T) {
 	cl, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, cl)
 

--- a/client_update_test.go
+++ b/client_update_test.go
@@ -128,7 +128,7 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -153,7 +153,7 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -177,7 +177,7 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -203,7 +203,7 @@ func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -226,7 +226,7 @@ func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -249,7 +249,7 @@ func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true},
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type menderConfig struct {
 	HttpsClient    struct {
 		Certificate string
 		Key         string
+		SkipVerify  bool
 	}
 	RootfsPartA         string
 	RootfsPartB         string
@@ -75,10 +76,11 @@ func readConfigFile(config interface{}, fileName string) error {
 
 func (c menderConfig) GetHttpConfig() httpsClientConfig {
 	return httpsClientConfig{
-		c.HttpsClient.Certificate,
-		c.HttpsClient.Key,
-		c.ServerCertificate,
-		c.ClientProtocol == "https",
+		certFile:   c.HttpsClient.Certificate,
+		certKey:    c.HttpsClient.Key,
+		serverCert: c.ServerCertificate,
+		isHttps:    c.ClientProtocol == "https",
+		noVerify:   c.HttpsClient.SkipVerify,
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -92,9 +92,11 @@ func validateConfiguration(t *testing.T, actual *menderConfig) {
 		HttpsClient: struct {
 			Certificate string
 			Key         string
+			SkipVerify  bool
 		}{
 			Certificate: "/data/client.crt",
 			Key:         "/data/client.key",
+			SkipVerify:  false,
 		},
 		RootfsPartA:         "/dev/mmcblk0p2",
 		RootfsPartB:         "/dev/mmcblk0p3",

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func argsParse(args []string) (runOptionsType, error) {
 	certKey := parsing.String("cert-key", "", "Client certificate's private key")
 	serverCert := parsing.String("trusted-certs", "", "Trusted server certificates")
 	forcebootstrap := parsing.Bool("forcebootstrap", false, "Force bootstrap")
+	skipVerify := parsing.Bool("skipverify", false, "Skip certificate verification")
 
 	// add log related command line options
 	logFlags := addLogFlags(parsing)
@@ -128,10 +129,11 @@ func argsParse(args []string) (runOptionsType, error) {
 		daemon:         daemon,
 		bootstrapForce: forcebootstrap,
 		httpsClientConfig: httpsClientConfig{
-			*certFile,
-			*certKey,
-			*serverCert,
-			false,
+			certFile:   *certFile,
+			certKey:    *certKey,
+			serverCert: *serverCert,
+			isHttps:    false,
+			noVerify:   *skipVerify,
 		},
 	}
 
@@ -337,6 +339,10 @@ func doMain(args []string) error {
 	config, err := LoadConfig(*runOptions.config)
 	if err != nil {
 		return err
+	}
+
+	if runOptions.httpsClientConfig.noVerify {
+		config.HttpsClient.SkipVerify = true
 	}
 
 	env := NewEnvironment(new(osCalls))

--- a/rootfs_test.go
+++ b/rootfs_test.go
@@ -65,7 +65,7 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 	fakeRunOptions.imageFile = &imageFileName
 
 	fakeRunOptions.httpsClientConfig =
-		httpsClientConfig{"client.crt", "client.key", "server.crt", true}
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false}
 
 	if err := doRootfs(&fakeDevice, fakeRunOptions); err == nil {
 		t.FailNow()


### PR DESCRIPTION
It might be useful to skip SSL certificate validation when troubleshooting integration issues.

@kacf @pasinskim 