### PR TITLE
MEN-1620 Remove trailing slash from server URL configuration.

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"strings"
 
 	"github.com/mendersoftware/log"
 	"github.com/mendersoftware/mender/client"
@@ -54,6 +55,10 @@ func LoadConfig(configFile string) (*menderConfig, error) {
 		// Use default configuration.
 		log.Infof("Error loading configuration from file: %s (%s)", configFile, err.Error())
 		return nil, err
+	}
+
+	if strings.HasSuffix(confFromFile.ServerURL, "/") {
+		confFromFile.ServerURL = strings.TrimSuffix(confFromFile.ServerURL, "/")
 	}
 
 	return &confFromFile, nil

--- a/config_test.go
+++ b/config_test.go
@@ -105,3 +105,14 @@ func Test_loadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 
 	validateConfiguration(t, config)
 }
+
+func TestServerURLConfig(t *testing.T) {
+	configFile, _ := os.Create("mender.config")
+	defer os.Remove("mender.config")
+
+	configFile.WriteString(`{"ServerURL": "https://mender.io/"}`)
+
+	config, err := LoadConfig("mender.config")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://mender.io", config.ServerURL)
+}


### PR DESCRIPTION
If the server URL contains trailing slash it is impossible to
make valid requests to the server. This commit is removing slash
form configuration parameter if there is one.

Changelog: Title

Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>