### PR TITLE
MEN-964 Wait with marking inactive partition until checking update st…

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -37,7 +37,7 @@ func InstallRootfs(device UInstaller) parser.DataHandlerFunc {
 			log.Errorf("update image installation failed: %v", err)
 			return err
 		}
-		return device.EnableUpdatedPartition()
+		return nil
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -539,6 +539,19 @@ func (u *UpdateInstallState) Handle(ctx *StateContext, c Controller) (State, boo
 		return NewFetchInstallRetryState(u, u.update, err), false
 	}
 
+	// check if update is not aborted
+	// this step is needed as installing might take a while and we might end up with
+	// proceeding with already cancelled update
+	merr = c.ReportUpdateStatus(u.update, client.StatusInstalling)
+	if merr != nil && merr.IsFatal() {
+		return NewUpdateErrorState(NewTransientError(merr.Cause()), u.update), false
+	}
+
+	// if install was successful mark inactive partition as active one
+	if err := c.EnableUpdatedPartition(); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), u.update), false
+	}
+
 	return NewRebootState(u.update), false
 }
 


### PR DESCRIPTION
…atus.

As installation step might take a while we should check is deployment
is still active after installation is done.
Only if deployment is still active we are marking inactive partition
as active one and proceeding with update.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>