### PR TITLE
Revert "Reduce binary size by removing debug symbols"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --always --dirty)
 
 GO_LDFLAGS = \
-	-ldflags "-s -w -X main.Version=$(VERSION)"
+	-ldflags "-X main.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v


### PR DESCRIPTION
This reverts commit b5d0c8f86a17ce3bd22961cb3b8baf4e3e0db338.

Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>