### PR TITLE
title MEN-1726 FIXED: Deployment logger now calls fsync

### DIFF
--- a/deployment_logger.go
+++ b/deployment_logger.go
@@ -42,7 +42,7 @@ type FileLogger struct {
 // just before logging is started
 func NewFileLogger(name string) *FileLogger {
 	// open log file
-	logFile, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	logFile, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0600)
 	if err != nil {
 		// if we can not open file for logging; return nil
 		return nil


### PR DESCRIPTION
changelog: FIXED: Log is writes syncronously to flash

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>