### PR TITLE
FIXED: MEN-1854: HTTP error 401 is not handled by all states

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -30,6 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func dummy() (AuthToken, error) {
+	return AuthToken(""), errors.New("")
+}
 func TestHttpClient(t *testing.T) {
 	cl, err := NewApiClient(
 		Config{"server.crt", true, false},
@@ -54,7 +58,7 @@ func TestApiClientRequest(t *testing.T) {
 	)
 	assert.NotNil(t, cl)
 
-	req := cl.Request("foobar")
+	req := cl.Request("foobar", dummy)
 	assert.NotNil(t, req)
 
 	responder := &struct {
@@ -111,7 +115,7 @@ func TestClientConnectionTimeout(t *testing.T) {
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)
 
-	req := cl.Request("foobar")
+	req := cl.Request("foobar", dummy)
 	assert.NotNil(t, req)
 
 	hreq, err := http.NewRequest(http.MethodGet, ts.URL, nil)

--- a/deployment_logger.go
+++ b/deployment_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ type FileLogger struct {
 // just before logging is started
 func NewFileLogger(name string) *FileLogger {
 	// open log file
-	logFile, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	logFile, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0600)
 	if err != nil {
 		// if we can not open file for logging; return nil
 		return nil

--- a/mender_test.go
+++ b/mender_test.go
@@ -537,6 +537,7 @@ func TestMenderReportStatus(t *testing.T) {
 
 	// 3. pretend that deployment was aborted
 	srv.Reset()
+	srv.Auth.Authorize = true
 	srv.Auth.Token = []byte("tokendata")
 	srv.Auth.Verify = true
 	srv.Status.Aborted = true


### PR DESCRIPTION
The responsecode for each http api-requests is explicitly checked and handles 401 by issuing for a new JWT token.

changelog: title
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>