### PR TITLE
Go 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: go
 
 # Golang version matrix
 go:
-    - 1.7
+    # use the same version as available in oe-meta-go
+    - 1.7.1
 
 env:
     global:

--- a/block_device.go
+++ b/block_device.go
@@ -54,7 +54,10 @@ func (bd *BlockDevice) Write(p []byte) (int, error) {
 		log.Infof("partition %s size: %v", bd.Path, size)
 
 		bd.out = out
-		bd.w = &utils.LimitedWriter{out, size}
+		bd.w = &utils.LimitedWriter{
+			W: out,
+			N: size,
+		}
 	}
 
 	w, err := bd.w.Write(p)


### PR DESCRIPTION
Bump Go version to 1.7.1 (same version as available in oe-meta-go). Fix issues that occurred during transition.

@kacf @pasinskim @GregorioDiStefano 