### PR TITLE
MEN-1972 Failover servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 mender
+
+# Go test coverage output
+*coverage*.txt

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -31,9 +31,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func dummy() (AuthToken, error) {
+func dummy_reauthfunc() (AuthToken, error) {
 	return AuthToken(""), errors.New("")
 }
+
+func dummy_srvMngmntFunc() string {
+	return ""
+}
+
 func TestHttpClient(t *testing.T) {
 	cl, err := NewApiClient(
 		Config{"server.crt", true, false},
@@ -58,7 +63,7 @@ func TestApiClientRequest(t *testing.T) {
 	)
 	assert.NotNil(t, cl)
 
-	req := cl.Request("foobar", dummy)
+	req := cl.Request("foobar", dummy_srvMngmntFunc, dummy_reauthfunc)
 	assert.NotNil(t, req)
 
 	responder := &struct {
@@ -115,7 +120,7 @@ func TestClientConnectionTimeout(t *testing.T) {
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)
 
-	req := cl.Request("foobar", dummy)
+	req := cl.Request("foobar", dummy_srvMngmntFunc, dummy_reauthfunc)
 	assert.NotNil(t, req)
 
 	hreq, err := http.NewRequest(http.MethodGet, ts.URL, nil)

--- a/config_test.go
+++ b/config_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/mendersoftware/mender/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,7 +49,21 @@ var testBrokenConfig = `{
   "RootfsPartB": "/dev/mmcblk0p3",
   "PollIntervalSeconds": 60,
   "ServerURL": "mender
-	"ServerCertificate": "/var/lib/mender/server.crt"
+  "ServerCertificate": "/var/lib/mender/server.crt"
+}`
+
+var testMultipleServersConfig = `{
+    "Servers": [
+        {"ServerURL": "https://server.one/"},
+        {"ServerURL": "https://server.two/"},
+        {"ServerURL": "https://server.three/"}
+    ]
+}`
+
+var testTooManyServerDefsConfig = `{
+  "ServerURL": "mender.io",
+  "ServerCertificate": "/var/lib/mender/server.crt",
+  "Servers": [{"ServerURL": "mender.io"}]
 }`
 
 func Test_readConfigFile_noFile_returnsError(t *testing.T) {
@@ -61,12 +76,12 @@ func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
 	defer os.Remove("mender.config")
 
 	configFile.WriteString(testBrokenConfig)
-	var confFromFile menderConfig
 
-	err := readConfigFile(&confFromFile, "mender.config")
+	// fails on first call to readConfigFile (invalid JSON)
+	confFromFile, err := LoadConfig("mender.config")
 	assert.Error(t, err)
 
-	assert.Equal(t, menderConfig{}, confFromFile)
+	assert.Nil(t, confFromFile)
 }
 
 func validateConfiguration(t *testing.T, actual *menderConfig) {
@@ -88,6 +103,7 @@ func validateConfiguration(t *testing.T, actual *menderConfig) {
 		ServerURL:                    "mender.io",
 		ServerCertificate:            "/var/lib/mender/server.crt",
 		UpdateLogPath:                "/var/lib/mender/log/deployment.log",
+		Servers:                      []client.MenderServer{{ServerURL: "mender.io"}},
 	}
 	if !assert.True(t, reflect.DeepEqual(actual, &expectedConfig)) {
 		t.Logf("got:      %+v", actual)
@@ -106,6 +122,7 @@ func Test_loadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 	assert.NotNil(t, config)
 
 	validateConfiguration(t, config)
+
 }
 
 func TestServerURLConfig(t *testing.T) {
@@ -116,48 +133,33 @@ func TestServerURLConfig(t *testing.T) {
 
 	config, err := LoadConfig("mender.config")
 	assert.NoError(t, err)
-	assert.Equal(t, "https://mender.io", config.ServerURL)
+	assert.Equal(t, "https://mender.io", config.Servers[0].ServerURL)
+
+	// Not allowed to specify server(s) both as a list and string entry.
+	configFile.Seek(0, os.SEEK_SET)
+	configFile.WriteString(testTooManyServerDefsConfig)
+	config, err = LoadConfig("mender.config")
+	assert.Error(t, err)
+	assert.Nil(t, config)
 }
 
 // TestMultipleServersConfig attempts to add multiple servers to config-
-// file, as well as overriding the ServerURL / TenantToken from the first
-// server.
+// file, as well as overriding the ServerURL from the first server.
 func TestMultipleServersConfig(t *testing.T) {
 
 	// create a temporary mender.conf file
 	tdir, _ := ioutil.TempDir("", "mendertest")
 	confPath := path.Join(tdir, "mender.conf")
-	confFile, _ := os.Create(confPath)
+	confFile, err := os.Create(confPath)
 	defer os.RemoveAll(tdir)
+	assert.NoError(t, err)
 
-	confFile.WriteString(`{
-    "Servers": [
-        {
-            "ServerURL": "https://server.one/",
-            "TenantToken": "hostedTokenInc"
-        },
-        {
-            "ServerURL": "https://server.two/",
-            "TenantToken": ""
-        },
-        {
-            "ServerURL": "https://server.three/"
-        }
-    ]
-}`)
-	// load config and assert expected values i.e. check that
-	// first server is loaded as "active", and that all server
-	// URL's trailing forward slash is trimmed off.
+	confFile.WriteString(testMultipleServersConfig)
+	// load config and assert expected values i.e. check that all entries
+	// are present and URL's trailing forward slash is trimmed off.
 	conf, err := LoadConfig(confPath)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://server.one", conf.ServerURL)
-	assert.Equal(t, "hostedTokenInc", conf.TenantToken)
-
 	assert.Equal(t, "https://server.one", conf.Servers[0].ServerURL)
 	assert.Equal(t, "https://server.two", conf.Servers[1].ServerURL)
 	assert.Equal(t, "https://server.three", conf.Servers[2].ServerURL)
-
-	assert.Equal(t, "hostedTokenInc", conf.Servers[0].TenantToken)
-	assert.Equal(t, "", conf.Servers[1].TenantToken)
-	assert.Equal(t, "", conf.Servers[2].TenantToken)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/mendersoftware/log"
+	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,8 @@ func TestRunDaemon(t *testing.T) {
 	// Give the client some time to settle in the authorizeWaitState.
 	time.Sleep(time.Second * 3)
 	td.StopDaemon()
+	// Yield thread so that daemon gets a chance to run.
+	time.Sleep(time.Second * 1)
 	assert.Contains(t, buf.String(), "forced wake-up from sleep", "daemon was not forced from sleep")
 }
 
@@ -302,7 +305,7 @@ func TestMainBootstrap(t *testing.T) {
 	// setup test config
 	cpath := path.Join(tdir, "mender.config")
 	writeConfig(t, cpath, menderConfig{
-		ServerURL: ts.URL,
+		Servers: []client.MenderServer{{ServerURL: ts.URL}},
 	})
 
 	// override identity helper script


### PR DESCRIPTION
@kacf @pasinskim ;
This PR is not yet finished, but it would be nice you could take a look at it and give some feedback of what you think about the implemented mechanic. So far only status codes 4XX and 5XX from API requests trigger failover, as well as an unsuccessful authorization request.
I have extended mender.conf to contain an array entry Servers of arbitrary many servers, that contains only the server URL and an optional tenant token, but it is straight forward to extend to also contain multiple different paths for server certificates (as @kacf [mentioned](https://tracker.mender.io/browse/MEN-1972?focusedCommentId=89477&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-89477) this might not be necessary).