### PR TITLE
MEN-873: Implement download retrying

### DIFF
--- a/error.go
+++ b/error.go
@@ -50,7 +50,8 @@ func (m *MenderError) Error() string {
 	return err.Error()
 }
 
-// create a new fatal error
+// Create a new fatal error.
+// Fatal errors will be reported back to the server.
 func NewFatalError(err error) menderError {
 	return &MenderError{
 		cause: err,
@@ -58,7 +59,9 @@ func NewFatalError(err error) menderError {
 	}
 }
 
-// create a new transient error
+// Create a new transient error.
+// Transient errors will normally not be reported back to the server, unless
+// they persist long enough for the client to give up.
 func NewTransientError(err error) menderError {
 	return &MenderError{
 		cause: err,


### PR DESCRIPTION
```
commit 5823e4fdb9351a9870f5e49e15bc5f715d5d4955
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Thu Dec 22 11:25:28 2016

    Improve description of error types.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 6061a3198cee05b77a1c4d17288b3a368dafdf1f
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Fri Dec 23 13:46:08 2016

    Turn CancellableState into an interface for easier testing.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 5024e5bb80a31588ca5e21134e02adb8934641d2
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Fri Dec 23 13:48:37 2016

    MEN-873: Implement download retrying.
    
    Image download is retried using a simple algorithm: Start with one
    minute and try three times, then double interval and repeat. If we
    exceed the configured poll interval, make three final attempts using
    this value and then give up.
    
    A couple of the existing tests were moved out of their original test
    functions because they are now covered by the new tests.
    
    Based on a patch by Marcin Pasinski <marcin.pasinski@mender.io>.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```