### PR TITLE
FIX: Do not enter infinite loop when inventory has not been sent.

### DIFF
--- a/state.go
+++ b/state.go
@@ -802,11 +802,6 @@ func (cw *CheckWaitState) Handle(ctx *StateContext, c Controller) (State, bool) 
 	update := ctx.lastUpdateCheck.Add(c.GetUpdatePollInterval())
 	inventory := ctx.lastInventoryUpdate.Add(c.GetInventoryPollInterval())
 
-	// if we haven't sent inventory so far
-	if ctx.lastInventoryUpdate.IsZero() {
-		inventory = ctx.lastInventoryUpdate
-	}
-
 	log.Debugf("check wait state; next checks: (update: %v) (inventory: %v)",
 		update, inventory)
 
@@ -819,7 +814,8 @@ func (cw *CheckWaitState) Handle(ctx *StateContext, c Controller) (State, bool) 
 		state: updateCheckState,
 	}
 
-	if inventory.Before(update) {
+	// Give inventory updates priority.
+	if inventory.Before(update) || inventory.Equal(update) {
 		next.when = inventory
 		next.state = inventoryUpdateState
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -658,10 +658,9 @@ func TestStateUpdateCheckWait(t *testing.T) {
 	assert.IsType(t, &InventoryUpdateState{}, s)
 	assert.False(t, c)
 	assert.WithinDuration(t, tend, tstart, 15*time.Millisecond)
+	ctx.lastInventoryUpdate = tend
 
 	// now we have inventory sent; should send update request
-	ctx.lastInventoryUpdate = tend
-	ctx.lastUpdateCheck = tend
 	tstart = time.Now()
 	s, c = cws.Handle(ctx, &stateTestController{
 		pollIntvl: 10 * time.Millisecond,
@@ -670,6 +669,7 @@ func TestStateUpdateCheckWait(t *testing.T) {
 	assert.IsType(t, &UpdateCheckState{}, s)
 	assert.False(t, c)
 	assert.WithinDuration(t, tend, tstart, 15*time.Millisecond)
+	ctx.lastUpdateCheck = tend
 
 	// asynchronously cancel state operation
 	go func() {


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>