### PR TITLE
MEN-2073: Merge configuration settings from two files.

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/mendersoftware/log"
@@ -45,21 +46,54 @@ type menderConfig struct {
 	TenantToken                     string
 }
 
-func LoadConfig(configFile string) (*menderConfig, error) {
-	var confFromFile menderConfig
+func loadConfig(mainConfigFile string, fallbackConfigFile string) (*menderConfig, error) {
+	// Load fallback configuration first, then main configuration.
+	// It is OK if either file does not exist, so long as the other one does exist.
+	// It is also OK if both files exist.
+	// Because the main configuration is loaded last, its option values
+	// override those from the fallback file, for options present in both files.
 
-	if err := readConfigFile(&confFromFile, configFile); err != nil {
-		// Some error occured while loading config file.
-		// Use default configuration.
-		log.Infof("Error loading configuration from file: %s (%s)", configFile, err.Error())
-		return nil, err
+	var filesLoadedCount int
+	var config menderConfig
+
+	if loadErr := loadConfigFile(fallbackConfigFile, &config, &filesLoadedCount); loadErr != nil {
+		return nil, loadErr
 	}
 
-	if strings.HasSuffix(confFromFile.ServerURL, "/") {
-		confFromFile.ServerURL = strings.TrimSuffix(confFromFile.ServerURL, "/")
+	if loadErr := loadConfigFile(mainConfigFile, &config, &filesLoadedCount); loadErr != nil {
+		return nil, loadErr
 	}
 
-	return &confFromFile, nil
+	if filesLoadedCount == 0 {
+		return nil, errors.New("could not find either configuration file")
+	}
+
+	// Normalize the server URL to remove trailing slash if present.
+	if strings.HasSuffix(config.ServerURL, "/") {
+		config.ServerURL = strings.TrimSuffix(config.ServerURL, "/")
+	}
+
+	log.Infof("Merged configuration = %#v", config)
+
+	return &config, nil
+}
+
+func loadConfigFile(configFile string, config *menderConfig, filesLoadedCount *int) error {
+	// Do not treat a single config file not existing as an error here.
+	// It is up to the caller to fail when both config files don't exist.
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		log.Info("Configuration file does not exist: ", configFile)
+		return nil
+	}
+
+	if err := readConfigFile(&config, configFile); err != nil {
+		log.Errorf("Error loading configuration from file: %s (%s)", configFile, err.Error())
+		return err
+	}
+
+	(*filesLoadedCount)++
+	log.Info("Loaded configuration file: ", configFile)
+	return nil
 }
 
 func readConfigFile(config interface{}, fileName string) error {

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type logOptionsType struct {
 type runOptionsType struct {
 	version         *bool
 	config          *string
+	fallbackConfig  *string
 	dataStore       *string
 	imageFile       *string
 	runStateScripts *bool
@@ -66,6 +67,7 @@ var (
 )
 
 var defaultConfFile string = path.Join(getConfDirPath(), "mender.conf")
+var defaultFallbackConfFile string = path.Join(getStateDirPath(), "mender.conf")
 
 var DeploymentLogger *DeploymentLogManager
 
@@ -99,6 +101,9 @@ func argsParse(args []string) (runOptionsType, error) {
 
 	config := parsing.String("config", defaultConfFile,
 		"Configuration file location.")
+
+	fallbackConfig := parsing.String("fallback-config", defaultFallbackConfFile,
+		"Fallback configuration file location.")
 
 	data := parsing.String("data", defaultDataStore,
 		"Mender state data location.")
@@ -135,6 +140,7 @@ func argsParse(args []string) (runOptionsType, error) {
 	runOptions := runOptionsType{
 		version:         version,
 		config:          config,
+		fallbackConfig:  fallbackConfig,
 		dataStore:       data,
 		imageFile:       imageFile,
 		runStateScripts: forceStateScripts,
@@ -409,7 +415,7 @@ func doMain(args []string) error {
 		return err
 	}
 
-	config, err := LoadConfig(*runOptions.config)
+	config, err := loadConfig(*runOptions.config, *runOptions.fallbackConfig)
 	if err != nil {
 		return err
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Previously, Mender loaded configuration settings from a
single file on the active root partition: /etc/mender/mender.conf
Like everything else on the root partition, this config file
is replaced with each upgrade.

Let us call /etc/mender/mender.conf the "main" configuration file.
Now there is an additional "fallback" configuration file,
/var/lib/mender/mender.conf, stored on the data partition.

If a setting is in the main file, it will be used.

If a setting is not in the main file but is in the fallback
file, the fallback value will be used.

If a setting is in both files, the value from the main
file will be used.

If both files exist but a setting does not appear in either
file, it will keep its defalut value ("" for a string or
0 for an integer).

If the main file does not exist but the fallback file exists,
settings from the fallback file will be used.

If the fallback file does not exist, but the main file exists,
settings from the main file will be used (this is the same
behavior as before this code change).

If neither file exists, an error occurs and Mender stops.

After successfully loading settings, the merged values
are all available in debug output from the Mender client.

Added --fallback-config command line option to override the default
location of the fallback configuration file.

Signed-off-by: Donald D. Cross <cosinekitty@gmail.com>