### PR TITLE
Make sure to report failed update after rebooting with broken image.

### DIFF
--- a/state.go
+++ b/state.go
@@ -548,14 +548,10 @@ func (a *AuthorizedState) Handle(ctx *StateContext, c Controller) (State, bool) 
 	}
 
 	// we have upgrade info but has flag is not set
+	// most probably last update failed
 	log.Infof("update info for deployment %v present, but update flag is not set",
 		sd.UpdateInfo.ID)
-
-	// starting from scratch
-	log.Debugf("starting from scratch")
-	RemoveStateData(ctx.store)
-
-	return updateCheckWaitState, false
+	return NewUpdateErrorState(NewTransientError(err), sd.UpdateInfo), false
 }
 
 type ErrorState struct {


### PR DESCRIPTION
If we are installing broken image device is rebooted reaching
`we have upgrade info but has flag is not set` point.
Here we are sending no information to the server that last update was
broken and we are entering infinite loop of fetching and installing
broken update.
Right now we will try to report broken update so that server will be able
to remove it from the queue.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>