### PR TITLE
MEN-961 Make sure rollback happens after deployment is aborted

### DIFF
--- a/state.go
+++ b/state.go
@@ -1047,10 +1047,6 @@ func (e *RebootState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	}
 
 	// we can not reach this point
-
-	// stop deployment logging
-	DeploymentLogger.Disable()
-
 	return doneState, false
 }
 
@@ -1077,8 +1073,16 @@ func (rs *RollbackState) Handle(ctx *StateContext, c Controller) (State, bool) {
 		// TODO: what can we do here
 		return NewErrorState(NewFatalError(err)), false
 	}
-	DeploymentLogger.Disable()
-	return NewRebootState(rs.update), false
+
+	log.Info("rebooting device")
+
+	if err := c.Reboot(); err != nil {
+		log.Errorf("error rebooting device: %v", err)
+		return NewErrorState(NewFatalError(err)), false
+	}
+
+	// we can not reach this point
+	return doneState, false
 }
 
 type FinalState struct {

--- a/state_test.go
+++ b/state_test.go
@@ -1091,7 +1091,7 @@ func TestStateRollback(t *testing.T) {
 	assert.False(t, c)
 
 	s, c = rs.Handle(nil, &stateTestController{})
-	assert.IsType(t, &RebootState{}, s)
+	assert.IsType(t, &FinalState{}, s)
 	assert.False(t, c)
 }
 


### PR DESCRIPTION
This is changing rollback state to perform reboot itself, instead of
switching to reboot state. The reason is we are storing state
information in reboot state and we are checking if deployment is valid.
In case of aborted deployment, which was correctly detected after
device was rebooted we've been entering rollback and then reboot state.
As deployment was aborted instead of continuing with reboot we
reported error and went back to error and then init state.
No rollback happened in this scenario.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>