### PR TITLE
main: include runtime information in -version output

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/mendersoftware/log"
@@ -264,7 +265,7 @@ func parseLogFlags(args logOptionsType) error {
 }
 
 func ShowVersion() {
-	v := fmt.Sprintf("%s\n", VersionString())
+	v := fmt.Sprintf("%s\nruntime: %s\n", VersionString(), runtime.Version())
 	os.Stdout.Write([]byte(v))
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -175,7 +176,7 @@ func TestVersion(t *testing.T) {
 	tfile.Close()
 	os.Remove(tname)
 
-	expected := fmt.Sprintf("%s\n", VersionString())
+	expected := fmt.Sprintf("%s\nruntime: %s\n", VersionString(), runtime.Version())
 	assert.Equal(t, expected, string(data),
 		"unexpected version output '%s' expected '%s'", string(data), expected)
 }


### PR DESCRIPTION
In #109 the behavior of `http.Client` was changed by runtime. It would be nice to include runtime version information in `-version` output so that we could spot any differences faster.

@kacf @pasinskim @GregorioDiStefano 