### PR TITLE
Revert "Reduce binary size by removing debug symbols"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --always --dirty)
 
 GO_LDFLAGS = \
-	-ldflags "-s -w -X main.Version=$(VERSION)"
+	-ldflags "-X main.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v


### PR DESCRIPTION
bitbake complains that:

"15:59:26 ERROR: mender-0.1+git999-r0 do_package: QA Issue: File '/usr/bin/mender' from mender was already stripped, this will prevent future debugging! [already-stripped]
15:59:26 NOTE: recipe mender-0.1+git999-r0: task do_populate_sysroot: Succeeded
15:59:26 ERROR: mender-0.1+git999-r0 do_package: Fatal QA errors found, failing task.
15:59:26 ERROR: mender-0.1+git999-r0 do_package: Function failed: do_package"

even thought the binary is not already stripped. 

This reverts commit b5d0c8f86a17ce3bd22961cb3b8baf4e3e0db338.