### PR TITLE
Deployments API changes & Device ID

### DIFF
--- a/client_update.go
+++ b/client_update.go
@@ -28,7 +28,7 @@ const (
 )
 
 type Updater interface {
-	GetScheduledUpdate(api ApiRequester, server string, deviceID string) (interface{}, error)
+	GetScheduledUpdate(api ApiRequester, server string) (interface{}, error)
 	FetchUpdate(api ApiRequester, url string) (io.ReadCloser, int64, error)
 }
 
@@ -43,13 +43,13 @@ func NewUpdateClient() *UpdateClient {
 	return &up
 }
 
-func (u *UpdateClient) GetScheduledUpdate(api ApiRequester, server string, deviceID string) (interface{}, error) {
-	return u.getUpdateInfo(api, processUpdateResponse, server, deviceID)
+func (u *UpdateClient) GetScheduledUpdate(api ApiRequester, server string) (interface{}, error) {
+	return u.getUpdateInfo(api, processUpdateResponse, server)
 }
 
-func (u *UpdateClient) getUpdateInfo(api ApiRequester, process RequestProcessingFunc, server string,
-	deviceID string) (interface{}, error) {
-	req, err := makeUpdateCheckRequest(server, deviceID)
+func (u *UpdateClient) getUpdateInfo(api ApiRequester, process RequestProcessingFunc,
+	server string) (interface{}, error) {
+	req, err := makeUpdateCheckRequest(server)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create update check request")
 	}
@@ -158,8 +158,8 @@ func processUpdateResponse(response *http.Response) (interface{}, error) {
 	}
 }
 
-func makeUpdateCheckRequest(server, deviceID string) (*http.Request, error) {
-	url := buildApiURL(server, "/deployments/devices/"+deviceID+"/update")
+func makeUpdateCheckRequest(server string) (*http.Request, error) {
+	url := buildApiURL(server, "/deployments/device/update")
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/client_update_test.go
+++ b/client_update_test.go
@@ -138,7 +138,7 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, errors.New("") }
 
-	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL)
 	assert.Error(t, err)
 }
 
@@ -162,7 +162,7 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	assert.NotNil(t, client)
 	fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, nil }
 
-	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL, "")
+	_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL)
 	assert.NoError(t, err)
 }
 
@@ -185,7 +185,7 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	client := NewUpdateClient()
 	assert.NotNil(t, client)
 
-	data, err := client.GetScheduledUpdate(ac, ts.URL, "")
+	data, err := client.GetScheduledUpdate(ac, ts.URL)
 	assert.NoError(t, err)
 	update, ok := data.(UpdateResponse)
 	assert.True(t, ok)

--- a/config.go
+++ b/config.go
@@ -24,7 +24,6 @@ import (
 type menderConfig struct {
 	ClientProtocol string
 	DeviceKey      string
-	DeviceID       string
 	HttpsClient    struct {
 		Certificate string
 		Key         string

--- a/config_test.go
+++ b/config_test.go
@@ -31,7 +31,6 @@ var testConfig = `{
   "RootfsPartB": "/dev/mmcblk0p3",
   "PollIntervalSeconds": 60,
   "ServerURL": "mender.io",
-  "DeviceID": "1234-ABCD",
   "ServerCertificate": "/var/lib/mender/server.crt",
   "UpdateLogPath": "/var/lib/mender/log/deployment.log"
 }`
@@ -47,7 +46,6 @@ var testConfigDevKey = `{
   "RootfsPartB": "/dev/mmcblk0p3",
   "PollIntervalSeconds": 60,
   "ServerURL": "mender.io",
-  "DeviceID": "1234-ABCD",
 	"ServerCertificate": "/var/lib/mender/server.crt",
   "UpdateLogPath": "/var/lib/mender/log/deployment.log"
 }`
@@ -62,7 +60,6 @@ var testBrokenConfig = `{
   "RootfsPartB": "/dev/mmcblk0p3",
   "PollIntervalSeconds": 60,
   "ServerURL": "mender
-  "DeviceID": "1234-ABCD",
 	"ServerCertificate": "/var/lib/mender/server.crt"
 }`
 
@@ -87,7 +84,6 @@ func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
 func validateConfiguration(t *testing.T, actual *menderConfig) {
 	expectedConfig := menderConfig{
 		ClientProtocol: "https",
-		DeviceID:       "1234-ABCD",
 		DeviceKey:      defaultKeyFile,
 		HttpsClient: struct {
 			Certificate string

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -53,7 +53,7 @@ type fakeUpdater struct {
 	fetchUpdateReturnError        error
 }
 
-func (f fakeUpdater) GetScheduledUpdate(api ApiRequester, url string, device string) (interface{}, error) {
+func (f fakeUpdater) GetScheduledUpdate(api ApiRequester, url string) (interface{}, error) {
 	return f.GetScheduledUpdateReturnIface, f.GetScheduledUpdateReturnError
 }
 func (f fakeUpdater) FetchUpdate(api ApiRequester, url string) (io.ReadCloser, int64, error) {

--- a/mender-default-test.conf
+++ b/mender-default-test.conf
@@ -1,6 +1,5 @@
 {
   "ClientProtocol": "https",
-  "DeviceID": "DEVICE_ID",
   "HttpsClient": {
     "Certificate": "",
     "Key": ""

--- a/mender.conf.example
+++ b/mender.conf.example
@@ -1,6 +1,5 @@
 {
   "ClientProtocol": "http",
-  "DeviceID": "ABCD-1234",
   "HttpsClient": {
     "Certificate": "",
     "Key": ""

--- a/mender.go
+++ b/mender.go
@@ -256,7 +256,7 @@ func (m *mender) CheckUpdate() (*UpdateResponse, menderError) {
 	// }
 
 	haveUpdate, err := m.updater.GetScheduledUpdate(m.api.Request(m.authToken),
-		m.config.ServerURL, m.config.DeviceID)
+		m.config.ServerURL)
 	if err != nil {
 		log.Error("Error receiving scheduled update data: ", err)
 		return nil, NewTransientError(err)


### PR DESCRIPTION
Small patch series that updates the API endpoints of deployments service. 

Also, Device ID is no longer needed as we no longer need to explicitly pass it in any outgoing request. The series addresses this by removing `DeviceID` from configuration.

@kacf