### PR TITLE
MEN-2083: Improve error message when running mender as non-root user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 # Golang version matrix
 go:
     # use the same version as available in oe-meta-go
-    - 1.8.4
+    - 1.10.3
 
 env:
     global:

--- a/bootenv_test.go
+++ b/bootenv_test.go
@@ -167,3 +167,13 @@ func Test_EnvCanary(t *testing.T) {
 	err = fakeEnv.WriteEnv(BootVars{"var": "1"})
 	assert.Error(t, err)
 }
+
+func Test_PermissionDenied(t *testing.T) {
+	env := NewEnvironment(new(osCalls))
+	vars, err := env.ReadEnv("var")
+	assert.Error(t, err)
+	assert.Nil(t, vars)
+
+	err = env.WriteEnv(nil)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This ommits changing the confusing error messages produced, but clarifies the
non-root execution attempt cases.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>