### PR TITLE
MEN-2073: Merge configuration settings from two files.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -99,11 +99,15 @@ func Test_loadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 
 	configFile.WriteString(testConfig)
 
-	config, err := LoadConfig("mender.config")
+	config, err := loadConfig("mender.config", "does-not-exist.config")
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
-
 	validateConfiguration(t, config)
+
+	config2, err2 := loadConfig("does-not-exist.config", "mender.config")
+	assert.NoError(t, err2)
+	assert.NotNil(t, config2)
+	validateConfiguration(t, config2)
 }
 
 func TestServerURLConfig(t *testing.T) {
@@ -112,7 +116,48 @@ func TestServerURLConfig(t *testing.T) {
 
 	configFile.WriteString(`{"ServerURL": "https://mender.io/"}`)
 
-	config, err := LoadConfig("mender.config")
+	config, err := loadConfig("mender.config", "does-not-exist.config")
 	assert.NoError(t, err)
 	assert.Equal(t, "https://mender.io", config.ServerURL)
+}
+
+func TestConfigurationMergeSettings(t *testing.T) {
+	var mainConfigJson = `{
+		"RootfsPartA": "Eggplant",
+		"UpdatePollIntervalSeconds": 375
+	}`
+
+	var fallbackConfigJson = `{
+		"RootfsPartA": "Spinach",
+		"RootfsPartB": "Lettuce"
+	}`
+
+	mainConfigFile, _ := os.Create("main.config")
+	defer os.Remove("main.config")
+	mainConfigFile.WriteString(mainConfigJson)
+
+	fallbackConfigFile, _ := os.Create("fallback.config")
+	defer os.Remove("fallback.config")
+	fallbackConfigFile.WriteString(fallbackConfigJson)
+
+	config, err := loadConfig("main.config", "fallback.config")
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+
+	// When a setting appears in neither file, it is left with its default value.
+	assert.Equal(t, "", config.ServerCertificate)
+	assert.Equal(t, 0, config.StateScriptTimeoutSeconds)
+
+	// When a setting appears in both files, the main file takes precedence.
+	assert.Equal(t, "Eggplant", config.RootfsPartA)
+
+	// When a setting appears in only one file, its value is used.
+	assert.Equal(t, "Lettuce", config.RootfsPartB)
+	assert.Equal(t, 375, config.UpdatePollIntervalSeconds)
+}
+
+func TestConfigurationNeitherFileExistsIsError(t *testing.T) {
+	config, err := loadConfig("does-not-exist", "also-does-not-exist")
+	assert.Error(t, err)
+	assert.Nil(t, config)
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type logOptionsType struct {
 type runOptionsType struct {
 	version         *bool
 	config          *string
+	fallbackConfig  *string
 	dataStore       *string
 	imageFile       *string
 	runStateScripts *bool
@@ -66,6 +67,7 @@ var (
 )
 
 var defaultConfFile string = path.Join(getConfDirPath(), "mender.conf")
+var defaultFallbackConfFile string = path.Join(getStateDirPath(), "mender.conf")
 
 var DeploymentLogger *DeploymentLogManager
 
@@ -99,6 +101,9 @@ func argsParse(args []string) (runOptionsType, error) {
 
 	config := parsing.String("config", defaultConfFile,
 		"Configuration file location.")
+
+	fallbackConfig := parsing.String("fallback-config", defaultFallbackConfFile,
+		"Fallback configuration file location.")
 
 	data := parsing.String("data", defaultDataStore,
 		"Mender state data location.")
@@ -135,6 +140,7 @@ func argsParse(args []string) (runOptionsType, error) {
 	runOptions := runOptionsType{
 		version:         version,
 		config:          config,
+		fallbackConfig:  fallbackConfig,
 		dataStore:       data,
 		imageFile:       imageFile,
 		runStateScripts: forceStateScripts,
@@ -409,7 +415,7 @@ func doMain(args []string) error {
 		return err
 	}
 
-	config, err := LoadConfig(*runOptions.config)
+	config, err := loadConfig(*runOptions.config, *runOptions.fallbackConfig)
 	if err != nil {
 		return err
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.


### PR DESCRIPTION
MEN-2073: Merge configuration settings from two files.

Changelog: Mender client now loads configuration settings from 
both /etc/mender/mender.conf and (if it exists) 
/var/lib/mender/mender.conf. The second file is located 
on the data partition, so it allows any subset of configuration
changes to survive upgrades.

Previously, Mender loaded configuration settings from a
single file on the active root partition: /etc/mender/mender.conf
Like everything else on the root partition, this config file
is replaced with each upgrade.

Let us call /etc/mender/mender.conf the "main" configuration file.
Now there is an additional "fallback" configuration file,
/var/lib/mender/mender.conf, stored on the data partition.

If a setting is in the main file, it will be used.

If a setting is not in the main file but is in the fallback
file, the fallback value will be used.

If a setting is in both files, the value from the main
file will be used.

If both files exist but a setting does not appear in either
file, it will keep its defalut value ("" for a string or
0 for an integer).

If the main file does not exist but the fallback file exists,
settings from the fallback file will be used.

If the fallback file does not exist, but the main file exists,
settings from the main file will be used (this is the same
behavior as before this code change).

If neither file exists, an error occurs and Mender stops.

Use DEBUG severity to log final merged configuration settings.
We do not use INFO because that would expose sensitive
information (keys) by default.

Added --fallback-config command line option to override the default
location of the fallback configuration file.

Updated copyright years in config_test.go, partitions.go
to satisfy Travis CI validation.  (I don't understand
how partitions.go didn't cause a failure already.)

Signed-off-by: Don Cross <cosinekitty@gmail.com>
