### PR TITLE
Added retry-later functionality on top of the state-script functionality 

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,16 +32,18 @@ type menderConfig struct {
 		Key         string
 		SkipVerify  bool
 	}
-	RootfsPartA                  string
-	RootfsPartB                  string
-	UpdatePollIntervalSeconds    int
-	InventoryPollIntervalSeconds int
-	RetryPollIntervalSeconds     int
-	StateScriptTimeoutSeconds    int
-	ServerURL                    string
-	ServerCertificate            string
-	UpdateLogPath                string
-	TenantToken                  string
+	RootfsPartA                     string
+	RootfsPartB                     string
+	UpdatePollIntervalSeconds       int
+	InventoryPollIntervalSeconds    int
+	RetryPollIntervalSeconds        int
+	StateScriptTimeoutSeconds       int
+	StateScriptRetryTimeoutSeconds  int
+	StateScriptRetryIntervalSeconds int
+	ServerURL                       string
+	ServerCertificate               string
+	UpdateLogPath                   string
+	TenantToken                     string
 }
 
 func LoadConfig(configFile string) (*menderConfig, error) {

--- a/mender.go
+++ b/mender.go
@@ -221,6 +221,8 @@ func NewMender(config menderConfig, pieces MenderPieces) (*mender, error) {
 		RootfsScriptsPath:       defaultRootfsScriptsPath,
 		SupportedScriptVersions: []int{2},
 		Timeout:                 config.StateScriptTimeoutSeconds,
+		RetryTimeout:            config.StateScriptRetryIntervalSeconds,
+		RetryInterval:           config.StateScriptRetryTimeoutSeconds,
 	}
 
 	m := &mender{
@@ -535,7 +537,7 @@ func shouldTransit(from, to State) bool {
 
 func TransitionError(s State, action string) State {
 	me := NewTransientError(errors.New("error executing state script"))
-	log.Errorf("will transit to error state form: %s [%s]",
+	log.Errorf("will transit to error state from: %s [%s]",
 		s.Id().String(), s.Transition().String())
 	switch t := s.(type) {
 	case *UpdateFetchState:

--- a/state.go
+++ b/state.go
@@ -132,7 +132,7 @@ import (
 //                           (daemon exit)
 //
 
-// state context carrying over data that may be used by all state handlers
+// StateContext carrying over data that may be used by all state handlers
 type StateContext struct {
 	// data store access
 	store                store.Store


### PR DESCRIPTION
For now, a retry later will stop the main execution thread with a
time.Sleep for a default, or user-configured interval.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>

