### PR TITLE
Fixes for MEN-759, MEN-760

### DIFF
--- a/client/client_status.go
+++ b/client/client_status.go
@@ -29,7 +29,6 @@ const (
 	StatusRebooting   = "rebooting"
 	StatusSuccess     = "success"
 	StatusFailure     = "failure"
-	StatusError       = "error"
 )
 
 type StatusReporter interface {

--- a/client/test/server.go
+++ b/client/test/server.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 
 	"github.com/mendersoftware/log"
@@ -35,6 +36,7 @@ type updateType struct {
 
 type updateDownloadType struct {
 	Called bool
+	Data   bytes.Buffer
 }
 
 type authType struct {
@@ -342,4 +344,14 @@ func (cts *ClientTestServer) updateDownloadReq(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// fetch should not carry Authorization header
+	hv := r.Header.Get("Authorization")
+	if hv != "" {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	w.Header().Set("Content-Length", strconv.Itoa(cts.UpdateDownload.Data.Len()))
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, &cts.UpdateDownload.Data)
 }

--- a/mender.go
+++ b/mender.go
@@ -315,7 +315,7 @@ func (m *mender) doBootstrap() menderError {
 }
 
 func (m *mender) FetchUpdate(url string) (io.ReadCloser, int64, error) {
-	return m.updater.FetchUpdate(m.api.Request(m.authToken), url)
+	return m.updater.FetchUpdate(m.api, url)
 }
 
 // Check if new update is available. In case of errors, returns nil and error

--- a/state_test.go
+++ b/state_test.go
@@ -217,7 +217,7 @@ func TestStateUpdateError(t *testing.T) {
 	assert.IsType(t, &UpdateStatusReportState{}, s)
 	// verify that update status report state data is correct
 	usr, _ := s.(*UpdateStatusReportState)
-	assert.Equal(t, client.StatusError, usr.status)
+	assert.Equal(t, client.StatusFailure, usr.status)
 	assert.Equal(t, update, usr.update)
 }
 
@@ -413,7 +413,7 @@ func TestStateAuthorized(t *testing.T) {
 	s, c = b.Handle(&ctx, &stateTestController{})
 	assert.IsType(t, &UpdateStatusReportState{}, s)
 	usr := s.(*UpdateStatusReportState)
-	assert.Equal(t, client.StatusError, usr.status)
+	assert.Equal(t, client.StatusFailure, usr.status)
 	assert.Equal(t, update, usr.update)
 
 	// now pretend we were trying to report success


### PR DESCRIPTION
The first problem is fixed by not adding `Authorization` header to update fetch requests.

The second is addressed by removing `StateError`. It looks that `StateError` was used interchangeably with `StateFailure`, what led to subtle error when reporting update status that resulted in logs not being uploaded.

@pasinskim @kacf