### PR TITLE
installer: improve incompatible image error message

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -68,7 +68,8 @@ func Install(art io.ReadCloser, dt string, key []byte, device UInstaller) error 
 				return nil
 			}
 		}
-		return errors.New("installer: image not compatible with device")
+		return errors.Errorf("installer: image (device types %v) not compatible with device %v",
+			devices, dt)
 	}
 
 	// VerifySignatureCallback needs to be registered both for

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -37,7 +37,7 @@ func TestInstall(t *testing.T) {
 	err = Install(art, "fake-device", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(),
-		"image not compatible with device")
+		"not compatible with device fake-device")
 
 	art, err = MakeRootfsImageArtifact(1, false)
 	assert.NoError(t, err)
@@ -62,7 +62,7 @@ func TestInstallSigned(t *testing.T) {
 	err = Install(art, "fake-device", []byte(PublicRSAKey), new(fDevice))
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(),
-		"image not compatible with device")
+		"not compatible with device fake-device")
 
 	// installation successful
 	art, err = MakeRootfsImageArtifact(2, true)


### PR DESCRIPTION
Include image device types and own device type in an error thrown when image is
incompatible with the device.

@kacf @pasinskim @oleorhagen @GregorioDiStefano 