### PR TITLE
Trim token of whitespaces before adding header

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -138,6 +138,9 @@ func (m *MenderAuthManager) MakeAuthRequest() (*AuthRequest, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read tenant token")
 	}
+
+	tentok = bytes.TrimSpace(tentok)
+
 	log.Debugf("tenant token: %s", tentok)
 
 	// fill tenant token


### PR DESCRIPTION
Trim the newline in the authorization tenant token before adding it to the http headers. 

This is a fix for:
```
Sep 13 10:01:20 vexpress-qemu mender[1390]: level=error msg="I/O read error for entry authtoken: open /var/lib/mender/authtoken: no such file or directory" module=dirstore
Sep 13 10:01:20 vexpress-qemu mender[1390]: level=error msg="authorize failed: transient error: authorization request failed: failed to execute authorization request: Post https://mender-api-gateway/api/devices/0.1/authentication/auth_requests: net/http: invalid header field value \"Bearer dummy\\n\" for key Authorization" module=state
Sep 13 10:01:20 vexpress-qemu mender[1390]: time="2016-09-13T10:01:20Z" level=error msg="authorize failed: transient error: authorization request failed: failed to execute authorization request: Post https://mender-api-gateway/api/devices/0.1/authentication/auth_requests: net/http: invalid header field value \"Bearer dummy\\n\" for key Authorization" module=state
Sep 13 10:01:20 vexpress-qemu mender[1390]: level=info msg="Mender state: bootstrapped -> authorize-wait" module=mender
Sep 13 10:01:20 vexpress-qemu mender[1390]: time="2016-09-13T10:01:20Z" level=info msg="Mender state: bootstrapped -> authorize-wait" module=mender

```
Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>