### PR TITLE
FIXED: MEN-1854: HTTP error 401 is not handled by all states

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -30,6 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func dummy() (AuthToken, error) {
+	return AuthToken(""), errors.New("")
+}
 func TestHttpClient(t *testing.T) {
 	cl, err := NewApiClient(
 		Config{"server.crt", true, false},
@@ -54,7 +58,7 @@ func TestApiClientRequest(t *testing.T) {
 	)
 	assert.NotNil(t, cl)
 
-	req := cl.Request("foobar")
+	req := cl.Request("foobar", dummy)
 	assert.NotNil(t, req)
 
 	responder := &struct {
@@ -111,7 +115,7 @@ func TestClientConnectionTimeout(t *testing.T) {
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)
 
-	req := cl.Request("foobar")
+	req := cl.Request("foobar", dummy)
 	assert.NotNil(t, req)
 
 	hreq, err := http.NewRequest(http.MethodGet, ts.URL, nil)

--- a/mender_test.go
+++ b/mender_test.go
@@ -537,6 +537,7 @@ func TestMenderReportStatus(t *testing.T) {
 
 	// 3. pretend that deployment was aborted
 	srv.Reset()
+	srv.Auth.Authorize = true
 	srv.Auth.Token = []byte("tokendata")
 	srv.Auth.Verify = true
 	srv.Status.Aborted = true


### PR DESCRIPTION
The responsecode for each http api-requests is explicitly checked and handles 401 by issuing for a new JWT token.
Also added fsync flag to deployment logger.

changelog: title
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>
(cherry picked from commit 732a0ae67b82902c5ac48ddd24081d592e58b6c5)