### PR TITLE
MEN-2285: Periodically Sync() when writing image to disk, don't ignore Sync() failures.

### DIFF
--- a/device.go
+++ b/device.go
@@ -137,7 +137,7 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 
 	if cerr := b.Close(); cerr != nil {
 		log.Errorf("closing device %v failed: %v", inactivePartition, cerr)
-		if err != nil {
+		if cerr != nil {
 			return cerr
 		}
 	}

--- a/device.go
+++ b/device.go
@@ -98,7 +98,12 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		inactivePartition = filepath.Join("/dev", inactivePartition)
 	}
 
-	b := &BlockDevice{Path: inactivePartition, typeUBI: typeUBI, ImageSize: size}
+	b := &BlockDevice{
+		Path:               inactivePartition,
+		typeUBI:            typeUBI,
+		ImageSize:          size,
+		FlushIntervalBytes: 4 * 1024 * 1024,
+	}
 
 	if bsz, err := b.Size(); err != nil {
 		log.Errorf("failed to read size of block device %s: %v",


### PR DESCRIPTION
See: https://tracker.mender.io/browse/MEN-2285

This PR doesn't add any new configuration items (just hardcodes `FlushIntervalBytes` to 4096), but we might want to consider allowing the `FlushIntervalBytes` to be set from the `mender.conf` file.

Also (see TODO) -- should the flushing logic be applied to UBI devices as well?  I don't know much about UBI devices.

Let me know if you have any questions.