### PR TITLE
MEN-630 Check update status before sending report to server.

### DIFF
--- a/state_test.go
+++ b/state_test.go
@@ -411,10 +411,9 @@ func TestStateAuthorized(t *testing.T) {
 		UpdateStatus: statusSuccess,
 	})
 	s, c = b.Handle(&ctx, &stateTestController{})
-	assert.IsType(t, &UpdateStatusReportState{}, s)
-	usr, _ = s.(*UpdateStatusReportState)
-	assert.Equal(t, statusSuccess, usr.status)
-	assert.Equal(t, update, usr.update)
+	assert.IsType(t, &UpdateVerifyState{}, s)
+	ver, _ := s.(*UpdateVerifyState)
+	assert.Equal(t, update, ver.update)
 
 	// pretend last update was interrupted
 	StoreStateData(ms, StateData{
@@ -822,15 +821,8 @@ func TestStateRollback(t *testing.T) {
 	assert.IsType(t, &ErrorState{}, s)
 	assert.False(t, c)
 
-	s, c = rs.Handle(nil, &stateTestController{
-		fakeDevice: fakeDevice{
-			retReboot: NewFatalError(errors.New("reboot failed")),
-		}})
-	assert.IsType(t, &ErrorState{}, s)
-	assert.False(t, c)
-
 	s, c = rs.Handle(nil, &stateTestController{})
-	assert.IsType(t, &FinalState{}, s)
+	assert.IsType(t, &RebootState{}, s)
 	assert.False(t, c)
 }
 


### PR DESCRIPTION
Previously when we've been not able to send status to the server after
successful update we've been rolling back to the last working image.
The problem was that `report state` has been saved as the last known state
with the status `success`. Once device was rebooted it continued to send
`success` to the server even though we rolled back.
This is fixing the issue by verifying exact state before sending report
to the server.
It also uses `reboot` state as a part of rollback.