### PR TITLE
MEN-1195 Use verification key location from configuration file.

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,6 @@ type runOptionsType struct {
 	config         *string
 	dataStore      *string
 	imageFile      *string
-	verifyKey      *string
 	commit         *bool
 	bootstrap      *bool
 	daemon         *bool
@@ -106,8 +105,6 @@ func argsParse(args []string) (runOptionsType, error) {
 	imageFile := parsing.String("rootfs", "",
 		"Root filesystem URI to use for update. Can be either a local "+
 			"file or a URL.")
-	verifyKey := parsing.String("key", "", "Path to the public key for verifying "+
-		"artifact if signed.")
 
 	daemon := parsing.Bool("daemon", false, "Run as a daemon.")
 
@@ -132,7 +129,6 @@ func argsParse(args []string) (runOptionsType, error) {
 		config:         config,
 		dataStore:      data,
 		imageFile:      imageFile,
-		verifyKey:      verifyKey,
 		commit:         commit,
 		bootstrap:      bootstrap,
 		daemon:         daemon,
@@ -410,7 +406,8 @@ func doMain(args []string) error {
 
 	case *runOptions.imageFile != "":
 		dt := GetDeviceType(defaultDeviceTypeFile)
-		return doRootfs(device, runOptions, dt)
+		vKey := config.GetVerificationKey()
+		return doRootfs(device, runOptions, dt, vKey)
 
 	case *runOptions.commit:
 		return device.CommitUpdate()

--- a/rootfs.go
+++ b/rootfs.go
@@ -28,7 +28,8 @@ import (
 )
 
 // This will be run manually from command line ONLY
-func doRootfs(device installer.UInstaller, args runOptionsType, dt string) error {
+func doRootfs(device installer.UInstaller, args runOptionsType, dt string,
+	vKey []byte) error {
 	var image io.ReadCloser
 	var imageSize int64
 	var err error
@@ -77,19 +78,7 @@ func doRootfs(device installer.UInstaller, args runOptionsType, dt string) error
 	}
 	tr := io.TeeReader(image, p)
 
-	// get the public key if provided
-	var key []byte = nil
-
-	if args.verifyKey != nil && *args.verifyKey != "" {
-		key, err = ioutil.ReadFile(*args.verifyKey)
-		if err != nil {
-			return errors.Wrapf(err,
-				"rootfs: error reading artifact verification key file: %s",
-				*args.verifyKey)
-		}
-	}
-
-	err = installer.Install(ioutil.NopCloser(tr), dt, key, device)
+	err = installer.Install(ioutil.NopCloser(tr), dt, vKey, device)
 	if err != nil {
 		log.Errorf("Installation failed: %s", err.Error())
 		return err

--- a/rootfs_test.go
+++ b/rootfs_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_doManualUpdate_noParams_fail(t *testing.T) {
-	if err := doRootfs(new(device), runOptionsType{}, ""); err == nil {
+	if err := doRootfs(new(device), runOptionsType{}, "", nil); err == nil {
 		t.FailNow()
 	}
 }
@@ -36,7 +36,7 @@ func Test_doManualUpdate_invalidHttpsClientConfig_updateFails(t *testing.T) {
 	runOptions.imageFile = &iamgeFileName
 	runOptions.ServerCert = "non-existing"
 
-	if err := doRootfs(new(device), runOptions, ""); err == nil {
+	if err := doRootfs(new(device), runOptions, "", nil); err == nil {
 		t.FailNow()
 	}
 }
@@ -47,7 +47,7 @@ func Test_doManualUpdate_nonExistingFile_fail(t *testing.T) {
 	imageFileName := "non-existing"
 	fakeRunOptions.imageFile = &imageFileName
 
-	if err := doRootfs(&fakeDevice, fakeRunOptions, ""); err == nil {
+	if err := doRootfs(&fakeDevice, fakeRunOptions, "", nil); err == nil {
 		t.FailNow()
 	}
 }
@@ -58,7 +58,7 @@ func Test_doManualUpdate_networkUpdateNoClient_fail(t *testing.T) {
 	imageFileName := "http://non-existing"
 	fakeRunOptions.imageFile = &imageFileName
 
-	if err := doRootfs(&fakeDevice, fakeRunOptions, ""); err == nil {
+	if err := doRootfs(&fakeDevice, fakeRunOptions, "", nil); err == nil {
 		t.FailNow()
 	}
 }
@@ -78,14 +78,14 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 			NoVerify:   false,
 		}
 
-	if err := doRootfs(&fakeDevice, fakeRunOptions, ""); err == nil {
+	if err := doRootfs(&fakeDevice, fakeRunOptions, "", nil); err == nil {
 		t.FailNow()
 	}
 }
 
 func Test_doManualUpdate_installFailing_updateFails(t *testing.T) {
-	fakeDevice := fakeDevice{}
-	fakeDevice.retInstallUpdate = errors.New("")
+	fd := fakeDevice{}
+	fd.retInstallUpdate = errors.New("")
 	fakeRunOptions := runOptionsType{}
 	imageFileName := "imageFile"
 	fakeRunOptions.imageFile = &imageFileName
@@ -98,7 +98,7 @@ func Test_doManualUpdate_installFailing_updateFails(t *testing.T) {
 
 	defer os.Remove("imageFile")
 
-	if err := doRootfs(fakeDevice, fakeRunOptions, ""); err == nil {
+	if err := doRootfs(fd, fakeRunOptions, "", nil); err == nil {
 		t.FailNow()
 	}
 }
@@ -125,6 +125,6 @@ func Test_doManualUpdate_existingFile_updateSuccess(t *testing.T) {
 	imageFileName := f.Name()
 	fakeRunOptions.imageFile = &imageFileName
 
-	err = doRootfs(dev, fakeRunOptions, "vexpress-qemu")
+	err = doRootfs(dev, fakeRunOptions, "vexpress-qemu", nil)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Remove command line parameter specifying the location of the
artifact signature verification key and use the value stored
in configuration file instead.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>