### PR TITLE
MEN-939: Include standard certificate authorities in client cert pool.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -158,7 +158,11 @@ func loadServerTrust(conf Config) (*x509.CertPool, error) {
 		return nil, nil
 	}
 
-	certs := x509.NewCertPool()
+	certs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
 	// Read certificate file.
 	cacert, err := ioutil.ReadFile(conf.ServerCert)
 	if err != nil {


### PR DESCRIPTION
This is in order for 3rd party download servers to work, such as S3,
which will not have custom certificates.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>