### PR TITLE
mender: user friendly state naming

### DIFF
--- a/mender.go
+++ b/mender.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -83,6 +84,36 @@ const (
 	// exit state
 	MenderStateDone
 )
+
+var (
+	stateNames = map[MenderState]string{
+		MenderStateInit:               "init",
+		MenderStateBootstrapped:       "bootstrapped",
+		MenderStateAuthorized:         "authorized",
+		MenderStateAuthorizeWait:      "authorize-wait",
+		MenderStateUpdateCheckWait:    "update-check-wait",
+		MenderStateUpdateCheck:        "update-check",
+		MenderStateUpdateFetch:        "update-fetch",
+		MenderStateUpdateInstall:      "update-install",
+		MenderStateUpdateVerify:       "update-verify",
+		MenderStateUpdateCommit:       "update-commit",
+		MenderStateUpdateStatusReport: "update-status-report",
+		MenderStateReportStatusError:  "status-report-error",
+		MenderStateReboot:             "reboot",
+		MenderStateRollback:           "rollback",
+		MenderStateError:              "error",
+		MenderStateUpdateError:        "update-error",
+		MenderStateDone:               "finished",
+	}
+)
+
+func (m MenderState) String() string {
+	n, ok := stateNames[m]
+	if !ok {
+		return fmt.Sprintf("unknown (%d)", m)
+	}
+	return n
+}
 
 type mender struct {
 	UInstallCommitRebooter

--- a/mender_test.go
+++ b/mender_test.go
@@ -540,3 +540,11 @@ func TestMenderLogUpload(t *testing.T) {
 	)
 	assert.NotNil(t, err)
 }
+
+func TestMenderStateName(t *testing.T) {
+	m := MenderStateInit
+	assert.Equal(t, "init", m.String())
+
+	m = MenderState(333)
+	assert.Equal(t, "unknown (333)", m.String())
+}


### PR DESCRIPTION
Basically this:
```
DEBU[0000] Reading Mender configuration from file ./mender.conf.example  module=config
DEBU[0000] block type: RSA PRIVATE KEY                   module=keystore
WARN[0000] No client key and certificate provided. Using system default.  module=client
WARN[0000] certificate verification skipped..            module=client
DEBU[0000] handle init state                             module=state
INFO[0000] Mender state: init -> bootstrapped            module=mender
DEBU[0000] handle bootstrapped state                     module=state
INFO[0000] authorization data present and valid, skipping authorization attempt  module=mender
INFO[0000] Mender state: bootstrapped -> authorized      module=mender
ERRO[0000] I/O read error for entry state: open state: no such file or directory  module=dirstore
DEBU[0000] no update in progress, proceed                module=state
INFO[0000] Mender state: authorized -> update-check-wait  module=mender
DEBU[0000] handle update check wait state                module=state
DEBU[0000] wait 10s before next poll                     module=state
```

@GregorioDiStefano @kacf @pasinskim 