### PR TITLE
Revert "state_test: fix nil dereference if TestStateUpdateInstall was…

### DIFF
--- a/state_test.go
+++ b/state_test.go
@@ -780,11 +780,6 @@ func TestStateUpdateInstall(t *testing.T) {
 	}
 	uis := NewUpdateInstallState(stream, int64(len(data)), update)
 
-	// create directory for storing deployments logs
-	tempDir, _ := ioutil.TempDir("", "logs")
-	defer os.RemoveAll(tempDir)
-	DeploymentLogger = NewDeploymentLogManager(tempDir)
-
 	ms := NewMemStore()
 	ctx := StateContext{
 		store: ms,


### PR DESCRIPTION
… run separately"

This reverts commit 7e02d486a106056d3477d1b90331f6bb3cd2c961.

@pasinskim @kacf 