### PR TITLE
rootfs image installation/download progress display

### DIFF
--- a/rootfs.go
+++ b/rootfs.go
@@ -17,11 +17,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 
 	"github.com/mendersoftware/log"
 	"github.com/mendersoftware/mender/client"
+	"github.com/mendersoftware/mender/utils"
 )
 
 // This will be run manually from command line ONLY
@@ -69,7 +71,14 @@ func doRootfs(device UInstaller, args runOptionsType) error {
 		return errors.New("Error while updateing image from command line: " + err.Error())
 	}
 
-	if err = device.InstallUpdate(image, imageSize); err != nil {
+	p := &utils.ProgressWriter{
+		Out: os.Stderr,
+		N:   imageSize,
+	}
+
+	tr := io.TeeReader(image, p)
+
+	if err = device.InstallUpdate(ioutil.NopCloser(tr), imageSize); err != nil {
 		return err
 	}
 	log.Info("Image correctly installed to inactive partition. " +

--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package utils
+
+import (
+	"fmt"
+	"io"
+)
+
+type ProgressWriter struct {
+	Out  io.Writer // progress output
+	N    int64     // size of the input
+	c    int64     // current count
+	over bool      // set to true of writes have gone over declared N bytes
+}
+
+func (p *ProgressWriter) Write(data []byte) (int, error) {
+	n := len(data)
+
+	p.reportGeneric(n)
+	p.c += int64(n)
+	return n, nil
+}
+
+func (p *ProgressWriter) maybeWarn(then int64) {
+	if p.N != 0 && then > p.N && !p.over {
+		w := fmt.Sprintf("going over declared size, expected %v N, now %v\n",
+			p.N, then)
+		p.Out.Write([]byte(w))
+		p.over = true
+	}
+}
+
+func (p *ProgressWriter) reportGeneric(n int) {
+	const perLine = 1 * 1024 * 1024 // 1MiB
+	const dotsPerLine = 32
+	const perDot = perLine / dotsPerLine
+
+	now := p.c
+	then := p.c + int64(n)
+	nowDots := now / perDot
+	thenDots := then / perDot
+
+	p.maybeWarn(then)
+
+	for ; nowDots < thenDots; nowDots++ {
+		p.Out.Write([]byte("."))
+		if nowDots != 0 && (nowDots+1)%dotsPerLine == 0 {
+			// print percentage and size after each complete line
+			var s string
+			nowSize := (nowDots + 1) * perDot
+			nowSizekB := nowSize / 1024
+			if p.N == 0 || then > p.N {
+				s = fmt.Sprintf(" %v KiB\n", nowSizekB)
+			} else {
+				s = fmt.Sprintf(" %3d%% %v KiB\n",
+					100*nowSize/p.N, nowSizekB)
+			}
+			p.Out.Write([]byte(s))
+		}
+	}
+
+	// fill up with spaces and display 100%, but only if we know the size
+	if then == p.N {
+		// a line was completed, so 100% progress was already displayed
+		// at line end boundary
+		if thenDots != 0 && thenDots%dotsPerLine == 0 {
+			return
+		}
+
+		// round up expected line count
+		lines := (then + perLine) / perLine
+		if then%perLine == 0 {
+			lines -= 1
+		}
+
+		left := (lines * dotsPerLine) - thenDots
+		// if there was too little data no dots will be printed, make up
+		// for this and print at least one to show progress
+		if thenDots == 0 {
+			p.Out.Write([]byte("."))
+			left -= 1
+		}
+		// fill remaining space with spaces
+		for i := int64(0); i < left; i++ {
+			p.Out.Write([]byte(" "))
+		}
+		// print 100%, make sure we proper size suffix just in case
+		// we are below 1kB with the whole size
+		szSuffix := "KiB"
+		size := p.N / 1024
+		if p.N < 1024 {
+			szSuffix = "B"
+			size = p.N
+		}
+		s := fmt.Sprintf(" 100%% %v %s\n", size, szSuffix)
+		p.Out.Write([]byte(s))
+	}
+}

--- a/utils/progress_test.go
+++ b/utils/progress_test.go
@@ -1,0 +1,124 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package utils
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeZeros(out io.Writer, cnt int64) {
+	for i := int64(0); i < cnt; i++ {
+		out.Write([]byte{0})
+	}
+}
+
+func TestProgress(t *testing.T) {
+	b := &bytes.Buffer{}
+	p := &ProgressWriter{
+		Out: b,
+		N:   100,
+	}
+
+	n, err := p.Write([]byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	writeZeros(p, 100)
+	assert.Equal(t, ".                                100% 100 B\n", b.String())
+
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+		N:   1024,
+	}
+	writeZeros(p, 1024)
+	assert.Equal(t, ".                                100% 1 KiB\n", b.String())
+
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+		N:   1024 * 800,
+	}
+	// 800KiB
+	writeZeros(p, 1024*800)
+	assert.Equal(t, ".........................        100% 800 KiB\n", b.String())
+
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+		N:   4 * 1024 * 1024,
+	}
+	// 4MiB
+	writeZeros(p, 4*1024*1024)
+	assert.Equal(t,
+		`................................  25% 1024 KiB
+................................  50% 2048 KiB
+................................  75% 3072 KiB
+................................ 100% 4096 KiB
+`,
+		b.String())
+
+	// do not specify the maximum size, % progress will not be displayed,
+	// but KiB will
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+	}
+	// 4MiB
+	writeZeros(p, 4*1024*1024)
+	assert.Equal(t,
+		`................................ 1024 KiB
+................................ 2048 KiB
+................................ 3072 KiB
+................................ 4096 KiB
+`,
+		b.String())
+
+	// same thing again, but now write less than full lines, a special case,
+	// since we don't know the full size, we cannot tell when the data
+	// stream will finish, so newlines and progress report only appears
+	// after a full line is complete
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+	}
+	// 3.5MiB
+	writeZeros(p, 3*1024*1024+512*1024)
+	assert.Equal(t,
+		`................................ 1024 KiB
+................................ 2048 KiB
+................................ 3072 KiB
+................`,
+		b.String())
+
+	// check if a warning is written if we go over declared size
+	b = &bytes.Buffer{}
+	p = &ProgressWriter{
+		Out: b,
+		N:   100,
+	}
+	// 1.5MiB
+	writeZeros(p, 1*1024*1024+512*1024)
+	assert.Equal(t,
+		`.                                100% 100 B
+going over declared size, expected 100 N, now 101
+................................ 1024 KiB
+................`,
+		b.String())
+
+}


### PR DESCRIPTION
Add support for installation progress display when meder is used in `-rootfs` mode. Demo:
https://asciinema.org/a/4cp2bwmdg5whlqywk7wyst3bi

@kacf @pasinskim @GregorioDiStefano 
