### PR TITLE
Do not set missing token to "authtentoken". 

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,8 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultTenantToken = "authtentoken"
-
 type menderConfig struct {
 	ClientProtocol    string
 	ArtifactVerifyKey string
@@ -103,10 +101,7 @@ func (c menderConfig) GetDeploymentLogLocation() string {
 // GetTenantToken returns a default tenant-token if
 // no custom token is set in local.conf
 func (c menderConfig) GetTenantToken() []byte {
-	if c.TenantToken != "" {
-		return []byte(c.TenantToken)
-	}
-	return []byte(defaultTenantToken)
+	return []byte(c.TenantToken)
 }
 
 func (c menderConfig) GetVerificationKey() []byte {


### PR DESCRIPTION
This was originally meant to be a file, but we have moved away from
that, and it is now a string from the config file. Hence empty string
is the correct string if missing.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>