### PR TITLE
Add check for canary value in U-Boot environment.

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"path"
 	"strings"
 	"syscall"
 
 	"github.com/mendersoftware/log"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -206,8 +206,7 @@ func (p *partitions) getAndCacheActivePartition(rootChecker func(StatCommander, 
 func getBootEnvActivePartition(env BootEnvReadWriter) (string, error) {
 	bootEnv, err := env.ReadEnv("mender_boot_part")
 	if err != nil {
-		log.Error(err)
-		return "", ErrorNoMatchBootPartRootPart
+		return "", errors.Wrapf(err, ErrorNoMatchBootPartRootPart.Error())
 	}
 
 	return bootEnv["mender_boot_part"], nil

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -193,9 +193,8 @@ func Test_getActivePartition_noActiveInactiveSet(t *testing.T) {
 		envCaller.output = test.fakeEnv
 		envCaller.retCode = test.fakeEnvRet
 		active, err := fakePartitions.getAndCacheActivePartition(test.rootChecker, mountedDevicesGetter)
-		if err != test.expectedError || active != test.expectedActive {
-			t.Fatal(err, active)
-		}
+		errorOK := (err == test.expectedError || strings.Contains(err.Error(), test.expectedError.Error()))
+		assert.True(t, errorOK && active == test.expectedActive)
 	}
 }
 


### PR DESCRIPTION
The way it works is that we store the 'mender_check_saveenv_canary=1'
variable in the default U-Boot environment. We do not store the
corresponding 'mender_saveenv_canary=1' value in the default
environment, but instead we write this during the boot process. When
the Mender client finds the former variable, it will look for the
second value as well, and produce an error if it is not present. If
this happens it is an indication that the U-Boot boot loader and the
user space tools do not agree on the location of the environment. It
will also catch cases where mender_setup is not run.

Also reorganize the logging and error returning to include the error
when returning higher up in the callstack, otherwise the resulting log
entry is quite misleading.

Changelog: Add automatic check for canary value in U-Boot environment
to try to detect if there is a problem in the environment setup of
U-Boot and/or the u-boot-fw-utils tools.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>