### PR TITLE
remove lingering client certificate code

### DIFF
--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -98,7 +98,7 @@ func TestClientAuth(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_inventory_test.go
+++ b/client/client_inventory_test.go
@@ -44,7 +44,7 @@ func TestInventoryClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_log_test.go
+++ b/client/client_log_test.go
@@ -44,7 +44,7 @@ func TestLogUploadClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_status_test.go
+++ b/client/client_status_test.go
@@ -44,7 +44,7 @@ func TestStatusClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestHttpClient(t *testing.T) {
 	cl, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, cl)
 
@@ -37,9 +37,9 @@ func TestHttpClient(t *testing.T) {
 	cl, err = NewApiClient(Config{})
 	assert.NotNil(t, cl)
 
-	// incomplete config should yield an error
+	// missing cert in config should yield an error
 	cl, err = NewApiClient(
-		Config{"foobar", "client.key", "", true, false},
+		Config{"missing.crt", true, false},
 	)
 	assert.Nil(t, cl)
 	assert.NotNil(t, err)
@@ -47,7 +47,7 @@ func TestHttpClient(t *testing.T) {
 
 func TestApiClientRequest(t *testing.T) {
 	cl, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, cl)
 
@@ -103,7 +103,7 @@ func TestClientConnectionTimeout(t *testing.T) {
 	}()
 
 	cl, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -174,7 +174,7 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -199,7 +199,7 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -223,7 +223,7 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -249,7 +249,7 @@ func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -272,7 +272,7 @@ func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -295,7 +295,7 @@ func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{"client.crt", "client.key", "server.crt", true, false},
+		Config{"server.crt", true, false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/config.go
+++ b/config.go
@@ -79,8 +79,6 @@ func readConfigFile(config interface{}, fileName string) error {
 
 func (c menderConfig) GetHttpConfig() client.Config {
 	return client.Config{
-		CertFile:   c.HttpsClient.Certificate,
-		CertKey:    c.HttpsClient.Key,
 		ServerCert: c.ServerCertificate,
 		IsHttps:    c.ClientProtocol == "https",
 		NoVerify:   c.HttpsClient.SkipVerify,

--- a/main.go
+++ b/main.go
@@ -109,8 +109,6 @@ func argsParse(args []string) (runOptionsType, error) {
 	daemon := parsing.Bool("daemon", false, "Run as a daemon.")
 
 	// add bootstrap related command line options
-	certFile := parsing.String("certificate", "", "Client certificate")
-	certKey := parsing.String("cert-key", "", "Client certificate's private key")
 	serverCert := parsing.String("trusted-certs", "", "Trusted server certificates")
 	forcebootstrap := parsing.Bool("forcebootstrap", false, "Force bootstrap")
 	skipVerify := parsing.Bool("skipverify", false, "Skip certificate verification")
@@ -134,8 +132,6 @@ func argsParse(args []string) (runOptionsType, error) {
 		daemon:         daemon,
 		bootstrapForce: forcebootstrap,
 		Config: client.Config{
-			CertFile:   *certFile,
-			CertKey:    *certKey,
 			ServerCert: *serverCert,
 			NoVerify:   *skipVerify,
 		},

--- a/mender.conf.example
+++ b/mender.conf.example
@@ -1,11 +1,11 @@
 {
   "ClientProtocol": "http",
   "HttpsClient": {
-    "Certificate": "",
-    "Key": ""
+    "SkipVerify": true
   },
   "PollIntervalSeconds": 60,
   "ServerCertificate": "",
-  "ServerURL": "localhost:9080"
+  "ServerURL": "localhost:9080",
+  "ArtifactVerifyKey": "/path/to/key.pub"
 }
 

--- a/rootfs_test.go
+++ b/rootfs_test.go
@@ -71,8 +71,6 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 
 	fakeRunOptions.Config =
 		client.Config{
-			CertFile:   "client.crt",
-			CertKey:    "client.key",
 			ServerCert: "server.crt",
 			IsHttps:    true,
 			NoVerify:   false,


### PR DESCRIPTION
Changelog: remove no longer referenced client certifate code
Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>

See: MEN-1292