### PR TITLE
MEN-1181 Do not install artifact if signature is missing.

### DIFF
--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -73,6 +73,18 @@ func TestInstallSigned(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestInstallNoSignature(t *testing.T) {
+	art, err := MakeRootfsImageArtifact(2, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, art)
+
+	// image does not contain signature
+	err = Install(art, "vexpress-qemu", []byte(PublicRSAKey), new(fDevice))
+	assert.Error(t, err)
+	assert.Contains(t, errors.Cause(err).Error(),
+		"missing artifact signature")
+}
+
 type fDevice struct{}
 
 func (d *fDevice) InstallUpdate(io.ReadCloser, int64) error { return nil }

--- a/rootfs.go
+++ b/rootfs.go
@@ -78,7 +78,8 @@ func doRootfs(device installer.UInstaller, args runOptionsType, dt string) error
 	tr := io.TeeReader(image, p)
 
 	// get the public key if provided
-	var key = make([]byte, 0)
+	var key []byte = nil
+
 	if args.verifyKey != nil && *args.verifyKey != "" {
 		key, err = ioutil.ReadFile(*args.verifyKey)
 		if err != nil {


### PR DESCRIPTION
If there is a verification key present, but the artifact signature
is missing do not install artifact.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>