### PR TITLE
travis: bump Go version to 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 # Golang version matrix
 go:
     # use the same version as available in oe-meta-go
-    - 1.7.1
+    - 1.7.3
 
 env:
     global:


### PR DESCRIPTION
oe-meta-go commit fbd51ce introduced Go 1.7.3. Bump travis config to use
the same version.

@pasinskim @kacf 