### PR TITLE
mender-device-identity: Check if file exists before reading

### DIFF
--- a/support/mender-device-identity
+++ b/support/mender-device-identity
@@ -30,6 +30,10 @@ ifdev=
 
 # find iface with lowest ifindex, skip non ARPHRD_ETHER types (lo, sit ...)
 for dev in $SCN/*; do
+    if [ ! -f "$dev/type" ]; then
+        continue
+    fi
+
     iftype=$(cat $dev/type)
     if [ $iftype -ne $arphrd_ether ]; then
         continue


### PR DESCRIPTION
Mender on oragepi fails to run because identty script exit with error like:
/usr/share/mender/identity/mender-device-identity
cat: can't open '/sys/class/net/bonding_masters/type': Not a directory

Add check before reading type to avoid problems.

Changelog: Commit

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>