### PR TITLE
Check if there is enough disk space for logs before starting update.

### DIFF
--- a/deployment_logger_test.go
+++ b/deployment_logger_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path"
 	"strings"
@@ -236,6 +237,20 @@ func TestLogManagerLogRotation(t *testing.T) {
 		t.FailNow()
 	}
 	logManager.Disable()
+}
+
+func TestEnabligLogsNoSpceForStoringLogs(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("", "logs")
+	defer os.RemoveAll(tempDir)
+
+	logManager := NewDeploymentLogManager(tempDir)
+	// hope we don't have that much space...
+	logManager.minLogSizeBytes = math.MaxUint64
+
+	if err := logManager.Enable("1111-2222"); err != ErrNotEnoughSpaceForLogs {
+		t.FailNow()
+	}
+
 }
 
 func TestDeploymentLoggingHook(t *testing.T) {

--- a/deployment_logger_test.go
+++ b/deployment_logger_test.go
@@ -152,10 +152,10 @@ func TestLogManagerCheckLogging(t *testing.T) {
 	}
 }
 
-func createFilesToRotate(num int) []string {
+func createFilesToRotate(location string, num int) []string {
 	fileNames := make([]string, num)
 	for i := 1; i <= num; i++ {
-		name := fmt.Sprintf(logFileNameScheme, i, "1111-2222")
+		name := path.Join(location, fmt.Sprintf(logFileNameScheme, i, "1111-2222"))
 		fileNames = append(fileNames, name)
 		os.Create(name)
 	}
@@ -169,23 +169,27 @@ func removeLogFiles(names []string) {
 }
 
 func TestLogManagerLogRotation(t *testing.T) {
-	// create files with indexes from .0001 to .0010
-	files := createFilesToRotate(10)
-	defer removeLogFiles(files)
+	tempDir, _ := ioutil.TempDir("", "logs")
+	defer os.RemoveAll(tempDir)
 
-	logManager := NewDeploymentLogManager(".")
+	filesToCreate := 10
+
+	// create files with indexes from .0001 to .0010
+	createFilesToRotate(tempDir, filesToCreate)
+
+	// add some content to the first file
+	logFileWithContent := path.Join(tempDir, fmt.Sprintf(logFileNameScheme, 1, "1111-2222"))
+	logContent := `{"msg":"test"}`
+	if err := openLogFileWithContent(logFileWithContent, logContent); err != nil {
+		t.FailNow()
+	}
+
+	logManager := NewDeploymentLogManager(tempDir)
 	logManager.deploymentID = "1111-2222"
 
 	logFiles, err := logManager.getSortedLogFiles()
-	if len(logFiles) != 10 || err != nil {
-		t.Fatalf("have files: [%v]\n", logFiles)
-	}
-
-	// add some content to the first file
-	logFileWithContent := fmt.Sprintf(logFileNameScheme, 1, "1111-2222")
-	logContent := `{"msg":"test"}`
-	if err = openLogFileWithContent(logFileWithContent, logContent); err != nil {
-		t.FailNow()
+	if len(logFiles) != filesToCreate || err != nil {
+		t.Fatalf("expected to have %v files; have files: [%v]\n", filesToCreate, logFiles)
 	}
 
 	// do log rotation
@@ -193,18 +197,45 @@ func TestLogManagerLogRotation(t *testing.T) {
 
 	logFiles, err = logManager.getSortedLogFiles()
 	if len(logFiles) != logManager.maxLogFiles || err != nil {
-		t.FailNow()
+		t.Fatalf("too many files left after rotating; expecting: %v (actual: %v)",
+			logManager.maxLogFiles, len(logFiles))
+	}
+
+	// test logging with the same deployment id; should not rotate files
+	logManager.Enable("1111-2222")
+	logFiles, err = logManager.getSortedLogFiles()
+	if len(logFiles) != logManager.maxLogFiles || err != nil {
+		t.Fatalf("should not rotate files as the deployment id did not change")
+	}
+	if path.Base(logFiles[len(logFiles)-1]) != fmt.Sprintf(logFileNameScheme, 1, "1111-2222") {
+		t.Fatalf("invalid name for the last log file; expecting %v (actual: %v)",
+			fmt.Sprintf(logFileNameScheme, 1, "1111-2222"),
+			path.Base(logFiles[len(logFiles)-1]))
 	}
 
 	// should not be rotated as deployment ID is the same as the first file
-	logFileWithContent = fmt.Sprintf(logFileNameScheme, 1, "1111-2222")
 	if !logFileContains(logFileWithContent, logContent) {
 		t.FailNow()
 	}
 
-	if logFiles[0] != fmt.Sprintf(logFileNameScheme, 5, "1111-2222") {
+	logManager.Disable()
+
+	// continue logging with different deployment id; should rotate log files
+	logManager.Enable("2222-3333")
+	logFiles, err = logManager.getSortedLogFiles()
+	if len(logFiles) != logManager.maxLogFiles || err != nil {
+		t.Fatalf("should rotate files as the deployment id changed: %v", logFiles)
+	}
+	if path.Base(logFiles[len(logFiles)-1]) != fmt.Sprintf(logFileNameScheme, 1, "2222-3333") {
+		t.Fatalf("expecting: %v; actual: %v [%v]",
+			fmt.Sprintf(logFileNameScheme, 1, "2222-3333"), logFiles[len(logFiles)-1], logFiles)
+	}
+	// should not be rotated as deployment ID is the same as the first file
+	logFileWithContent = path.Join(tempDir, fmt.Sprintf(logFileNameScheme, 2, "1111-2222"))
+	if !logFileContains(logFileWithContent, logContent) {
 		t.FailNow()
 	}
+	logManager.Disable()
 }
 
 func TestDeploymentLoggingHook(t *testing.T) {

--- a/state.go
+++ b/state.go
@@ -303,7 +303,9 @@ func NewUpdateCommitState(update UpdateResponse) State {
 func (uc *UpdateCommitState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	// start deployment logging
-	DeploymentLogger.Enable(uc.update.ID)
+	if err := DeploymentLogger.Enable(uc.update.ID); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), uc.update), false
+	}
 
 	log.Debugf("handle update commit state")
 	err := c.CommitUpdate()
@@ -354,7 +356,9 @@ func NewUpdateFetchState(update UpdateResponse) State {
 func (u *UpdateFetchState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	// start logging as we are having new update to be installed
-	DeploymentLogger.Enable(u.update.ID)
+	if err := DeploymentLogger.Enable(u.update.ID); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), u.update), false
+	}
 
 	if err := StoreStateData(ctx.store, StateData{
 		Id:         u.Id(),
@@ -403,7 +407,9 @@ func (u *UpdateInstallState) Handle(ctx *StateContext, c Controller) (State, boo
 	defer u.imagein.Close()
 
 	// start deployment logging
-	DeploymentLogger.Enable(u.update.ID)
+	if err := DeploymentLogger.Enable(u.update.ID); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), u.update), false
+	}
 
 	if err := StoreStateData(ctx.store, StateData{
 		Id:         u.Id(),
@@ -417,6 +423,7 @@ func (u *UpdateInstallState) Handle(ctx *StateContext, c Controller) (State, boo
 	c.ReportUpdateStatus(u.update, statusInstalling)
 
 	log.Debugf("handle update install state")
+
 	if err := c.InstallUpdate(u.imagein, u.size); err != nil {
 		log.Errorf("update install failed: %s", err)
 		return NewUpdateErrorState(NewTransientError(err), u.update), false
@@ -528,7 +535,9 @@ func (a *AuthorizedState) Handle(ctx *StateContext, c Controller) (State, bool) 
 
 	if has {
 		// start logging as we might need to store some error logs
-		DeploymentLogger.Enable(sd.UpdateInfo.ID)
+		if err := DeploymentLogger.Enable(sd.UpdateInfo.ID); err != nil {
+			return NewUpdateErrorState(NewTransientError(err), sd.UpdateInfo), false
+		}
 
 		if sd.UpdateInfo.Image.YoctoID == c.GetCurrentImageID() {
 			log.Infof("successfully running with new image %v", c.GetCurrentImageID())
@@ -652,7 +661,9 @@ func (usr *UpdateStatusReportState) sendDeploymentLogs(c Controller) bool {
 func (usr *UpdateStatusReportState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	// start deployment logging
-	DeploymentLogger.Enable(usr.update.ID)
+	if err := DeploymentLogger.Enable(usr.update.ID); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), usr.update), false
+	}
 
 	if err := StoreStateData(ctx.store, StateData{
 		Id:           usr.Id(),
@@ -746,7 +757,9 @@ func NewRebootState(update UpdateResponse) State {
 func (e *RebootState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	// start deployment logging
-	DeploymentLogger.Enable(e.update.ID)
+	if err := DeploymentLogger.Enable(e.update.ID); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), e.update), false
+	}
 
 	if err := StoreStateData(ctx.store, StateData{
 		Id:         e.Id(),


### PR DESCRIPTION
If there is not enough space for storing deployment logs we need
to invalidate the update.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>