### PR TITLE
MEN-964 Wait with marking inactive partition until checking update st…

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -37,7 +37,7 @@ func InstallRootfs(device UInstaller) parser.DataHandlerFunc {
 			log.Errorf("update image installation failed: %v", err)
 			return err
 		}
-		return device.EnableUpdatedPartition()
+		return nil
 	}
 }
 

--- a/rootfs.go
+++ b/rootfs.go
@@ -77,7 +77,19 @@ func doRootfs(device installer.UInstaller, args runOptionsType, dt string) error
 	}
 	tr := io.TeeReader(image, p)
 
-	return installer.Install(ioutil.NopCloser(tr), dt, device)
+	err = installer.Install(ioutil.NopCloser(tr), dt, device)
+	if err != nil {
+		log.Errorf("Installation failed: %s", err.Error())
+		return err
+	}
+
+	err = device.EnableUpdatedPartition()
+	if err != nil {
+		log.Errorf("Enabling updated partition failed: %s", err.Error())
+		return err
+	}
+
+	return nil
 }
 
 // FetchUpdateFromFile returns a byte stream of the given file, size of the file

--- a/state.go
+++ b/state.go
@@ -539,6 +539,19 @@ func (u *UpdateInstallState) Handle(ctx *StateContext, c Controller) (State, boo
 		return NewFetchInstallRetryState(u, u.update, err), false
 	}
 
+	// check if update is not aborted
+	// this step is needed as installing might take a while and we might end up with
+	// proceeding with already cancelled update
+	merr = c.ReportUpdateStatus(u.update, client.StatusInstalling)
+	if merr != nil && merr.IsFatal() {
+		return NewUpdateErrorState(NewTransientError(merr.Cause()), u.update), false
+	}
+
+	// if install was successful mark inactive partition as active one
+	if err := c.EnableUpdatedPartition(); err != nil {
+		return NewUpdateErrorState(NewTransientError(err), u.update), false
+	}
+
 	return NewRebootState(u.update), false
 }
 


### PR DESCRIPTION
…atus.

As installation step might take a while we should check is deployment
is still active after installation is done.
Only if deployment is still active we are marking inactive partition
as active one and proceeding with update.

doRootfs is only called via command line and therefore takes the
shortcut straight to updating the partition.

Based on Marcin Pasinski's original commit:
f986d4a657ae4d56823474e986e788dfb0b912c5

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>