### PR TITLE
Fall-back to environment and conf in active part probe

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -191,6 +191,20 @@ func (p *partitions) getAndCacheActivePartition(rootChecker func(StatCommander, 
 
 	activePartition, err := getRootFromMountedDevices(p, rootChecker, mountedDevices, rootDevice)
 	if err != nil {
+		// If we reach this point, we have not been able to find a match
+		// based on mounted device.
+		//
+		// Fall-back to configuration and environment only!
+		if checkBootEnvAndRootPartitionMatch(bootEnvBootPart, p.rootfsPartA) {
+			p.active = p.rootfsPartA
+			log.Debug("Setting active partition from configuration and environment: ", p.active)
+			return p.active, nil
+		}
+		if checkBootEnvAndRootPartitionMatch(bootEnvBootPart, p.rootfsPartB) {
+			p.active = p.rootfsPartB
+			log.Debug("Setting active partition from configuration and environment: ", p.active)
+			return p.active, nil
+		}
 		return "", err
 	}
 	if checkBootEnvAndRootPartitionMatch(bootEnvBootPart, activePartition) {


### PR DESCRIPTION
There are situations where it nearly impossible to find the active
root-filesystem based on probing mounted devices.

One example is this:

    /dev/root on /rom type squashfs (ro,relatime)

There is no information about the actual device device used in above
example.

One additional probe step could be parsing /proc/cmdline to find the
"root=" argument but this is essentially the same as looking at
"mender_boot_part" environment variable.

Hence we add a fall-back to only using the "mender_boot_part"
environment variable and comparing that to what we have in
"mender.conf".

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>