### PR TITLE
Upgrade to Go 1.10.3 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 # Golang version matrix
 go:
-    # use the same version as available in oe-meta-go
-    - 1.8.4
+    # use the same version as available in openembedded-core (sumo)
+    - 1.10.3
 
 env:
     global:


### PR DESCRIPTION
To match the current version we are using on release branches.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>