### PR TITLE
Contribution improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 Contributing to Mender
 ======================
 
-Thank you for showing interest in contributing to the Mender project. 
-Connecting with contributors and growing a community is very important to us. 
+Thank you for showing interest in contributing to the Mender project.
+Connecting with contributors and growing a community is very important to us.
 We hope you will find what you need to get started on this page.
 
 ## Reporting security issues
@@ -20,7 +20,7 @@ will publish the fix and acknowledge your finding on our site if you so wish.
 Pull requests are very welcome, and the maintainers of Mender work hard
 to stay on top to review and hopefully merge your work.
 
-If your work is significant, it can make sense to discuss the idea with the 
+If your work is significant, it can make sense to discuss the idea with the
 maintainers and relevant project members upfront. Start a discussion via our
 [Google group](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender)
 or reach our team at [contact@mender.io](mailto:contact@mender.io).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ to stay on top to review and hopefully merge your work.
 
 If your work is significant, it can make sense to discuss the idea with the
 maintainers and relevant project members upfront. Start a discussion via our
-[Google group](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender)
-or reach our team at [contact@mender.io](mailto:contact@mender.io).
+[Google group mailing
+list](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender).
 
 
 ### Sign your work


### PR DESCRIPTION
Clarify that Google groups is a mailing list, not a forum.

Also remove contact@mender.io as a contact point for pull requests. It
is not the appropriate channel for such requests.