### PR TITLE
inventory reporting & improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,17 @@ ifeq ($(V),1)
 BUILDV = -v
 endif
 
+TAGS =
+ifeq ($(LOCAL),1)
+TAGS += local
+endif
+
+ifneq ($(TAGS),)
+BUILDTAGS = -tags '$(TAGS)'
+endif
+
 build:
-	$(GO) build $(GO_LDFLAGS) $(BUILDV)
+	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
 install:
 	$(GO) install $(GO_LDFLAGS) $(BUILDV)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
 install:
-	$(GO) install $(GO_LDFLAGS) $(BUILDV)
+	$(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
 clean:
 	$(GO) clean

--- a/client_inventory.go
+++ b/client_inventory.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+type InventoryReporter interface {
+	Submit(api ApiRequester, server string, data interface{}) error
+}
+
+type InventoryClient struct {
+}
+
+func NewInventoryClient() InventoryReporter {
+	return &InventoryClient{}
+}
+
+// Report status information to the backend
+func (i *InventoryClient) Submit(api ApiRequester, url string, data interface{}) error {
+	req, err := makeInventorySubmitRequest(url, data)
+	if err != nil {
+		return errors.Wrapf(err, "failed to prepare inventory submit request")
+	}
+
+	r, err := api.Do(req)
+	if err != nil {
+		log.Error("failed to submit inventory data: ", err)
+		return errors.Wrapf(err, "inventory submit failed")
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		log.Errorf("got unexpected HTTP status when submitting to inventory: %v", r.StatusCode)
+		return errors.Errorf("inventory submit failed, bad status %v", r.StatusCode)
+	}
+	log.Debugf("inventory update sent, response %v", r)
+
+	return nil
+}
+
+func makeInventorySubmitRequest(server string, data interface{}) (*http.Request, error) {
+	url := buildApiURL(server, "/inventory/device/attributes")
+
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder(out)
+	enc.Encode(&data)
+
+	hreq, err := http.NewRequest(http.MethodPatch, url, out)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create inventory HTTP request")
+	}
+
+	hreq.Header.Add("Content-Type", "application/json")
+	return hreq, nil
+}

--- a/client_inventory.go
+++ b/client_inventory.go
@@ -22,14 +22,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-type InventoryReporter interface {
+type InventorySubmitter interface {
 	Submit(api ApiRequester, server string, data interface{}) error
 }
 
 type InventoryClient struct {
 }
 
-func NewInventoryClient() InventoryReporter {
+func NewInventoryClient() InventorySubmitter {
 	return &InventoryClient{}
 }
 

--- a/client_inventory_test.go
+++ b/client_inventory_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInventoryClient(t *testing.T) {
+	responder := &struct {
+		httpStatus int
+		recdata    []byte
+		path       string
+	}{
+		http.StatusOK,
+		[]byte{},
+		"",
+	}
+
+	// Test server that always responds with 200 code, and specific payload
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(responder.httpStatus)
+
+		responder.recdata, _ = ioutil.ReadAll(r.Body)
+		responder.path = r.URL.Path
+	}))
+	defer ts.Close()
+
+	ac, err := NewApiClient(
+		httpsClientConfig{"client.crt", "client.key", "server.crt", true, false},
+	)
+	assert.NotNil(t, ac)
+	assert.NoError(t, err)
+
+	client := InventoryClient{}
+	assert.NotNil(t, client)
+
+	err = client.Submit(ac, ts.URL, InventoryData{
+		{"foo", "bar"},
+		{"bar", []string{"baz", "zen"}},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, responder.recdata)
+	assert.JSONEq(t,
+		`[{"name": "foo", "value": "bar"},{"name": "bar", "value": ["baz", "zen"]}]`,
+		string(responder.recdata))
+	assert.Equal(t, apiPrefix+"inventory/device/attributes", responder.path)
+
+	responder.httpStatus = 401
+	err = client.Submit(ac, ts.URL, nil)
+	assert.Error(t, err)
+}

--- a/identity_data.go
+++ b/identity_data.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"path"
 	"strings"
 
 	"github.com/mendersoftware/log"
@@ -24,7 +25,7 @@ import (
 )
 
 var (
-	identityDataHelper = "/usr/bin/mender-device-identity"
+	identityDataHelper = path.Join(getBinDirPath(), "mender-device-identity")
 )
 
 type IdentityDataGetter interface {

--- a/identity_data.go
+++ b/identity_data.go
@@ -25,7 +25,11 @@ import (
 )
 
 var (
-	identityDataHelper = path.Join(getBinDirPath(), "mender-device-identity")
+	identityDataHelper = path.Join(
+		getDataDirPath(),
+		"identity",
+		"mender-device-identity",
+	)
 )
 
 type IdentityDataGetter interface {

--- a/inventory.go
+++ b/inventory.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+type InventoryAttribute struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+}
+
+type InventoryData []InventoryAttribute

--- a/inventory_data.go
+++ b/inventory_data.go
@@ -1,0 +1,162 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	inventoryToolPrefix = "mender-inventory-"
+)
+
+type InventoryDataGetter interface {
+	Get() (InventoryData, error)
+}
+
+func NewInventoryDataGetter(scriptsDir string) InventoryDataGetter {
+	return &InventoryDataRunner{
+		scriptsDir,
+		&osCalls{},
+	}
+}
+
+type InventoryDataRunner struct {
+	dir string
+	cmd Commander
+}
+
+func listRunnable(dpath string) ([]string, error) {
+	dp, err := os.Open(dpath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open")
+	}
+
+	finfos, err := dp.Readdir(0)
+	if err != nil {
+		// don't care about any FileInfo that were read up to this point
+		return nil, errors.Wrapf(err, "failed to readdir")
+	}
+
+	runnable := []string{}
+	for _, finfo := range finfos {
+		if !strings.HasPrefix(finfo.Name(), inventoryToolPrefix) {
+			continue
+		}
+
+		runBits := os.FileMode(syscall.S_IXUSR | syscall.S_IXGRP | syscall.S_IXOTH)
+		if finfo.Mode()&runBits == 0 {
+			continue
+		}
+
+		runnable = append(runnable, path.Join(dpath, finfo.Name()))
+	}
+
+	return runnable, nil
+}
+
+type tempInventoryAttribute []string
+
+func (tia tempInventoryAttribute) ToInventoryAttribute(name string) InventoryAttribute {
+	if len(tia) > 1 {
+		return InventoryAttribute{Name: name, Value: []string(tia)}
+	} else if len(tia) == 1 {
+		return InventoryAttribute{Name: name, Value: tia[0]}
+	}
+	return InventoryAttribute{Name: name, Value: ""}
+}
+
+type tempInventoryData map[string]tempInventoryAttribute
+
+func (tid tempInventoryData) Add(name string, values ...string) {
+	_, has := tid[name]
+	if has {
+		tid[name] = append(tid[name], values...)
+	} else {
+		tid[name] = values
+	}
+}
+
+func (tid tempInventoryData) Append(idata tempInventoryData) {
+	for k, v := range idata {
+		tid.Add(k, []string(v)...)
+	}
+}
+
+func (tid tempInventoryData) ToInventoryData() InventoryData {
+	data := make(InventoryData, 0, len(tid))
+	for k, v := range tid {
+		data = append(data, v.ToInventoryAttribute(k))
+	}
+	return data
+}
+
+func (id *InventoryDataRunner) Get() (InventoryData, error) {
+	tools, err := listRunnable(id.dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list tools for inventory data")
+	}
+
+	idata := tempInventoryData{}
+	for _, t := range tools {
+		data, err := id.cmd.Command(t).Output()
+		if err != nil {
+			log.Errorf("inventory tool %s failed with status: %v", t, err)
+			continue
+		}
+
+		td, err := parseInventoryData(data)
+		if err != nil {
+			log.Warnf("inventory tool %s returned unparsable output: %v", t, err)
+			continue
+		}
+		idata.Append(td)
+	}
+	return idata.ToInventoryData(), nil
+}
+
+func parseInventoryData(data []byte) (tempInventoryData, error) {
+	td := tempInventoryData{}
+
+	in := bufio.NewScanner(bytes.NewBuffer(data))
+	for in.Scan() {
+		line := in.Text()
+
+		if len(line) == 0 {
+			continue
+		}
+
+		val := strings.SplitN(line, "=", 2)
+
+		if len(val) < 2 {
+			return nil, errors.Errorf("incorrect line '%s'", line)
+		}
+
+		td.Add(val[0], val[1])
+	}
+
+	if len(td) == 0 {
+		return nil, errors.Errorf("obtained no output")
+	}
+
+	return td, nil
+}

--- a/inventory_data.go
+++ b/inventory_data.go
@@ -29,12 +29,8 @@ const (
 	inventoryToolPrefix = "mender-inventory-"
 )
 
-type InventoryDataGetter interface {
-	Get() (InventoryData, error)
-}
-
-func NewInventoryDataGetter(scriptsDir string) InventoryDataGetter {
-	return &InventoryDataRunner{
+func NewInventoryDataRunner(scriptsDir string) InventoryDataRunner {
+	return InventoryDataRunner{
 		scriptsDir,
 		&osCalls{},
 	}

--- a/inventory_data.go
+++ b/inventory_data.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -42,12 +43,7 @@ type InventoryDataRunner struct {
 }
 
 func listRunnable(dpath string) ([]string, error) {
-	dp, err := os.Open(dpath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open %s", dpath)
-	}
-
-	finfos, err := dp.Readdir(0)
+	finfos, err := ioutil.ReadDir(dpath)
 	if err != nil {
 		// don't care about any FileInfo that were read up to this point
 		return nil, errors.Wrapf(err, "failed to readdir")

--- a/inventory_data.go
+++ b/inventory_data.go
@@ -48,7 +48,7 @@ type InventoryDataRunner struct {
 func listRunnable(dpath string) ([]string, error) {
 	dp, err := os.Open(dpath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open")
+		return nil, errors.Wrapf(err, "failed to open %s", dpath)
 	}
 
 	finfos, err := dp.Readdir(0)

--- a/inventory_data_test.go
+++ b/inventory_data_test.go
@@ -43,16 +43,34 @@ func TestTempInventoryData(t *testing.T) {
 		"zed": []string{"zen"},
 	}
 
+	// inventory data should get merged
 	td.Append(tdnew)
-	assert.Equal(t, tempInventoryData{
+
+	expecttd := tempInventoryData{
 		"foo": tempInventoryAttribute{"bar", "baz", "zed"},
 		"zed": tempInventoryAttribute{"zen"},
-	}, td)
+	}
+	assert.Equal(t, expecttd, td)
 
-	assert.Equal(t, InventoryData{
-		{"foo", []string{"bar", "baz", "zed"}},
-		{"zed", "zen"},
-	}, td.ToInventoryData())
+	idata := td.ToInventoryData()
+	// for each InventoryAttribute check that it exists in expected set and that
+	// it has an equal value
+	for _, idi := range idata {
+		if assert.Contains(t, expecttd, idi.Name, expecttd) {
+			expv := expecttd[idi.Name]
+			if len(expv) > 1 {
+				if assert.IsType(t, []string{}, idi.Value) {
+					ls, _ := idi.Value.([]string)
+					assert.Len(t, ls, len(expv))
+					for _, v := range ls {
+						assert.Contains(t, expv, v)
+					}
+				}
+			} else if len(expv) == 1 {
+				assert.Equal(t, expv[0], idi.Value)
+			}
+		}
+	}
 }
 
 func TestParseInventoryData(t *testing.T) {

--- a/inventory_data_test.go
+++ b/inventory_data_test.go
@@ -19,74 +19,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTempInventoryData(t *testing.T) {
-	td := tempInventoryData{}
+func TestInventoryDataDecoder(t *testing.T) {
 
-	td.Add("foo", "bar")
-	assert.Contains(t, td, "foo")
-	assert.Equal(t, tempInventoryAttribute{"bar"}, td["foo"])
+	idec := NewInventoryDataDecoder()
+	assert.NotNil(t, idec)
 
-	fattrs := td["foo"]
-	assert.Equal(t, InventoryAttribute{"foo", "bar"},
-		fattrs.ToInventoryAttribute("foo"))
-
-	td.Add("foo", "baz")
-	assert.Contains(t, td, "foo")
-	assert.Equal(t, tempInventoryAttribute{"bar", "baz"}, td["foo"])
-
-	fattrs = td["foo"]
-	assert.Equal(t, InventoryAttribute{"foo", []string{"bar", "baz"}},
-		fattrs.ToInventoryAttribute("foo"))
-
-	tdnew := tempInventoryData{
-		"foo": []string{"zed"},
-		"zed": []string{"zen"},
-	}
-
-	// inventory data should get merged
-	td.Append(tdnew)
-
-	expecttd := tempInventoryData{
-		"foo": tempInventoryAttribute{"bar", "baz", "zed"},
-		"zed": tempInventoryAttribute{"zen"},
-	}
-	assert.Equal(t, expecttd, td)
-
-	idata := td.ToInventoryData()
-	// for each InventoryAttribute check that it exists in expected set and that
-	// it has an equal value
-	for _, idi := range idata {
-		if assert.Contains(t, expecttd, idi.Name, expecttd) {
-			expv := expecttd[idi.Name]
-			if len(expv) > 1 {
-				if assert.IsType(t, []string{}, idi.Value) {
-					ls, _ := idi.Value.([]string)
-					assert.Len(t, ls, len(expv))
-					for _, v := range ls {
-						assert.Contains(t, expv, v)
-					}
-				}
-			} else if len(expv) == 1 {
-				assert.Equal(t, expv[0], idi.Value)
-			}
-		}
-	}
-}
-
-func TestParseInventoryData(t *testing.T) {
-	td, err := parseInventoryData([]byte(`
-foo=bar
-foo=baz
-zed=zen
-`))
+	_, err := idec.Write([]byte(`foo=bar`))
 	assert.NoError(t, err)
-	assert.NotNil(t, td)
-	assert.Equal(t, tempInventoryData{
-		"foo": tempInventoryAttribute{"bar", "baz"},
-		"zed": tempInventoryAttribute{"zen"},
-	}, td)
 
-	_, err = parseInventoryData([]byte(``))
-	assert.EqualError(t, err, "obtained no output")
+	assert.Contains(t, idec.GetInventoryData(), InventoryAttribute{"foo", "bar"})
 
+	_, err = idec.Write([]byte(`foo=baz`))
+	assert.NoError(t, err)
+	assert.Contains(t, idec.data, "foo")
+	assert.Contains(t, idec.GetInventoryData(),
+		InventoryAttribute{"foo", []string{"bar", "baz"}})
+
+	_, err = idec.Write([]byte(`bar=zen`))
+	assert.NoError(t, err)
+	assert.Contains(t, idec.GetInventoryData(),
+		InventoryAttribute{"foo", []string{"bar", "baz"}})
+	assert.Contains(t, idec.GetInventoryData(), InventoryAttribute{"bar", "zen"})
+
+	_, err = idec.Write([]byte("adada"))
+	assert.Error(t, err)
+
+	idata := idec.GetInventoryData()
+	// added only foo & bar keys
+	assert.Len(t, idata, 2)
+	assert.Contains(t, idata, InventoryAttribute{"foo", []string{"bar", "baz"}})
+	assert.Contains(t, idata, InventoryAttribute{"bar", "zen"})
 }

--- a/inventory_data_test.go
+++ b/inventory_data_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTempInventoryData(t *testing.T) {
+	td := tempInventoryData{}
+
+	td.Add("foo", "bar")
+	assert.Contains(t, td, "foo")
+	assert.Equal(t, tempInventoryAttribute{"bar"}, td["foo"])
+
+	fattrs := td["foo"]
+	assert.Equal(t, InventoryAttribute{"foo", "bar"},
+		fattrs.ToInventoryAttribute("foo"))
+
+	td.Add("foo", "baz")
+	assert.Contains(t, td, "foo")
+	assert.Equal(t, tempInventoryAttribute{"bar", "baz"}, td["foo"])
+
+	fattrs = td["foo"]
+	assert.Equal(t, InventoryAttribute{"foo", []string{"bar", "baz"}},
+		fattrs.ToInventoryAttribute("foo"))
+
+	tdnew := tempInventoryData{
+		"foo": []string{"zed"},
+		"zed": []string{"zen"},
+	}
+
+	td.Append(tdnew)
+	assert.Equal(t, tempInventoryData{
+		"foo": tempInventoryAttribute{"bar", "baz", "zed"},
+		"zed": tempInventoryAttribute{"zen"},
+	}, td)
+
+	assert.Equal(t, InventoryData{
+		{"foo", []string{"bar", "baz", "zed"}},
+		{"zed", "zen"},
+	}, td.ToInventoryData())
+}
+
+func TestParseInventoryData(t *testing.T) {
+	td, err := parseInventoryData([]byte(`
+foo=bar
+foo=baz
+zed=zen
+`))
+	assert.NoError(t, err)
+	assert.NotNil(t, td)
+	assert.Equal(t, tempInventoryData{
+		"foo": tempInventoryAttribute{"bar", "baz"},
+		"zed": tempInventoryAttribute{"zen"},
+	}, td)
+
+	_, err = parseInventoryData([]byte(``))
+	assert.EqualError(t, err, "obtained no output")
+
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/mendersoftware/log"
@@ -55,7 +56,7 @@ var (
 		"incompatible log log options specified.")
 )
 
-var defaultConfFile string = "/etc/mender/mender.conf"
+var defaultConfFile string = path.Join(getConfDirPath(), "mender.conf")
 
 var DeploymentLogger *DeploymentLogManager
 

--- a/mender.go
+++ b/mender.go
@@ -378,7 +378,7 @@ func (m *mender) RunState(ctx *StateContext) (State, bool) {
 
 func (m *mender) InventoryRefresh() error {
 	ic := NewInventoryClient()
-	idg := NewInventoryDataGetter(path.Join(getDataDirPath(), "inventory"))
+	idg := NewInventoryDataRunner(path.Join(getDataDirPath(), "inventory"))
 
 	idata, err := idg.Get()
 	if err != nil {

--- a/mender.go
+++ b/mender.go
@@ -62,6 +62,8 @@ const (
 	MenderStateAuthorized
 	// wait before authorization attempt
 	MenderStateAuthorizeWait
+	// inventory update
+	MenderStateInventoryUpdate
 	// wait for new update
 	MenderStateUpdateCheckWait
 	// check update
@@ -96,6 +98,7 @@ var (
 		MenderStateBootstrapped:       "bootstrapped",
 		MenderStateAuthorized:         "authorized",
 		MenderStateAuthorizeWait:      "authorize-wait",
+		MenderStateInventoryUpdate:    "inventory-update",
 		MenderStateUpdateCheckWait:    "update-check-wait",
 		MenderStateUpdateCheck:        "update-check",
 		MenderStateUpdateFetch:        "update-fetch",

--- a/mender.go
+++ b/mender.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -43,7 +44,10 @@ type Controller interface {
 const (
 	defaultManifestFile = "/etc/mender/build_mender"
 	defaultKeyFile      = "mender-agent.pem"
-	defaultDataStore    = "/var/lib/mender"
+)
+
+var (
+	defaultDataStore = getStateDirPath()
 )
 
 type MenderState int

--- a/mender.go
+++ b/mender.go
@@ -377,7 +377,7 @@ func (m *mender) RunState(ctx *StateContext) (State, bool) {
 }
 
 func (m *mender) InventoryRefresh() error {
-	ic := InventoryClient{}
+	ic := NewInventoryClient()
 	idg := NewInventoryDataGetter(path.Join(getDataDirPath(), "inventory"))
 
 	idata, err := idg.Get()

--- a/mender.go
+++ b/mender.go
@@ -43,12 +43,12 @@ type Controller interface {
 }
 
 const (
-	defaultManifestFile = "/etc/mender/build_mender"
-	defaultKeyFile      = "mender-agent.pem"
+	defaultKeyFile = "mender-agent.pem"
 )
 
 var (
-	defaultDataStore = getStateDirPath()
+	defaultManifestFile = path.Join(getConfDirPath(), "build_mender")
+	defaultDataStore    = getStateDirPath()
 )
 
 type MenderState int

--- a/paths.go
+++ b/paths.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+// +build !local
+
+package main
+
+func getDataDirPath() string {
+	return "/usr/share/mender"
+}
+
+func getStateDirPath() string {
+	return "/var/lib/mender"
+}
+
+func getConfDirPath() string {
+	return "/etc/mender"
+}
+
+func getBinDirPath() string {
+	return "/usr/bin"
+}

--- a/paths.go
+++ b/paths.go
@@ -32,7 +32,3 @@ func getStateDirPath() string {
 func getConfDirPath() string {
 	return "/etc/mender"
 }
-
-func getBinDirPath() string {
-	return "/usr/bin"
-}

--- a/paths.go
+++ b/paths.go
@@ -16,8 +16,13 @@
 
 package main
 
+var (
+	// needed so that we can override it when testing
+	defaultPathDataDir = "/usr/share/mender"
+)
+
 func getDataDirPath() string {
-	return "/usr/share/mender"
+	return defaultPathDataDir
 }
 
 func getStateDirPath() string {

--- a/paths_local.go
+++ b/paths_local.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+// +build local
+
+package main
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func getRunningBinaryPath() string {
+	return filepath.Dir(os.Args[0])
+}
+
+func getDataDirPath() string {
+	return path.Join(getRunningBinaryPath(), "support")
+}
+
+func getStateDirPath() string {
+	return getRunningBinaryPath()
+}
+
+func getConfDirPath() string {
+	return getRunningBinaryPath()
+}
+
+func getBinDirPath() string {
+	return path.Join(getRunningBinaryPath(), "support")
+}

--- a/paths_local.go
+++ b/paths_local.go
@@ -37,7 +37,3 @@ func getStateDirPath() string {
 func getConfDirPath() string {
 	return getRunningBinaryPath()
 }
-
-func getBinDirPath() string {
-	return path.Join(getRunningBinaryPath(), "support")
-}

--- a/state_test.go
+++ b/state_test.go
@@ -44,6 +44,7 @@ type stateTestController struct {
 	reportUpdate    UpdateResponse
 	logUpdate       UpdateResponse
 	logs            []byte
+	inventoryErr    error
 }
 
 func (s *stateTestController) Bootstrap() menderError {
@@ -96,6 +97,10 @@ func (s *stateTestController) UploadLog(update UpdateResponse, logs []byte) mend
 	s.logUpdate = update
 	s.logs = logs
 	return s.logSendingError
+}
+
+func (s *stateTestController) InventoryRefresh() error {
+	return s.inventoryErr
 }
 
 func TestStateBase(t *testing.T) {
@@ -358,7 +363,7 @@ func TestStateAuthorized(t *testing.T) {
 	s, c = b.Handle(&ctx, &stateTestController{
 		hasUpgrade: false,
 	})
-	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.IsType(t, &InventoryUpdateState{}, s)
 	assert.False(t, c)
 
 	// pretend we have state data
@@ -429,6 +434,18 @@ func TestStateAuthorized(t *testing.T) {
 	assert.IsType(t, &UpdateErrorState{}, s)
 	use, _ = s.(*UpdateErrorState)
 	assert.Equal(t, update, use.update)
+}
+
+func TestStateInvetoryUpdate(t *testing.T) {
+	ius := inventoryUpdateState
+
+	s, _ := ius.Handle(nil, &stateTestController{
+		inventoryErr: errors.New("some err"),
+	})
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
+
+	s, _ = ius.Handle(nil, &stateTestController{})
+	assert.IsType(t, &UpdateCheckWaitState{}, s)
 }
 
 func TestStateAuthorizeWait(t *testing.T) {
@@ -598,7 +615,7 @@ func TestStateUpdateCheck(t *testing.T) {
 
 	// no update
 	s, c = cs.Handle(nil, &stateTestController{})
-	assert.IsType(t, &UpdateCheckWaitState{}, s)
+	assert.IsType(t, &InventoryUpdateState{}, s)
 	assert.False(t, c)
 
 	// pretend update check failed

--- a/support/mender-device-identity
+++ b/support/mender-device-identity
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Example script called by Mender agent to collect device identity
-# data. The script needs to be located at
-# $(bindir)/mender-device-identity path for the agent to find it.
-# The script shall exit with non-0 status on errors. In this case the
-# agent will discard any output the script may have produced.
+# Example script called by Mender agent to collect device identity data. The
+# script needs to be located at
+# $(datadir)/mender/identity/mender-device-identity path for the agent to find
+# it. The script shall exit with non-0 status on errors. In this case the agent
+# will discard any output the script may have produced.
 #
 # The script shall output identity data in <key>=<value> format, one
 # entry per line. Example

--- a/support/mender-inventory-network
+++ b/support/mender-inventory-network
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Example script called by Mender agent to collect inventory data for a
+# particular devce. The script needs to be located in $(datadir)/mender and its
+# name shall start with `mender-inventory-` prefix. The script shall exit with
+# non-0 status on errors. In this case the agent will discard any output the
+# script may have produced.
+#
+# The script shall output inventory data in <key>=<value> format, one entry per
+# line. Entries appearing multiple times will be joined in a list under the same
+# key.
+#
+# $ ./mender-inventory-network
+# mac_br-fbfdad18c33c=02:42:7e:74:96:85
+# ifaces=br-fbfdad18c33c
+# ipv4_br-fbfdad18c33c=172.21.0.1/16
+# mac_enp0s25=de:ad:be:ef:bb:05
+# ifaces=enp0s25
+# ipv4_enp0s25=123.22.0.197/16
+# ipv4_enp0s25=10.20.20.105/16
+# ipv6_enp0s25=fe80::2aad:beff:feef:bb05/64
+#
+#
+# The example script collects the list of network interfaces, as well as
+# ethernet and IP addresses of each of the interfaces.
+#
+
+set -ueo pipefail
+
+SCN=/sys/class/net
+min=65535
+ifdev=
+
+# find iface with lowest ifindex, except loopback
+for devpath in $SCN/*; do
+    dev=$(basename $devpath)
+    if [ $dev = "lo" ]; then
+        continue
+    fi
+    echo "mac_$dev=$(cat $devpath/address)"
+    echo "ifaces=$dev"
+
+    ip addr show dev $dev | awk -v dev=$dev '
+       /inet / { printf("ipv4_%s=%s\n", dev, $2) }
+       /inet6 / {printf("ipv6_%s=%s\n", dev, $2) }
+    '
+done


### PR DESCRIPTION
Introduce inventory support. `Controller` interface is extended with `InventoryRefresh()` method. New state `InventoryUpdateState` is added to the state machine, and is executed right after `UpdateCheckState` in case no update is present. Additionally, the state will be run when transitioning from `AuthorizedState`, so that we get a refresh of inventory data if Mender client was restarted.

A couple of extra commits introduce (incomplete) support for 'local' builds. Something I wanted to explore before, but had it only as a couple of stashed patches. The idea is that it would be nice to be able to build and run mender locally as part of one's development cycle. Right now we can build the client, but running it will bail out early in `HasUpgrade()`. Even if one adds `return false, nil` over there, the client will fail once again when attempting to run identity data script. Now, with inventory support, the inventory scripts will not be run because we just assume a specific prefix in the code. 

When building for local environment, the client should use paths that lead it back to the source tree, also any code that would normally reference u-boot or fiddle with partitions, should interact with local files instead.

If agent was written in C we could use a couple of defines/headers to work around that, however in Go the only reasonable method I found is build tags, hence the series introduces a 'local' build tag (triggered by `make LOCAL=1`) that for now only influences how system paths are found. So, with this PR, we only need this small patch

```
diff --git a/mender.go b/mender.go
index 28a3d41..ffc9c3c 100644
--- a/mender.go
+++ b/mender.go
@@ -197,6 +197,7 @@ func (m mender) GetCurrentImageID() string {
 }
 
 func (m *mender) HasUpgrade() (bool, menderError) {
+       return false, nil
        env, err := m.env.ReadEnv("upgrade_available")
        if err != nil {
                return false, NewFatalError(err)
```
to be able to build & run the client locally, and get it through authorization/update check/inventory update steps. It should be quite easy to add `device_local.go` and implement environment & image writing on local files. 

@pasinskim @kacf @GregorioDiStefano 