### PR TITLE
MEN-1126 Implement writing to UBI block devices in Mender client

### DIFF
--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -16,6 +16,7 @@ b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  vendor/github.
 402f39eed8a1851385d0703999aa9f23d067c2ea3e15c63c074e389cbf8f8f8f  vendor/github.com/stretchr/testify/LICENSE
 402f39eed8a1851385d0703999aa9f23d067c2ea3e15c63c074e389cbf8f8f8f  vendor/github.com/stretchr/testify/LICENCE.txt
 fde7d610b9b95fc5a6304055c4dae951025b630aaa42a24e95ebf76675ae832c  vendor/github.com/stretchr/objx/LICENSE.md
+ffa15bdce332058a03a1d923910864fb6e58bf6df66a0e3914284725b327183e  vendor/github.com/ungerik/go-sysfs/LICENSE
 #
 # These are identical to BSD 3 Clause license.
 2eb550be6801c1ea434feba53bf6d12e7c71c90253e0a9de4a4f46cf88b56477  vendor/github.com/pmezard/go-difflib/LICENSE

--- a/block_device.go
+++ b/block_device.go
@@ -34,9 +34,10 @@ type BlockDeviceGetSectorSizeFunc func(file *os.File) (int, error)
 // BlockDevice is a low-level wrapper for a block device. The wrapper implements
 // io.Writer and io.Closer interfaces.
 type BlockDevice struct {
-	Path string               // device path, ex. /dev/mmcblk0p1
-	out  *os.File             // os.File for writing
-	w    *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
+	Path    string               // device path, ex. /dev/mmcblk0p1
+	out     *os.File             // os.File for writing
+	w       *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
+	typeUBI bool                 // Set to true if we are updating an UBI volume
 }
 
 // Write writes data `p` to underlying block device. Will automatically open

--- a/block_device.go
+++ b/block_device.go
@@ -34,10 +34,11 @@ type BlockDeviceGetSectorSizeFunc func(file *os.File) (int, error)
 // BlockDevice is a low-level wrapper for a block device. The wrapper implements
 // io.Writer and io.Closer interfaces.
 type BlockDevice struct {
-	Path    string               // device path, ex. /dev/mmcblk0p1
-	out     *os.File             // os.File for writing
-	w       *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
-	typeUBI bool                 // Set to true if we are updating an UBI volume
+	Path      string               // device path, ex. /dev/mmcblk0p1
+	out       *os.File             // os.File for writing
+	w         *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
+	typeUBI   bool                 // Set to true if we are updating an UBI volume
+	ImageSize int64                // image size
 }
 
 // Write writes data `p` to underlying block device. Will automatically open

--- a/device.go
+++ b/device.go
@@ -91,7 +91,7 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		inactivePartition = filepath.Join("/dev", inactivePartition)
 	}
 
-	b := &BlockDevice{Path: inactivePartition, typeUBI: typeUBI)
+	b := &BlockDevice{Path: inactivePartition, typeUBI: typeUBI, ImageSize: size}
 
 	if bsz, err := b.Size(); err != nil {
 		log.Errorf("failed to read size of block device %s: %v",

--- a/device.go
+++ b/device.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"io"
+	"path/filepath"
 	"strconv"
 	"syscall"
 
@@ -78,7 +79,19 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		return err
 	}
 
-	b := &BlockDevice{Path: inactivePartition}
+	typeUBI := isUbiBlockDevice(inactivePartition)
+	if typeUBI {
+		// UBI block devices are not prefixed with /dev due to the fact
+		// that the kernel root= argument does not handle UBI block
+		// devices which are prefixed with /dev
+		//
+		// Kernel root= only accepts:
+		// - ubi0_0
+		// - ubi:rootfsa
+		inactivePartition = filepath.Join("/dev", inactivePartition)
+	}
+
+	b := &BlockDevice{Path: inactivePartition, typeUBI: typeUBI)
 
 	if bsz, err := b.Size(); err != nil {
 		log.Errorf("failed to read size of block device %s: %v",

--- a/device_test.go
+++ b/device_test.go
@@ -98,7 +98,9 @@ func Test_installUpdate_existingAndNonInactivePartition(t *testing.T) {
 	image.Seek(0, 0)
 
 	old := BlockDeviceGetSizeOf
+	oldSectorSizeOf := BlockDeviceGetSectorSizeOf
 	BlockDeviceGetSizeOf = func(file *os.File) (uint64, error) { return uint64(len(imageContent)), nil }
+	BlockDeviceGetSectorSizeOf = func(file *os.File) (int, error) { return int(len(imageContent)), nil }
 
 	if err := testDevice.InstallUpdate(image, int64(len(imageContent))); err != nil {
 		t.FailNow()
@@ -109,6 +111,7 @@ func Test_installUpdate_existingAndNonInactivePartition(t *testing.T) {
 		t.FailNow()
 	}
 	BlockDeviceGetSizeOf = old
+	BlockDeviceGetSectorSizeOf = oldSectorSizeOf
 }
 
 func Test_FetchUpdate_existingAndNonExistingUpdateFile(t *testing.T) {

--- a/ioctl.go
+++ b/ioctl.go
@@ -32,6 +32,10 @@ type ioctlRequestValue uintptr
 
 var NotABlockDevice = errors.New("Not a block device.")
 
+func isUbiBlockDevice(deviceName string) bool {
+	return sysfs.Class.Object("ubi").SubObject(deviceName).Exists()
+}
+
 func setUbiUpdateVolume(file *os.File, imageSize int64) error {
 	err := ioctlWrite(file.Fd(), UBI_IOCVOLUP, imageSize)
 	if err != nil {

--- a/ioctl.go
+++ b/ioctl.go
@@ -49,6 +49,15 @@ func ioctl(fd uintptr, request ioctlRequestValue) (uint64, error) {
 	return response, nil
 }
 
+func getBlockDeviceSectorSize(file *os.File) (int, error) {
+	sectorSize, err := ioctl(file.Fd(), BLKSSZGET)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(sectorSize), nil
+}
+
 func getBlockDeviceSize(file *os.File) (uint64, error) {
 	blkSize, err := ioctl(file.Fd(), BLKGETSIZE64)
 	if err != nil {

--- a/ioctl.go
+++ b/ioctl.go
@@ -32,6 +32,15 @@ type ioctlRequestValue uintptr
 
 var NotABlockDevice = errors.New("Not a block device.")
 
+func setUbiUpdateVolume(file *os.File, imageSize int64) error {
+	err := ioctlWrite(file.Fd(), UBI_IOCVOLUP, imageSize)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func getUbiDeviceSectorSize(file *os.File) (int, error) {
 	dev := strings.TrimPrefix(file.Name(), "/dev/")
 

--- a/ioctl_32_bit.go
+++ b/ioctl_32_bit.go
@@ -16,6 +16,8 @@
 
 package main
 
+// Taken from <mtd/ubi-user.h>
+const UBI_IOCVOLUP ioctlRequestValue = 0x40084f00
 
 // Taken from <linux/fs.h>
 const BLKSSZGET ioctlRequestValue = 0x00001268

--- a/ioctl_32_bit.go
+++ b/ioctl_32_bit.go
@@ -16,5 +16,9 @@
 
 package main
 
+
+// Taken from <linux/fs.h>
+const BLKSSZGET ioctlRequestValue = 0x00001268
+
 // Taken from <sys/mount.h>
 const BLKGETSIZE64 ioctlRequestValue = 0x80041272

--- a/ioctl_64_bit.go
+++ b/ioctl_64_bit.go
@@ -16,5 +16,9 @@
 
 package main
 
+
+// Taken from <linux/fs.h>
+const BLKSSZGET ioctlRequestValue = 0x00001268
+
 // Taken from <sys/mount.h>
 const BLKGETSIZE64 ioctlRequestValue = 0x80081272

--- a/ioctl_64_bit.go
+++ b/ioctl_64_bit.go
@@ -16,6 +16,8 @@
 
 package main
 
+// Taken from <mtd/ubi-user.h>
+const UBI_IOCVOLUP ioctlRequestValue = 0x40084f00
 
 // Taken from <linux/fs.h>
 const BLKSSZGET ioctlRequestValue = 0x00001268

--- a/vendor/github.com/ungerik/go-sysfs/LICENSE
+++ b/vendor/github.com/ungerik/go-sysfs/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Erik Unger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ungerik/go-sysfs/README.md
+++ b/vendor/github.com/ungerik/go-sysfs/README.md
@@ -1,0 +1,4 @@
+go-sysfs
+========
+
+Go package for Linux sysfs

--- a/vendor/github.com/ungerik/go-sysfs/attribute.go
+++ b/vendor/github.com/ungerik/go-sysfs/attribute.go
@@ -1,0 +1,246 @@
+package sysfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type Attribute struct {
+	Path string
+	File *os.File
+}
+
+func (attrib *Attribute) Exists() bool {
+	return fileExists(attrib.Path)
+}
+
+func (attrib *Attribute) Open() (err error) {
+	attrib.File, err = os.OpenFile(attrib.Path, os.O_RDWR|syscall.O_NONBLOCK, 0660)
+	return err
+}
+
+func (attrib *Attribute) OpenRO() (err error) {
+	attrib.File, err = os.OpenFile(attrib.Path, os.O_RDONLY|syscall.O_NONBLOCK, 0666)
+	return err
+}
+
+func (attrib *Attribute) Close() (err error) {
+	err = attrib.File.Close()
+	attrib.File = nil
+	return err
+}
+
+func (attrib *Attribute) Ioctl(request, arg uintptr) (result uintptr, errno syscall.Errno, err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	result, _, errno = syscall.Syscall(syscall.SYS_IOCTL, attrib.File.Fd(), request, arg)
+	return result, errno, err
+}
+
+func (attrib *Attribute) Read() (str string, err error) {
+	if attrib.File == nil {
+		err = attrib.OpenRO()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	data, err := ioutil.ReadAll(attrib.File)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (attrib *Attribute) Write(value string) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	_, err = attrib.File.WriteString(value)
+	return err
+}
+
+func (attrib *Attribute) Print(value interface{}) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	_, err = fmt.Fprint(attrib.File, value)
+	return err
+}
+
+func (attrib *Attribute) Scan(value interface{}) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	_, err = fmt.Fscan(attrib.File, value)
+	return err
+}
+
+func (attrib *Attribute) Printf(format string, args ...interface{}) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	_, err = fmt.Fprintf(attrib.File, format, args...)
+	return err
+}
+
+func (attrib *Attribute) Scanf(format string, args ...interface{}) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	_, err = fmt.Fscanf(attrib.File, format, args...)
+	return err
+}
+
+func (attrib *Attribute) ReadBytes() (data []byte, err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	attrib.File.Seek(0, os.SEEK_SET)
+	return ioutil.ReadAll(attrib.File)
+}
+
+func (attrib *Attribute) WriteBytes(data []byte) (err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	_, err = attrib.File.WriteAt(data, 0)
+	return err
+}
+
+func (attrib *Attribute) ReadByte() (value byte, err error) {
+	if attrib.File == nil {
+		err = attrib.Open()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	data := make([]byte, 1)
+	_, err = attrib.File.ReadAt(data, 0)
+	return data[0], err
+}
+
+func (attrib *Attribute) WriteByte(value byte) (err error) {
+	return attrib.WriteBytes([]byte{value})
+}
+
+func (attrib *Attribute) ReadInt() (value int, err error) {
+	s, err := attrib.Read()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(s)
+}
+
+func (attrib *Attribute) ReadUint64() (value uint64, err error) {
+	s, err := attrib.Read()
+	if err != nil {
+		return 0, err
+	}
+
+	s = strings.TrimSpace(s)
+
+	return strconv.ParseUint(s, 10, 64)
+}
+
+func (attrib *Attribute) WriteInt(value int) (err error) {
+	return attrib.Write(strconv.Itoa(value))
+}
+
+func (attrib *Attribute) WriteUint64(value uint64) (err error) {
+	return attrib.Write(strconv.FormatUint(value, 10))
+}

--- a/vendor/github.com/ungerik/go-sysfs/object.go
+++ b/vendor/github.com/ungerik/go-sysfs/object.go
@@ -1,0 +1,42 @@
+package sysfs
+
+import (
+	// "os"
+	"strings"
+)
+
+type Object string
+
+func (obj Object) Exists() bool {
+	return dirExists(string(obj))
+}
+
+func (obj Object) Name() string {
+	return string(obj)[strings.LastIndex(string(obj), "/")+1:]
+}
+
+func (obj Object) SubObjects() []Object {
+	path := string(obj) + "/"
+	objects := make([]Object, 0)
+	lsDirs(path, func(name string) {
+		objects = append(objects, Object(path+name))
+	})
+	return objects
+}
+
+func (obj Object) SubObject(name string) Object {
+	return Object(string(obj) + "/" + name)
+}
+
+func (obj Object) Attributes() []Attribute {
+	path := string(obj) + "/"
+	attribs := make([]Attribute, 0)
+	lsFiles(path, func(name string) {
+		attribs = append(attribs, Attribute{Path: path + name})
+	})
+	return attribs
+}
+
+func (obj Object) Attribute(name string) *Attribute {
+	return &Attribute{Path: string(obj) + "/" + name}
+}

--- a/vendor/github.com/ungerik/go-sysfs/subsystem.go
+++ b/vendor/github.com/ungerik/go-sysfs/subsystem.go
@@ -1,0 +1,28 @@
+package sysfs
+
+import (
+// "os"
+)
+
+type Subsystem string
+
+func (subsys Subsystem) Exists() bool {
+	return dirExists(string(subsys))
+}
+
+func (subsys Subsystem) Name() string {
+	return string(subsys)[5:]
+}
+
+func (subsys Subsystem) Objects() []Object {
+	path := string(subsys) + "/"
+	objects := make([]Object, 0)
+	lsDirs(path, func(name string) {
+		objects = append(objects, Object(path+name))
+	})
+	return objects
+}
+
+func (subsys Subsystem) Object(name string) Object {
+	return Object(string(subsys) + "/" + name)
+}

--- a/vendor/github.com/ungerik/go-sysfs/sysfs.go
+++ b/vendor/github.com/ungerik/go-sysfs/sysfs.go
@@ -1,0 +1,70 @@
+package sysfs
+
+import (
+	"os"
+)
+
+var (
+	Block       Subsystem = "/sys/block"
+	Bus         Subsystem = "/sys/bus"
+	Class       Subsystem = "/sys/class"
+	Dev         Subsystem = "/sys/dev"
+	Devices     Subsystem = "/sys/devices"
+	Firmware    Subsystem = "/sys/firmware"
+	FS          Subsystem = "/sys/fs"
+	Hypervision Subsystem = "/sys/hypervisor"
+	Kernel      Subsystem = "/sys/kernel"
+	Module      Subsystem = "/sys/module"
+	Power       Subsystem = "/sys/power"
+)
+
+// func exists(filename string) bool {
+// 	_, err := os.Stat(filename)
+// 	return err == nil
+// }
+
+func dirExists(dirname string) bool {
+	info, err := os.Stat(dirname)
+	return err == nil && info.IsDir()
+}
+
+func fileExists(dirname string) bool {
+	info, err := os.Stat(dirname)
+	return err == nil && !info.IsDir()
+}
+
+func lsFiles(dir string, callback func(name string)) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fileInfos, err := f.Readdir(-1)
+	if err != nil {
+		return err
+	}
+	for i := range fileInfos {
+		if !fileInfos[i].IsDir() {
+			callback(fileInfos[i].Name())
+		}
+	}
+	return nil
+}
+
+func lsDirs(dir string, callback func(name string)) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fileInfos, err := f.Readdir(-1)
+	if err != nil {
+		return err
+	}
+	for i := range fileInfos {
+		if fileInfos[i].IsDir() {
+			callback(fileInfos[i].Name())
+		}
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -139,6 +139,12 @@
 			"revisionTime": "2016-06-15T09:26:46Z"
 		},
 		{
+			"checksumSHA1": "S1/Ypfn5uVhGb/kEsgbwcQvhv0Q=",
+			"path": "github.com/ungerik/go-sysfs",
+			"revision": "9c991ee656202cc7089e2221b6bda2be1683b45f",
+			"revisionTime": "2017-04-24T07:48:47Z"
+		},
+		{
 			"checksumSHA1": "fE6q0joUMXfdulb+72U1p1BDAik=",
 			"path": "golang.org/x/net/http2",
 			"revision": "fb93926129b8ec0056f2f458b1f519654814edf0",


### PR DESCRIPTION
Note that I changed the title in regard what MEN-1126 says in the Mender tracker. I believe that this tittle better describes what is done.

The implementation was written trying to be generic, that is we do not need any "extra" information in the Mender artifact to determinate if we are flashing an UBI or SD/MMC block device. 

This has been tested on my Colibri VF61 in standalone mode only. But I wanted to put it out there to get some feedback. 

I have also tested running this version of the Mender client on my Raspberry Pi which also seems to work. But more testing is certainly required before this is merged, hopefully this pull request will trigger some tests and I will see what I have broken :).

I pulled in a new dependency (go-sysfs) and this could probably be discussed. I felt that I did not need to re-invent the wheel when there was a package that did what I wanted, though we do not use "that much" but could also be useful moving forward with UBI support since all information about UBI is in sysfs. I am also not sure if I added the new dependency in `vendor`correctly but I guess you will let me know.

Eager to get your feedback and to continue with the work of adding UBI support.

(Be gently, golang was completely to me :))


