### PR TITLE
Make sure that deployment logs are formatted correctly.

### DIFF
--- a/deployment_logger_test.go
+++ b/deployment_logger_test.go
@@ -225,7 +225,8 @@ func TestDeploymentLoggingHook(t *testing.T) {
 
 	log.Info("test3")
 
-	if !logFileContains(fileLocation, `{"level":"info","msg":"test2","time":"`) {
+	// test correct format of log messages
+	if !logFileContains(fileLocation, `{"level":"info","message":"test2","timestamp":"`) {
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
At the moment server endpoint requires JSON log format as follows:
{"level":"info", "message":"log", "timestamp":"2016-08-09T12:03:53Z"}

We are adding new custom log formatter to make sure that logs are
formatted as expected by the server.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>