### PR TITLE
FIX: Enabling compiling ppc64le

### DIFF
--- a/ioctl_64_bit.go
+++ b/ioctl_64_bit.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-// +build amd64 arm64
+// +build amd64 arm64 ppc64le
 
 package main
 


### PR DESCRIPTION
This patch enables Mender compilation on ppc64le

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>