### PR TITLE
Removed the DeviceKey option in menderConfig.

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,7 +24,6 @@ import (
 
 type menderConfig struct {
 	ClientProtocol    string
-	DeviceKey         string
 	ArtifactVerifyKey string
 	HttpsClient       struct {
 		Certificate string
@@ -49,12 +48,6 @@ func LoadConfig(configFile string) (*menderConfig, error) {
 		// Use default configuration.
 		log.Infof("Error loading configuration from file: %s (%s)", configFile, err.Error())
 		return nil, err
-	}
-
-	if confFromFile.DeviceKey == "" {
-		log.Infof("device key path not configured, fallback to default %s",
-			defaultKeyFile)
-		confFromFile.DeviceKey = defaultKeyFile
 	}
 
 	return &confFromFile, nil

--- a/config_test.go
+++ b/config_test.go
@@ -36,21 +36,6 @@ var testConfig = `{
   "UpdateLogPath": "/var/lib/mender/log/deployment.log"
 }`
 
-var testConfigDevKey = `{
-  "ClientProtocol": "https",
-  "DeviceKey": "/foo/bar",
-  "HttpsClient": {
-    "Certificate": "/data/client.crt",
-    "Key": "/data/client.key"
-  },
-  "RootfsPartA": "/dev/mmcblk0p2",
-  "RootfsPartB": "/dev/mmcblk0p3",
-  "PollIntervalSeconds": 60,
-  "ServerURL": "mender.io",
-	"ServerCertificate": "/var/lib/mender/server.crt",
-  "UpdateLogPath": "/var/lib/mender/log/deployment.log"
-}`
-
 var testBrokenConfig = `{
   "ClientProtocol": "https",
   "HttpsClient": {
@@ -85,7 +70,6 @@ func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
 func validateConfiguration(t *testing.T, actual *menderConfig) {
 	expectedConfig := menderConfig{
 		ClientProtocol: "https",
-		DeviceKey:      defaultKeyFile,
 		HttpsClient: struct {
 			Certificate string
 			Key         string
@@ -120,16 +104,4 @@ func Test_loadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 	assert.NotNil(t, config)
 
 	validateConfiguration(t, config)
-}
-
-func Test_loadConfig_correctConfFile_returnsConfigurationDeviceKey(t *testing.T) {
-	configFile, _ := os.Create("mender.config")
-	defer os.Remove("mender.config")
-
-	configFile.WriteString(testConfigDevKey)
-
-	config, err := LoadConfig("mender.config")
-	assert.NoError(t, err)
-	assert.NotNil(t, config)
-	assert.Equal(t, "/foo/bar", config.DeviceKey)
 }

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func commonInit(config *menderConfig, opts *runOptionsType) (*MenderPieces, erro
 		return nil, errors.Wrapf(err, "failed to load tenant token")
 	}
 
-	ks := getKeyStore(*opts.dataStore, config.DeviceKey)
+	ks := getKeyStore(*opts.dataStore, defaultKeyFile)
 	if ks == nil {
 		return nil, errors.New("failed to setup key storage")
 	}

--- a/mender_test.go
+++ b/mender_test.go
@@ -103,11 +103,8 @@ func newTestMender(runner *testOSCalls, config menderConfig, pieces testMenderPi
 	}
 
 	if pieces.authMgr == nil {
-		if config.DeviceKey == "" {
-			config.DeviceKey = "devkey"
-		}
 
-		ks := store.NewKeystore(pieces.store, config.DeviceKey)
+		ks := store.NewKeystore(pieces.store, defaultKeyFile)
 
 		cmdr := newTestOSCalls("mac=foobar", 0)
 		pieces.authMgr = NewAuthManager(AuthManagerConfig{
@@ -131,9 +128,7 @@ func Test_ForceBootstrap(t *testing.T) {
 	// generate valid keys
 	ms := store.NewMemStore()
 	mender := newTestMender(nil,
-		menderConfig{
-			DeviceKey: "temp.key",
-		},
+		menderConfig{},
 		testMenderPieces{
 			MenderPieces: MenderPieces{
 				store: ms,
@@ -144,7 +139,7 @@ func Test_ForceBootstrap(t *testing.T) {
 	merr := mender.Bootstrap()
 	assert.NoError(t, merr)
 
-	kdataold, err := ms.ReadAll("temp.key")
+	kdataold, err := ms.ReadAll(defaultKeyFile)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, kdataold)
 
@@ -156,7 +151,7 @@ func Test_ForceBootstrap(t *testing.T) {
 	assert.NoError(t, merr)
 
 	// bootstrap should have generated a new key
-	kdatanew, err := ms.ReadAll("temp.key")
+	kdatanew, err := ms.ReadAll(defaultKeyFile)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, kdatanew)
 	// we should have a new key
@@ -165,9 +160,7 @@ func Test_ForceBootstrap(t *testing.T) {
 
 func Test_Bootstrap(t *testing.T) {
 	mender := newTestMender(nil,
-		menderConfig{
-			DeviceKey: "temp.key",
-		},
+		menderConfig{},
 		testMenderPieces{},
 	)
 
@@ -176,7 +169,7 @@ func Test_Bootstrap(t *testing.T) {
 	assert.NoError(t, mender.Bootstrap())
 
 	mam, _ := mender.authMgr.(*MenderAuthManager)
-	k := store.NewKeystore(mam.store, "temp.key")
+	k := store.NewKeystore(mam.store, defaultKeyFile)
 	assert.NotNil(t, k)
 	assert.NoError(t, k.Load())
 }
@@ -185,15 +178,13 @@ func Test_BootstrappedHaveKeys(t *testing.T) {
 
 	// generate valid keys
 	ms := store.NewMemStore()
-	k := store.NewKeystore(ms, "temp.key")
+	k := store.NewKeystore(ms, defaultKeyFile)
 	assert.NotNil(t, k)
 	assert.NoError(t, k.Generate())
 	assert.NoError(t, k.Save())
 
 	mender := newTestMender(nil,
-		menderConfig{
-			DeviceKey: "temp.key",
-		},
+		menderConfig{},
 		testMenderPieces{
 			MenderPieces: MenderPieces{
 				store: ms,


### PR DESCRIPTION
DeviceKey file is now a constant set in the source code.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>