### PR TITLE
No device & URLs update

### DIFF
--- a/client_log.go
+++ b/client_log.go
@@ -62,7 +62,7 @@ func (u *LogUploadClient) Upload(api ApiRequester, url string, logs LogData) err
 }
 
 func makeLogUploadRequest(server string, logs *LogData) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/devices/deployments/%s/log",
+	path := fmt.Sprintf("/deployments/device/deployments/%s/log",
 		logs.deploymentID)
 	url := buildApiURL(server, path)
 

--- a/client_log.go
+++ b/client_log.go
@@ -27,7 +27,6 @@ type LogUploader interface {
 }
 
 type LogData struct {
-	deviceID     string
 	deploymentID string
 	Messages     []byte `json:"messages"`
 }
@@ -63,8 +62,8 @@ func (u *LogUploadClient) Upload(api ApiRequester, url string, logs LogData) err
 }
 
 func makeLogUploadRequest(server string, logs *LogData) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/devices/%s/deployments/%s/log",
-		logs.deviceID, logs.deploymentID)
+	path := fmt.Sprintf("/deployments/devices/deployments/%s/log",
+		logs.deploymentID)
 	url := buildApiURL(server, path)
 
 	return http.NewRequest(http.MethodPut, url, bytes.NewReader(logs.Messages))

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -52,7 +52,6 @@ func TestLogUploadClient(t *testing.T) {
 	assert.NotNil(t, client)
 
 	err = client.Upload(ac, ts.URL, LogData{
-		deviceID:     "foodev",
 		deploymentID: "deployment1",
 		Messages: []byte(`{ "messages":
 [{ "time": "12:12:12", "level": "error", "msg": "log foo" },
@@ -74,11 +73,10 @@ func TestLogUploadClient(t *testing.T) {
 	          "msg": "log bar"
 	      }
 	   ]}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/devices/foodev/deployments/deployment1/log", responder.path)
+	assert.Equal(t, apiPrefix+"deployments/devices/deployments/deployment1/log", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Upload(ac, ts.URL, LogData{
-		deviceID:     "foodev",
 		deploymentID: "deployment1",
 		Messages: []byte(`[{ "time": "12:12:12", "level": "error", "msg": "log foo" },
 { "time": "12:12:13", "level": "debug", "msg": "log bar" }]`),

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -73,7 +73,7 @@ func TestLogUploadClient(t *testing.T) {
 	          "msg": "log bar"
 	      }
 	   ]}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/devices/deployments/deployment1/log", responder.path)
+	assert.Equal(t, apiPrefix+"deployments/device/deployments/deployment1/log", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Upload(ac, ts.URL, LogData{

--- a/client_status.go
+++ b/client_status.go
@@ -36,7 +36,6 @@ type StatusReporter interface {
 }
 
 type StatusReport struct {
-	deviceID     string
 	deploymentID string
 	Status       string `json:"status"`
 }
@@ -72,8 +71,8 @@ func (u *StatusClient) Report(api ApiRequester, url string, report StatusReport)
 }
 
 func makeStatusReportRequest(server string, report StatusReport) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/devices/%s/deployments/%s/status",
-		report.deviceID, report.deploymentID)
+	path := fmt.Sprintf("/deployments/devices/deployments/%s/status",
+		report.deploymentID)
 	url := buildApiURL(server, path)
 
 	out := &bytes.Buffer{}

--- a/client_status.go
+++ b/client_status.go
@@ -71,7 +71,7 @@ func (u *StatusClient) Report(api ApiRequester, url string, report StatusReport)
 }
 
 func makeStatusReportRequest(server string, report StatusReport) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/devices/deployments/%s/status",
+	path := fmt.Sprintf("/deployments/device/deployments/%s/status",
 		report.deploymentID)
 	url := buildApiURL(server, path)
 

--- a/client_status_test.go
+++ b/client_status_test.go
@@ -58,7 +58,7 @@ func TestStatusClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, responder.recdata)
 	assert.JSONEq(t, `{"status": "failure"}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/devices/deployments/deployment1/status", responder.path)
+	assert.Equal(t, apiPrefix+"deployments/device/deployments/deployment1/status", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Report(ac, ts.URL, StatusReport{

--- a/client_status_test.go
+++ b/client_status_test.go
@@ -52,18 +52,16 @@ func TestStatusClient(t *testing.T) {
 	assert.NotNil(t, client)
 
 	err = client.Report(ac, ts.URL, StatusReport{
-		deviceID:     "foodev",
 		deploymentID: "deployment1",
 		Status:       statusFailure,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, responder.recdata)
 	assert.JSONEq(t, `{"status": "failure"}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/devices/foodev/deployments/deployment1/status", responder.path)
+	assert.Equal(t, apiPrefix+"deployments/devices/deployments/deployment1/status", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Report(ac, ts.URL, StatusReport{
-		deviceID:     "foodev",
 		deploymentID: "deployment1",
 		Status:       statusSuccess,
 	})


### PR DESCRIPTION
Last part of device ID cleanups. Patches 1 and 2 remove device ID from URLs and structures that are passed to the code making an actual API request. The changes are harmless, as device ID was never really passed form mender controller.

The last 2 patches address URL changes in deployments API.

@pasinskim @kacf @GregorioDiStefano 