### PR TITLE
Reduce binary size by removing debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --always --dirty)
 
 GO_LDFLAGS = \
-	-ldflags "-X main.Version=$(VERSION)"
+	-ldflags "-s -w -X main.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v


### PR DESCRIPTION
Shrinks the mender binary by 30%, but debug symbols are lost.

@kacf @bboozzoo 