### PR TITLE
MEN-806: Split poll intervals and increase to 30 min.

### DIFF
--- a/mender-default-test.conf
+++ b/mender-default-test.conf
@@ -6,7 +6,8 @@
   },
   "RootfsPartA": "/dev/mmcblk0p2",
   "RootfsPartB": "/dev/mmcblk0p3",
-  "PollIntervalSeconds": 60,
+  "UpdatePollIntervalSeconds": 1800,
+  "InventoryPollIntervalSeconds": 1800,
   "ServerURL": "",
   "ServerCertificate": ""
 }


### PR DESCRIPTION
This follows the change in f33956deab76069251.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>