### PR TITLE
Remove printing message to stdout.

### DIFF
--- a/deployment_logger.go
+++ b/deployment_logger.go
@@ -179,7 +179,6 @@ func (dlm DeploymentLogManager) Rotate() {
 
 	// check if last file is the one with the current deployment ID
 	if strings.Contains(logFiles[0], dlm.deploymentID) {
-		fmt.Printf("do not rotate: [%v]", dlm.deploymentID)
 		return
 	}
 


### PR DESCRIPTION
This was left by accident while merging client logging.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>