### PR TITLE
MEN-480: Make sure U-Boot environment update is atomic.

### DIFF
--- a/bootenv.go
+++ b/bootenv.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -33,22 +34,41 @@ func NewEnvironment(cmd Commander) *uBootEnv {
 
 func (e *uBootEnv) ReadEnv(names ...string) (BootVars, error) {
 	getEnvCmd := e.Command("fw_printenv", names...)
-	return getOrSetEnvironmentVariable(getEnvCmd)
+	return getEnvironmentVariable(getEnvCmd)
 }
 
 func (e *uBootEnv) WriteEnv(vars BootVars) error {
-	//TODO: try to make this atomic later
+	// Make environment update atomic by using fw_setenv "-s" option.
+	setEnvCmd := e.Command("fw_setenv", "-s", "-")
+	pipe, err := setEnvCmd.StdinPipe()
+	if err != nil {
+		log.Errorln("Could not set up pipe to fw_setenv command: ", err)
+		return err
+	}
+	err = setEnvCmd.Start()
+	if err != nil {
+		log.Errorln("Could not execute fw_setenv: ", err)
+		pipe.Close()
+		return err
+	}
 	for k, v := range vars {
-		setEnvCmd := e.Command("fw_setenv", k, v)
-		if _, err := getOrSetEnvironmentVariable(setEnvCmd); err != nil {
-			log.Error("Error setting U-Boot variable: ", err)
+		_, err = fmt.Fprintf(pipe, "%s %s\n", k, v)
+		if err != nil {
+			log.Error("Error while setting U-Boot variable: ", err)
+			pipe.Close()
 			return err
 		}
+	}
+	pipe.Close()
+	err = setEnvCmd.Wait()
+	if err != nil {
+		log.Errorln("fw_setenv returned failure: ", err)
+		return err
 	}
 	return nil
 }
 
-func getOrSetEnvironmentVariable(cmd *exec.Cmd) (BootVars, error) {
+func getEnvironmentVariable(cmd *exec.Cmd) (BootVars, error) {
 	cmdReader, err := cmd.StdoutPipe()
 
 	if err != nil {

--- a/bootenv_test.go
+++ b/bootenv_test.go
@@ -67,11 +67,6 @@ func Test_EnvWrite_OSResponseError_Fails(t *testing.T) {
 	if err := fakeEnv.WriteEnv(BootVars{"bootcnt": "3"}); err == nil {
 		t.FailNow()
 	}
-
-	runner = newTestOSCalls("Cannot parse config file: No such file or directory\n", 0)
-	if err := fakeEnv.WriteEnv(BootVars{"bootcnt": "3"}); err == nil {
-		t.FailNow()
-	}
 }
 
 func Test_EnvRead_HaveVariable_ReadsVariable(t *testing.T) {

--- a/statcommander_test.go
+++ b/statcommander_test.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -58,6 +59,9 @@ func TestHelperProcessSuccess(t *testing.T) {
 	if os.Getenv("NEED_MENDER_TEST_HELPER_PROCESS") != "1" {
 		return
 	}
+
+	// Drain input if there is any.
+	_, _ = ioutil.ReadAll(os.Stdin)
 
 	//set helper process return code
 	i, err := strconv.Atoi(os.Args[3])


### PR DESCRIPTION
We need to update the environment in one operation, because otherwise
it can be in an in-between state if the device goes down unexpectedly.
The actual atomicity of the operation is ensured by U-Boot and its
redundant environment, we just need to call the right command.

One test case was removed because it's not possible to get such an
error anymore.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>