### PR TITLE
MEN-1511: Implement download resume feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 # Golang version matrix
 go:
     # use the same version as available in oe-meta-go
-    - 1.7.3
+    - 1.8.4
 
 env:
     global:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ get-tools:
 check: test extracheck
 
 test:
-	$(GO) test -v $(PKGS)
+	$(GO) test $(BUILDV) $(PKGS)
 
 extracheck:
 	echo "-- checking if code is gofmt'ed"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -193,3 +193,64 @@ func TestEmptySystemCertPool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotZero(t, certs)
 }
+
+func TestExponentialBackoffTimeCalculation(t *testing.T) {
+	// Test with one minute maximum interval.
+	intvl, err := GetExponentialBackoffTime(0, 1*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(1, 1*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(2, 1*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(3, 1*time.Minute)
+	assert.Error(t, err)
+
+	intvl, err = GetExponentialBackoffTime(7, 1*time.Minute)
+	assert.Error(t, err)
+
+	// Test with two minute maximum interval.
+	intvl, err = GetExponentialBackoffTime(5, 2*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 2*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(6, 2*time.Minute)
+	assert.Error(t, err)
+
+	// Test with 10 minute maximum interval.
+	intvl, err = GetExponentialBackoffTime(11, 10*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 8*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(12, 10*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 10*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(14, 10*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 10*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(15, 10*time.Minute)
+	assert.Error(t, err)
+
+	// Test with one second maximum interval.
+	intvl, err = GetExponentialBackoffTime(0, 1*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(1, 1*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(2, 1*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, intvl, 1*time.Minute)
+
+	intvl, err = GetExponentialBackoffTime(3, 1*time.Second)
+	assert.Error(t, err)
+}

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -257,7 +258,7 @@ func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
 	client := NewUpdate()
 	assert.NotNil(t, client)
 
-	_, _, err = client.FetchUpdate(ac, ts.URL)
+	_, _, err = client.FetchUpdate(ac, ts.URL, 1*time.Minute)
 	assert.Error(t, err)
 }
 
@@ -280,7 +281,7 @@ func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
 	client := NewUpdate()
 	assert.NotNil(t, client)
 
-	_, _, err = client.FetchUpdate(ac, "broken-request")
+	_, _, err = client.FetchUpdate(ac, "broken-request", 1*time.Minute)
 	assert.Error(t, err)
 }
 
@@ -304,7 +305,7 @@ func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
 	assert.NotNil(t, client)
 	client.minImageSize = 1
 
-	_, _, err = client.FetchUpdate(ac, ts.URL)
+	_, _, err = client.FetchUpdate(ac, ts.URL, 1*time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -316,7 +317,7 @@ func Test_UpdateApiClientError(t *testing.T) {
 	assert.Error(t, err)
 
 	_, _, err = client.FetchUpdate(NewMockApiClient(nil, errors.New("foo")),
-		"http://foo.bar")
+		"http://foo.bar", 1*time.Minute)
 	assert.Error(t, err)
 }
 

--- a/client/update_resumer.go
+++ b/client/update_resumer.go
@@ -1,0 +1,175 @@
+// Copyright 2017 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type UpdateResumer struct {
+	stream        io.ReadCloser
+	apiReq        ApiRequester
+	req           *http.Request
+	offset        int64
+	contentLength int64
+	retryAttempts int
+	maxWait       time.Duration
+}
+
+// Note: It is important that nothing has been read from the stream yet.
+func NewUpdateResumer(stream io.ReadCloser,
+	contentLength int64,
+	maxWait time.Duration,
+	apiReq ApiRequester,
+	req *http.Request) *UpdateResumer {
+
+	return &UpdateResumer{
+		stream:        stream,
+		apiReq:        apiReq,
+		req:           req,
+		contentLength: contentLength,
+		maxWait:       maxWait,
+	}
+}
+
+func (h *UpdateResumer) Read(buf []byte) (int, error) {
+	origOffset := h.offset
+	for {
+		bytesRead, err := h.stream.Read(buf[h.offset-origOffset:])
+		if bytesRead > 0 {
+			h.offset += int64(bytesRead)
+		}
+		if err == nil ||
+			h.offset <= 0 ||
+			(err == io.EOF && h.offset >= h.contentLength) {
+
+			return int(h.offset - origOffset), err
+		}
+
+		// If we get here we have unexpected EOF, either an actual unexpected
+		// EOF, or a normal EOF, but with an unexpected number of bytes. This is
+		// a sign that we should try to resume from the same position.
+
+		h.req.Header.Set("Range", fmt.Sprintf("bytes=%d-", h.offset))
+
+		var res *http.Response
+		for {
+			log.Errorf("Download connection broken: %s", err.Error())
+
+			waitTime, err := GetExponentialBackoffTime(h.retryAttempts, h.maxWait)
+			if err != nil {
+				return int(h.offset - origOffset),
+					errors.Wrapf(err, "Cannot resume download")
+			}
+
+			log.Infof("Resuming download in %s", waitTime.String())
+			h.retryAttempts += 1
+
+			time.Sleep(waitTime)
+
+			log.Infof("Attempting to resume artifact download from offset %d", h.offset)
+
+			res, err = h.apiReq.Do(h.req)
+			if err != nil {
+				log.Infof("Download resume request failed: %s", err.Error())
+				continue
+			}
+
+			stream, err := h.getStreamFromPartialContent(res)
+			if err != nil {
+				continue
+			}
+
+			h.stream = stream
+			break
+		}
+
+		// Repeat from the top.
+	}
+}
+
+func (h *UpdateResumer) getStreamFromPartialContent(res *http.Response) (io.ReadCloser, error) {
+	var err error
+
+	if h.offset > 0 && res.StatusCode != http.StatusPartialContent {
+		return nil, fmt.Errorf("Could not resume download from offset %d. HTTP status code: %s",
+			h.offset, res.Status)
+	}
+
+	hRangeStr := res.Header.Get("Content-Range")
+	log.Debugf("Content-Range received from server: '%s'", hRangeStr)
+	if !strings.HasPrefix(hRangeStr, "bytes ") {
+		return nil, fmt.Errorf("HTTP server returned garbled or missing range: '%s'", hRangeStr)
+	}
+	hRangeStr = strings.TrimSpace(hRangeStr[len("bytes "):])
+
+	hRangePosAndSize := strings.Split(hRangeStr, "/")
+	if len(hRangePosAndSize) > 2 {
+		return nil, fmt.Errorf("Unexpected Content-Range received from server: %s", hRangeStr)
+	} else if len(hRangePosAndSize) == 2 {
+		var sizeFromServer int64
+		sizeFromServer, err = strconv.ParseInt(hRangePosAndSize[1], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP server returned garbled or missing range: '%s'", hRangeStr)
+		} else if sizeFromServer != h.contentLength {
+			return nil, fmt.Errorf("Size of artifact changed after download was resumed "+
+				"(expected %d, got %d)", h.contentLength, sizeFromServer)
+		}
+		// Intentional fallthrough. Response does not have to contain
+		// the total size after '/'.
+	}
+	hRangeStartAndEnd := strings.Split(hRangePosAndSize[0], "-")
+	if len(hRangeStartAndEnd) != 2 {
+		return nil, fmt.Errorf("Invalid Content-Range returned by server: '%s'", hRangeStr)
+	}
+
+	var newOffset int64
+	newOffset, err = strconv.ParseInt(hRangeStartAndEnd[0], 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "HTTP server returned garbled range: %s", hRangeStr)
+	}
+
+	if newOffset > h.offset {
+		return nil, fmt.Errorf("HTTP server did not return expected range. Expected %d, got %d",
+			h.offset, newOffset)
+	} else if newOffset < h.offset {
+		// Server gave us an offset which is earlier than we asked.
+		// Consume input to get back where we were.
+		bytesRead, err := io.CopyN(ioutil.Discard, res.Body, h.offset-newOffset)
+		if err == io.ErrUnexpectedEOF {
+			// Treat this specifically to force a retry in the outer function.
+			return nil, err
+		} else if err != nil || bytesRead != h.offset-newOffset {
+			return nil, errors.Wrapf(err,
+				"Could not resume download, unable to catch up to offset %d from offset %d",
+				h.offset, newOffset)
+		}
+		// Intentional fallthrough to end.
+	}
+
+	return res.Body, nil
+}
+
+func (h *UpdateResumer) Close() error {
+	return h.stream.Close()
+}

--- a/client/update_resumer_test.go
+++ b/client/update_resumer_test.go
@@ -1,0 +1,360 @@
+// Copyright 2017 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testHandler struct {
+	t    *testing.T
+	addr string
+
+	brokenContentLength     bool
+	missingContentLength    bool
+	earlyRangeStart         bool
+	lateRangeStart          bool
+	noPartialContentSupport bool
+	customContentRange      string
+	missingContentRange     bool
+	garbledContentStart     bool
+	breakAfterShortRange    bool
+	serverDownAfter         time.Duration
+	serverUpAgainAfter      time.Duration
+
+	success bool
+}
+
+func (h *testHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	t := h.t
+
+	hRangeStr := req.Header.Get("Range")
+	var code int
+	var pos int64
+	var err error
+
+	f, err := os.Open("update_resumer_test.go")
+	assert.NoError(t, err)
+	stat, err := f.Stat()
+	assert.NoError(t, err)
+	size := stat.Size()
+
+	if len(hRangeStr) > 0 && !h.noPartialContentSupport {
+		code = http.StatusPartialContent
+		assert.True(t, strings.HasPrefix(hRangeStr, "bytes="))
+		hRange := strings.Split(hRangeStr[len("bytes="):], "-")
+		assert.Equal(t, 2, len(hRange))
+		pos, err = strconv.ParseInt(hRange[0], 10, 64)
+		assert.NoError(t, err)
+		if h.earlyRangeStart {
+			pos -= 5
+		} else if h.lateRangeStart {
+			pos += 5
+		}
+		if h.missingContentRange {
+			res.Header().Set("Content-Range", "")
+		} else if h.customContentRange != "" {
+			res.Header().Set("Content-Range", h.customContentRange)
+		} else if h.missingContentLength {
+			res.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d", pos, size-1))
+		} else if h.garbledContentStart {
+			res.Header().Set("Content-Range", fmt.Sprintf("bytes abc-%d/%d", size-1, size))
+		} else {
+			if h.brokenContentLength {
+				size -= 1
+			}
+			res.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", pos, size-1, size))
+		}
+	} else {
+		code = http.StatusOK
+		pos = 0
+	}
+
+	res.Header().Set("Content-Length", fmt.Sprintf("%d", size-pos))
+
+	_, err = f.Seek(pos, os.SEEK_SET)
+	assert.NoError(t, err)
+
+	res.WriteHeader(code)
+	// Only give some, not all, then terminate connection.
+	toCopy := size / 5
+	if h.breakAfterShortRange && len(hRangeStr) > 0 {
+		// Terminate before we even get to the part the client is
+		// interested in.
+		toCopy = 2
+		// Only do this once.
+		h.breakAfterShortRange = false
+	}
+	if toCopy > size-pos {
+		toCopy = size - pos
+	}
+	_, err = io.CopyN(res, f, toCopy)
+
+	if h.success {
+		assert.NoError(t, err)
+	}
+}
+
+func testBrokenReadAndPartialDownload_oneCase(t *testing.T, h *testHandler) {
+	t.Parallel()
+
+	var server http.Server
+	server.Addr = h.addr
+
+	server.Handler = h
+
+	f, err := os.Open("update_resumer_test.go")
+	assert.NoError(t, err)
+	expected, err := ioutil.ReadAll(f)
+	assert.NoError(t, err)
+
+	server.SetKeepAlivesEnabled(false)
+
+	go server.ListenAndServe()
+	defer server.Close()
+
+	var client http.Client
+	portAttempts := 5
+	for {
+		_, err := client.Get(fmt.Sprintf("http://localhost%s/", h.addr))
+		// Wait until port is open
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+		portAttempts -= 1
+		if portAttempts <= 0 {
+			t.Fatalf("Port %s never opened!", server.Addr)
+		}
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost%s/update_resumer_test.go", h.addr), nil)
+	assert.NoError(t, err)
+	res, err := client.Do(req)
+	assert.NoError(t, err)
+
+	contentLength, err := strconv.ParseInt(res.Header.Get("Content-Length"), 10, 64)
+	assert.NoError(t, err)
+
+	updateResumer := NewUpdateResumer(res.Body, contentLength, 3*time.Second, &client, req)
+	defer updateResumer.Close()
+
+	if h.serverDownAfter > 0 {
+		go func() {
+			time.Sleep(h.serverDownAfter)
+			server.Close()
+			if h.serverUpAgainAfter > 0 {
+				time.Sleep(h.serverUpAgainAfter)
+				server.ListenAndServe()
+			}
+		}()
+	}
+
+	actual, err := ioutil.ReadAll(updateResumer)
+	if h.success {
+		assert.NoError(t, err)
+		assert.Equal(t, string(expected), string(actual))
+	} else {
+		// Everything read up until the error should be correct.
+		assert.Equal(t, string(expected[:len(actual)]), string(actual))
+		assert.Error(t, err)
+	}
+}
+
+func testBrokenReadAndPartialDownload_group(t *testing.T) {
+	var base testHandler
+	base.t = t
+
+	{
+		h := base
+		h.addr = ":9753"
+		h.success = true
+		t.Run("success", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9754"
+		h.success = true
+		h.earlyRangeStart = true
+		t.Run("earlyRangeStart", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9755"
+		h.success = false
+		h.lateRangeStart = true
+		t.Run("lateRangeStart", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9756"
+		h.success = false
+		h.brokenContentLength = true
+		t.Run("brokenContentLength", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9757"
+		h.success = true
+		h.missingContentLength = true
+		t.Run("missingContentLength", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9758"
+		h.success = false
+		h.noPartialContentSupport = true
+		t.Run("noPartialContentSupport", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9759"
+		h.success = false
+		h.customContentRange = "bytes "
+		t.Run("emptyContentRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9760"
+		h.success = false
+		h.customContentRange = "bytes abc-def/deadbeef"
+		t.Run("formattedButInvalidContentRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9761"
+		h.success = false
+		h.customContentRange = "bytes 5"
+		t.Run("improperlyFormattedContentRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9762"
+		h.success = false
+		h.customContentRange = "5-6/2"
+		t.Run("missingBytesContentRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9763"
+		h.success = false
+		h.missingContentRange = true
+		t.Run("missingContentRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9764"
+		h.success = false
+		h.customContentRange = "bytes 5-6/20 7-8/20"
+		t.Run("tooManyContentRanges", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9765"
+		h.success = false
+		h.garbledContentStart = true
+		t.Run("garbledContentStart", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9766"
+		h.success = true
+		h.earlyRangeStart = true
+		h.breakAfterShortRange = true
+		t.Run("breakAfterShortRange", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9767"
+		h.success = true
+		h.serverDownAfter = 3 * time.Second
+		h.serverUpAgainAfter = 5 * time.Second
+		t.Run("serverDownAndUp", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+
+	{
+		h := base
+		h.addr = ":9768"
+		h.success = false
+		h.serverDownAfter = 3 * time.Second
+		t.Run("serverDown", func(t *testing.T) {
+			testBrokenReadAndPartialDownload_oneCase(t, &h)
+		})
+	}
+}
+
+func TestBrokenReadAndPartialDownload(t *testing.T) {
+	oldExponentialBackoffSmallestUnit := exponentialBackoffSmallestUnit
+	// Set this to a second to make tests go faster.
+	exponentialBackoffSmallestUnit = time.Second
+	defer func() {
+		exponentialBackoffSmallestUnit = oldExponentialBackoffSmallestUnit
+	}()
+
+	t.Run("group", testBrokenReadAndPartialDownload_group)
+}

--- a/mender.go
+++ b/mender.go
@@ -406,7 +406,7 @@ func (m *mender) doBootstrap() menderError {
 }
 
 func (m *mender) FetchUpdate(url string) (io.ReadCloser, int64, error) {
-	return m.updater.FetchUpdate(m.api, url)
+	return m.updater.FetchUpdate(m.api, url, m.GetRetryPollInterval())
 }
 
 // Check if new update is available. In case of errors, returns nil and error

--- a/rootfs.go
+++ b/rootfs.go
@@ -56,7 +56,7 @@ func doRootfs(device installer.UInstaller, args runOptionsType, dt string,
 
 		log.Debug("Client initialized. Start downloading image.")
 
-		image, imageSize, err = upclient.FetchUpdate(ac, updateLocation)
+		image, imageSize, err = upclient.FetchUpdate(ac, updateLocation, 0)
 		log.Debugf("Image downloaded: %d [%v] [%v]", imageSize, image, err)
 	} else {
 		// perform update from local file

--- a/state_test.go
+++ b/state_test.go
@@ -784,67 +784,6 @@ func TestStateUpdateFetch(t *testing.T) {
 	assert.IsType(t, &UpdateStatusReportState{}, s)
 }
 
-func TestRetryIntervalCalculation(t *testing.T) {
-	// Test with one minute maximum interval.
-	intvl, err := getFetchStoreRetry(0, 1*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(1, 1*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(2, 1*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(3, 1*time.Minute)
-	assert.Error(t, err)
-
-	intvl, err = getFetchStoreRetry(7, 1*time.Minute)
-	assert.Error(t, err)
-
-	// Test with two minute maximum interval.
-	intvl, err = getFetchStoreRetry(5, 2*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 2*time.Minute)
-
-	intvl, err = getFetchStoreRetry(6, 2*time.Minute)
-	assert.Error(t, err)
-
-	// Test with 10 minute maximum interval.
-	intvl, err = getFetchStoreRetry(11, 10*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 8*time.Minute)
-
-	intvl, err = getFetchStoreRetry(12, 10*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 10*time.Minute)
-
-	intvl, err = getFetchStoreRetry(14, 10*time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 10*time.Minute)
-
-	intvl, err = getFetchStoreRetry(15, 10*time.Minute)
-	assert.Error(t, err)
-
-	// Test with one second maximum interval.
-	intvl, err = getFetchStoreRetry(0, 1*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(1, 1*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(2, 1*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, intvl, 1*time.Minute)
-
-	intvl, err = getFetchStoreRetry(3, 1*time.Second)
-	assert.Error(t, err)
-}
-
 func TestStateUpdateFetchRetry(t *testing.T) {
 	// pretend we have an update
 	update := client.UpdateResponse{


### PR DESCRIPTION
This implements the ability of the client to resume download if the
connection is broken for any reason. It does this by replacing the
socket reader with a custom reader object that keeps track of the read
offset, and if it is broken at any point, the download is
reestablished at the same point and reading continues.

This requires some custom parsing of the 'Content-Range' header, since
Go does not have this support natively on the client side. We
primarily need the offset that the server gives us back, with some
surrounding code to check for sanity of the returned header. All
according to HTTP spec.

One weakness of this method is that it is not possible to abort the
update and have the client notice this in the middle of the download,
even if the connection is broken. But this would require changing
state to check for deployment status, which would be quite hard to do
while an update is in progress mid-stream. Not impossible, but a lot
of work, and it was deemed out of scope for this initial feature. It's
also no worse than it was before, since you cannot currently abort an
update mid-download either.

Changelog: Fix 'unexpected EOF' error when downloading large updates.

Changelog: Implement ability for client to resume a download from
where it left off if the connection is broken.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>