### PR TITLE
state: use time based limits for update state report attempts

### DIFF
--- a/state.go
+++ b/state.go
@@ -735,10 +735,16 @@ func sendStatus(update UpdateResponse, status string, c Controller) menderError 
 	return c.ReportUpdateStatus(update, status)
 }
 
-const maxReportSendingTries = 5
+var maxReportSendingTime = 5 * time.Minute
 
 func (usr *UpdateStatusReportState) trySend(send SendData, c Controller) (error, bool) {
-	for usr.triesSendingReport < maxReportSendingTries {
+	poll := c.GetUpdatePollInterval()
+	if poll == 0 {
+		poll = 5 * time.Second
+	}
+	maxAttempts := int(maxReportSendingTime / poll)
+
+	for usr.triesSendingReport < maxAttempts {
 		log.Infof("attempting to report data of deployment [%v] to the backend;"+
 			" deployment status [%v], try %d",
 			usr.update.ID, usr.status, usr.triesSendingReport)

--- a/state_test.go
+++ b/state_test.go
@@ -300,7 +300,7 @@ func TestStateUpdateReportStatus(t *testing.T) {
 	s, c = usr.Handle(&ctx, sc)
 	assert.IsType(t, s, &ReportErrorState{})
 	assert.False(t, c)
-	assert.WithinDuration(t, time.Now(), now1, 2*time.Second+500*time.Millisecond)
+	assert.WithinDuration(t, time.Now(), now1, 3*time.Second)
 	assert.InDelta(t, int(maxReportSendingTime/poll),
 		usr.(*UpdateStatusReportState).triesSendingReport, 100)
 
@@ -314,7 +314,7 @@ func TestStateUpdateReportStatus(t *testing.T) {
 	s, c = usr.Handle(&ctx, sc)
 	assert.IsType(t, s, &ReportErrorState{})
 	assert.False(t, c)
-	assert.WithinDuration(t, now2, time.Now(), 2*time.Second+500*time.Millisecond)
+	assert.WithinDuration(t, now2, time.Now(), 3*time.Second)
 
 	maxReportSendingTime = old
 }


### PR DESCRIPTION
Retry update status report attempts for 5 minutes, after that return an
error and assume that reporting failed.

@pasinskim @kacf @GregorioDiStefano 