### PR TITLE
[1.6.x] MEN-2152: Log whether artifact's digital signature is valid 

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ func Install(art io.ReadCloser, dt string, key []byte, scrDir string,
 		ar = areader.NewReaderSigned(art)
 	} else {
 		ar = areader.NewReader(art)
+		log.Info("no public key was provided for authenticating the artifact")
 	}
 
 	if err := ar.RegisterHandler(rootfs); err != nil {
@@ -90,7 +91,12 @@ func Install(art io.ReadCloser, dt string, key []byte, scrDir string,
 
 		// Do the verification only if the key is provided.
 		s := artifact.NewVerifier(key)
-		return s.Verify(message, sig)
+		err := s.Verify(message, sig)
+		if err == nil {
+			// MEN-2152 Provide confirmation in log that digital signature was authenticated.
+			log.Info("installer: authenticated digital signature of artifact")
+		}
+		return err
 	}
 
 	scr := statescript.NewStore(scrDir)

--- a/main.go
+++ b/main.go
@@ -534,13 +534,15 @@ func runDaemon(d *menderDaemon) error {
 }
 
 func main() {
-	if err := doMain(os.Args[1:]); err != nil && err != flag.ErrHelp {
+	if err := doMain(os.Args[1:]); err != nil {
 		var returnCode int
 		if err == errorNoUpgradeMounted {
 			log.Warnln(err.Error())
 			returnCode = 2
 		} else {
-			log.Errorln(err.Error())
+			if err != flag.ErrHelp {
+				log.Errorln(err.Error())
+			}
 			returnCode = 1
 		}
 		os.Exit(returnCode)

--- a/main.go
+++ b/main.go
@@ -419,7 +419,7 @@ func doMain(args []string) error {
 	}
 	// Do not run anything else if update-check is triggered.
 	if *runOptions.updateCheck {
-		return updateCheck(exec.Command("kill", "--signal", "SIGUSR1"), exec.Command("systemctl", "show", "-p", "MainPID", "mender"))
+		return updateCheck(exec.Command("kill", "-USR1"), exec.Command("systemctl", "show", "-p", "MainPID", "mender"))
 	}
 
 	config, err := LoadConfig(*runOptions.config)


### PR DESCRIPTION
Changelog: Print a message to the mender log when the
mender client has confirmed the authenticity of an
artifact's digital signature.

When the Mender client authenticates a downloaded
artifact's digital signature using a public key configured
by the property "ArtifactVerifyKey" in mender.conf,
it now logs the following message:
"installer: authenticated digital signature of artifact"
This allows the developer to confirm that verification
of mender.sig took place, and that this Mender client
will reject any future downloads bearing a forged signature.

When the Mender client is not configured with a public
key for authenticating downloaded artifacts, log
the following message:
"no public key was provided for authenticating the artifact"
This informs the developer that no signature verification
took place. If signature verification was intended, it
reveals something went wrong and needs to be investigated.

Signed-off-by: Don Cross <cosinekitty@gmail.com>
(cherry picked from commit efb0e6ea44f1ccdc31bb6a50a66f3d15881364c0)