### PR TITLE
Client interval and resending improvements.

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type menderConfig struct {
 	RootfsPartB                  string
 	UpdatePollIntervalSeconds    int
 	InventoryPollIntervalSeconds int
+	RetryPollIntervalSeconds     int
 	ServerURL                    string
 	ServerCertificate            string
 	UpdateLogPath                string

--- a/mender.go
+++ b/mender.go
@@ -50,6 +50,7 @@ type Controller interface {
 	GetCurrentArtifactName() string
 	GetUpdatePollInterval() time.Duration
 	GetInventoryPollInterval() time.Duration
+	GetRetryPollInterval() time.Duration
 	HasUpgrade() (bool, menderError)
 	CheckUpdate() (*client.UpdateResponse, menderError)
 	FetchUpdate(url string) (io.ReadCloser, int64, error)
@@ -422,6 +423,15 @@ func (m mender) GetInventoryPollInterval() time.Duration {
 	if t == 0 {
 		log.Warn("InventoryPollIntervalSeconds is not defined")
 		t = 30 * time.Minute
+	}
+	return t
+}
+
+func (m mender) GetRetryPollInterval() time.Duration {
+	t := time.Duration(m.config.RetryPollIntervalSeconds) * time.Second
+	if t == 0 {
+		log.Warn("RetryPollIntervalSeconds is not defined")
+		t = 5 * time.Minute
 	}
 	return t
 }

--- a/mender.go
+++ b/mender.go
@@ -412,7 +412,7 @@ func (m mender) GetUpdatePollInterval() time.Duration {
 	t := time.Duration(m.config.UpdatePollIntervalSeconds) * time.Second
 	if t == 0 {
 		log.Warn("UpdatePollIntervalSeconds is not defined")
-		t = 5 * time.Second
+		t = 30 * time.Minute
 	}
 	return t
 }
@@ -421,7 +421,7 @@ func (m mender) GetInventoryPollInterval() time.Duration {
 	t := time.Duration(m.config.InventoryPollIntervalSeconds) * time.Second
 	if t == 0 {
 		log.Warn("InventoryPollIntervalSeconds is not defined")
-		t = 5 * time.Second
+		t = 30 * time.Minute
 	}
 	return t
 }

--- a/state.go
+++ b/state.go
@@ -591,7 +591,7 @@ func NewAuthorizeWaitState() State {
 
 func (a *AuthorizeWaitState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	log.Debugf("handle authorize wait state")
-	intvl := c.GetUpdatePollInterval()
+	intvl := c.GetRetryPollInterval()
 
 	log.Debugf("wait %v before next authorization attempt", intvl)
 	return a.StateAfterWait(bootstrappedState, a, intvl)

--- a/state.go
+++ b/state.go
@@ -773,13 +773,28 @@ func sendStatus(update client.UpdateResponse, status string, c Controller) mende
 	return c.ReportUpdateStatus(update, status)
 }
 
-var maxReportSendingTime = 5 * time.Minute
+// retry at least that many times
+var minReportSendRetries = 3
+
+// try to send failed report at lest 3 times or keep trying every
+// 'retryPollInterval' for the duration of two 'updatePollInterval'
+func maxSendingAttempts(upi, rpi time.Duration) int {
+	if rpi == 0 {
+		return minReportSendRetries
+	}
+	max := upi / rpi
+	if max <= 3 {
+		return minReportSendRetries
+	}
+	return int(max) * 2
+}
 
 func (usr *UpdateStatusReportState) trySend(send SendData, c Controller) (error, bool) {
-	poll := c.GetUpdatePollInterval()
-	maxAttempts := int(maxReportSendingTime / poll)
 
-	for usr.triesSendingReport < maxAttempts {
+	maxTrySending :=
+		maxSendingAttempts(c.GetUpdatePollInterval(), c.GetRetryPollInterval())
+	for usr.triesSendingReport < maxTrySending {
+
 		log.Infof("attempting to report data of deployment [%v] to the backend;"+
 			" deployment status [%v], try %d",
 			usr.update.ID, usr.status, usr.triesSendingReport)
@@ -793,7 +808,7 @@ func (usr *UpdateStatusReportState) trySend(send SendData, c Controller) (error,
 
 			// error reporting status or sending logs;
 			// wait for some time before trying again
-			if wc := usr.Wait(c.GetUpdatePollInterval()); wc == false {
+			if wc := usr.Wait(c.GetRetryPollInterval()); wc == false {
 				// if the waiting was interrupted don't increase triesSendingReport
 				return nil, true
 			}

--- a/state.go
+++ b/state.go
@@ -777,9 +777,6 @@ var maxReportSendingTime = 5 * time.Minute
 
 func (usr *UpdateStatusReportState) trySend(send SendData, c Controller) (error, bool) {
 	poll := c.GetUpdatePollInterval()
-	if poll == 0 {
-		poll = 5 * time.Second
-	}
 	maxAttempts := int(maxReportSendingTime / poll)
 
 	for usr.triesSendingReport < maxAttempts {

--- a/state_test.go
+++ b/state_test.go
@@ -65,6 +65,10 @@ func (s *stateTestController) GetInventoryPollInterval() time.Duration {
 	return s.pollIntvl
 }
 
+func (s *stateTestController) GetRetryPollInterval() time.Duration {
+	return s.pollIntvl
+}
+
 func (s *stateTestController) HasUpgrade() (bool, menderError) {
 	return s.hasUpgrade, s.hasUpgradeErr
 }

--- a/state_test.go
+++ b/state_test.go
@@ -34,6 +34,7 @@ type stateTestController struct {
 	bootstrapErr    menderError
 	artifactName    string
 	pollIntvl       time.Duration
+	retryIntvl      time.Duration
 	hasUpgrade      bool
 	hasUpgradeErr   menderError
 	state           State
@@ -66,7 +67,7 @@ func (s *stateTestController) GetInventoryPollInterval() time.Duration {
 }
 
 func (s *stateTestController) GetRetryPollInterval() time.Duration {
-	return s.pollIntvl
+	return s.retryIntvl
 }
 
 func (s *stateTestController) HasUpgrade() (bool, menderError) {
@@ -281,6 +282,7 @@ func TestStateUpdateReportStatus(t *testing.T) {
 	// fails and cancel
 	sc = &stateTestController{
 		pollIntvl:   5 * time.Second,
+		retryIntvl:  1 * time.Second,
 		reportError: NewTransientError(errors.New("report failed")),
 	}
 	usr = NewUpdateStatusReportState(update, client.StatusSuccess)
@@ -297,22 +299,21 @@ func TestStateUpdateReportStatus(t *testing.T) {
 	assert.Equal(t, update, sd.UpdateInfo)
 	assert.Equal(t, client.StatusSuccess, sd.UpdateStatus)
 
-	old := maxReportSendingTime
-	maxReportSendingTime = 2 * time.Second
-
-	poll := 1 * time.Millisecond
+	poll := 5 * time.Millisecond
+	retry := 1 * time.Millisecond
 	now1 := time.Now()
 	// error sending status
 	sc = &stateTestController{
 		pollIntvl:   poll,
+		retryIntvl:  retry,
 		reportError: NewTransientError(errors.New("test error sending status")),
 	}
 	s, c = usr.Handle(&ctx, sc)
 	assert.IsType(t, s, &ReportErrorState{})
 	assert.False(t, c)
-	assert.WithinDuration(t, time.Now(), now1, 3*time.Second)
-	assert.InDelta(t, int(maxReportSendingTime/poll),
-		usr.(*UpdateStatusReportState).triesSendingReport, 100)
+	assert.WithinDuration(t, time.Now(), now1, poll*3)
+	assert.Equal(t, maxSendingAttempts(poll, retry),
+		usr.(*UpdateStatusReportState).triesSendingReport)
 
 	// error sending logs
 	now2 := time.Now()
@@ -325,8 +326,6 @@ func TestStateUpdateReportStatus(t *testing.T) {
 	assert.IsType(t, s, &ReportErrorState{})
 	assert.False(t, c)
 	assert.WithinDuration(t, now2, time.Now(), 3*time.Second)
-
-	maxReportSendingTime = old
 
 	// pretend update was aborted at the backend, but was applied
 	// successfully on the device
@@ -500,7 +499,7 @@ func TestStateAuthorizeWait(t *testing.T) {
 
 	tstart = time.Now()
 	s, c = cws.Handle(ctx, &stateTestController{
-		pollIntvl: 100 * time.Millisecond,
+		retryIntvl: 100 * time.Millisecond,
 	})
 	tend = time.Now()
 	assert.IsType(t, &BootstrappedState{}, s)
@@ -515,7 +514,7 @@ func TestStateAuthorizeWait(t *testing.T) {
 	// should finish right away
 	tstart = time.Now()
 	s, c = cws.Handle(ctx, &stateTestController{
-		pollIntvl: 100 * time.Millisecond,
+		retryIntvl: 100 * time.Millisecond,
 	})
 	tend = time.Now()
 	// canceled state should return itself
@@ -989,4 +988,11 @@ func TestStateReportError(t *testing.T) {
 
 	_, err = LoadStateData(ms)
 	assert.Equal(t, err, os.ErrNotExist)
+}
+
+func TestMaxSendingAttempts(t *testing.T) {
+	assert.Equal(t, minReportSendRetries, maxSendingAttempts(time.Second, 0*time.Second))
+	assert.Equal(t, minReportSendRetries, maxSendingAttempts(time.Second, time.Minute))
+	assert.Equal(t, 10, maxSendingAttempts(5*time.Second, time.Second))
+	assert.Equal(t, minReportSendRetries, maxSendingAttempts(time.Second, time.Second))
 }


### PR DESCRIPTION
Set the default poll interval to 30 minutes in case not configured.
Add retry poll interval configuration option and use it for re-sending auth requests and reports. 