### PR TITLE
MEN-2285: Periodically Sync() when writing image to disk, don't ignore Sync() failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: go
 
 # Golang version matrix
 go:
-    # use the same version as available in oe-meta-go
-    - 1.9.7
+    # Use a slightly newer version of Go than the one in oe-meta-go to allow
+    # test code to use newer parts of the standard library
+    - 1.10.7
 
 env:
     global:

--- a/block_device.go
+++ b/block_device.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"io"
 	"os"
 
 	"github.com/mendersoftware/log"
@@ -34,11 +35,59 @@ type BlockDeviceGetSectorSizeFunc func(file *os.File) (int, error)
 // BlockDevice is a low-level wrapper for a block device. The wrapper implements
 // io.Writer and io.Closer interfaces.
 type BlockDevice struct {
-	Path      string               // device path, ex. /dev/mmcblk0p1
-	out       *os.File             // os.File for writing
-	w         *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
-	typeUBI   bool                 // Set to true if we are updating an UBI volume
-	ImageSize int64                // image size
+	Path               string               // device path, ex. /dev/mmcblk0p1
+	out                *os.File             // os.File for writing
+	w                  *utils.LimitedWriter // wrapper for `out` limited the number of bytes written
+	typeUBI            bool                 // Set to true if we are updating an UBI volume
+	ImageSize          int64                // image size
+	FlushIntervalBytes uint64               // Force a flush to disk each time this many bytes are written
+}
+
+// A WriteSyncer is an io.Writer that also implements a Sync() function which commits written data to stable storage.
+// For instance, an os.File is a WriteSyncer.
+type WriteSyncer interface {
+	io.Writer
+	Sync() error // Commits previously-written data to stable storage.
+}
+
+// FlushingWriter is a wrapper around a WriteSyncer which forces a Sync() to occur every so many bytes.
+// FlushingWriter implements WriteSyncer.
+type FlushingWriter struct {
+	WF                    WriteSyncer
+	FlushIntervalBytes    uint64
+	unflushedBytesWritten uint64
+}
+
+// NewFlushingWriter returns a WriteSyncer which wraps the provided WriteSyncer
+// and automatically flushes (calls Sync()) each time the specified number of
+// bytes is written.
+// Setting flushIntervalBytes == 0 causes Sync() to be called after every Write().
+func NewFlushingWriter(wf WriteSyncer, flushIntervalBytes uint64) *FlushingWriter {
+	return &FlushingWriter{
+		WF:                    wf,
+		FlushIntervalBytes:    flushIntervalBytes,
+		unflushedBytesWritten: 0,
+	}
+}
+
+func (fw *FlushingWriter) Write(p []byte) (int, error) {
+	rv, err := fw.WF.Write(p)
+
+	fw.unflushedBytesWritten += uint64(rv)
+
+	if err != nil {
+		return rv, err
+	} else if fw.unflushedBytesWritten >= fw.FlushIntervalBytes {
+		err = fw.Sync()
+	}
+
+	return rv, err
+}
+
+func (fw *FlushingWriter) Sync() error {
+	err := fw.WF.Sync()
+	fw.unflushedBytesWritten = 0
+	return err
 }
 
 // Write writes data `p` to underlying block device. Will automatically open
@@ -50,6 +99,10 @@ func (bd *BlockDevice) Write(p []byte) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+
+		var wrappedOut io.Writer
+
+		wrappedOut = out
 
 		// From <mtd/ubi-user.h>
 		//
@@ -73,6 +126,8 @@ func (bd *BlockDevice) Write(p []byte) (int, error) {
 				log.Errorf("Failed to write images size to UBI_IOCVOLUP: %v", err)
 				return 0, err
 			}
+		} else {
+			wrappedOut = NewFlushingWriter(out, bd.FlushIntervalBytes)
 		}
 
 		size, err := BlockDeviceGetSizeOf(out)
@@ -85,7 +140,7 @@ func (bd *BlockDevice) Write(p []byte) (int, error) {
 
 		bd.out = out
 		bd.w = &utils.LimitedWriter{
-			W: out,
+			W: wrappedOut,
 			N: size,
 		}
 	}

--- a/chunked_copy_test.go
+++ b/chunked_copy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/chunked_copy_test.go
+++ b/chunked_copy_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type MyWriter struct {
+	writtenChunkSizes []int
+	writtenData       bytes.Buffer
+}
+
+func (mw *MyWriter) Write(data []byte) (n int, err error) {
+	mw.writtenChunkSizes = append(mw.writtenChunkSizes, len(data))
+	n, err = mw.writtenData.Write(data)
+	return
+}
+
+func (mw *MyWriter) GetTotalOutput() []byte {
+	return mw.writtenData.Bytes()
+
+}
+
+func TestChunkedCopy(t *testing.T) {
+
+	CHUNK_SIZE := int64(337)
+
+	bldr := strings.Builder{}
+
+	for i := 0; i < 1000; i++ {
+		bldr.WriteString(fmt.Sprintf("x%07d", i)) // can ignore return value
+	}
+
+	input_bytes := []byte(bldr.String())
+
+	mw := &MyWriter{}
+
+	bytes_written, err := chunkedCopy(mw, bytes.NewBuffer(input_bytes), CHUNK_SIZE) // use a strange chunk size just to prove it works
+
+	// a Copy() routine should return err == nil on EOF.
+	if err != nil {
+		t.Errorf("chunkedCopy: expected err to be nil but got: %v", err)
+	}
+
+	if int(bytes_written) != len(input_bytes) {
+		t.Errorf("chunkedCopy: did not copy full input: expected %v, got %v", len(input_bytes), bytes_written)
+	}
+
+	output_bytes := mw.GetTotalOutput()
+
+	if !bytes.Equal(output_bytes, input_bytes) {
+		t.Errorf("chunkedCopy: output did not match input")
+	}
+
+	// This is what we really want to check. All of the calls to Write (except the last) must be of size CHUNK_SIZE
+	for i := 0; i < len(mw.writtenChunkSizes)-2; i++ {
+		if mw.writtenChunkSizes[i] != int(CHUNK_SIZE) {
+			t.Errorf("chunkedCopy: writtenChunkSizes[%d] = %v, expected %v", i, mw.writtenChunkSizes[i], CHUNK_SIZE)
+		}
+	}
+
+}

--- a/chunked_copy_test.go
+++ b/chunked_copy_test.go
@@ -67,11 +67,22 @@ func TestChunkedCopy(t *testing.T) {
 		t.Errorf("chunkedCopy: output did not match input")
 	}
 
+	total_of_chunks := 0
+
 	// This is what we really want to check. All of the calls to Write (except the last) must be of size CHUNK_SIZE
 	for i := 0; i < len(mw.writtenChunkSizes)-1; i++ {
 		if mw.writtenChunkSizes[i] != int(CHUNK_SIZE) {
 			t.Errorf("chunkedCopy: writtenChunkSizes[%d] = %v, expected %v", i, mw.writtenChunkSizes[i], CHUNK_SIZE)
 		}
+		total_of_chunks += mw.writtenChunkSizes[i]
+	}
+	total_of_chunks += mw.writtenChunkSizes[len(mw.writtenChunkSizes)-1] // include last chunk in sum
+
+	if total_of_chunks != len(input_bytes) {
+		t.Errorf("chunkedCopy: sum of writtenChunkSizes (%v) does not match expected size (%v)",
+			total_of_chunks,
+			len(input_bytes),
+		)
 	}
 
 }

--- a/chunked_copy_test.go
+++ b/chunked_copy_test.go
@@ -68,7 +68,7 @@ func TestChunkedCopy(t *testing.T) {
 	}
 
 	// This is what we really want to check. All of the calls to Write (except the last) must be of size CHUNK_SIZE
-	for i := 0; i < len(mw.writtenChunkSizes)-2; i++ {
+	for i := 0; i < len(mw.writtenChunkSizes)-1; i++ {
 		if mw.writtenChunkSizes[i] != int(CHUNK_SIZE) {
 			t.Errorf("chunkedCopy: writtenChunkSizes[%d] = %v, expected %v", i, mw.writtenChunkSizes[i], CHUNK_SIZE)
 		}

--- a/device.go
+++ b/device.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/device.go
+++ b/device.go
@@ -170,7 +170,7 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 
 	if cerr := b.Close(); cerr != nil {
 		log.Errorf("closing device %v failed: %v", inactivePartition, cerr)
-		if err != nil {
+		if cerr != nil {
 			return cerr
 		}
 	}

--- a/device.go
+++ b/device.go
@@ -122,11 +122,11 @@ func chunkedCopy(out io.Writer, in io.Reader, chunkSize int64) (total_written in
 			}
 
 			if bytesWritten != bytesRead {
-				panic(fmt.Sprintf(
+				return total_written, fmt.Errorf(
 					"Unexpected short write: attempted %v bytes but only wrote %v",
 					bytesRead,
 					bytesWritten,
-				))
+				)
 			}
 		}
 

--- a/device.go
+++ b/device.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -96,6 +97,50 @@ func (d *device) SwapPartitions() error {
 	return nil
 }
 
+// chunkedCopy copies data from in to out in chunks of exactly chunkSize
+// bytes.
+// Data is held in memory until chunkSize bytes are available to be written.
+func chunkedCopy(out io.Writer, in io.Reader, chunkSize int64) (total_written int64, err error) {
+	buf := bytes.NewBuffer(make([]byte, 0, chunkSize))
+
+	total_written = 0
+
+	for {
+		buf.Reset()
+
+		// read chunkSize bytes into buf
+		bytesRead, readErr := io.CopyN(buf, in, chunkSize)
+
+		if bytesRead > 0 {
+			// write all of buf to out
+			bytesWritten, writeErr := buf.WriteTo(out)
+
+			total_written += bytesWritten
+
+			if writeErr != nil {
+				return total_written, writeErr
+			}
+
+			if bytesWritten != bytesRead {
+				panic(fmt.Sprintf(
+					"Unexpected short write: attempted %v bytes but only wrote %v",
+					bytesRead,
+					bytesWritten,
+				))
+			}
+		}
+
+		if readErr != nil {
+			// Note: readErr might be io.EOF, still return
+
+			if readErr == io.EOF {
+				readErr = nil
+			}
+			return total_written, nil
+		}
+	}
+}
+
 func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 
 	log.Debugf("Trying to install update of size: %d", size)
@@ -153,18 +198,31 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		return syscall.ENOSPC
 	}
 
-	ssz, err := b.SectorSize()
+	native_ssz, err := b.SectorSize()
 	if err != nil {
 		log.Errorf("failed to read sector size of block device %s: %v",
 			inactivePartition, err)
 		return err
 	}
 
-	// allocate buffer based on sector size and provide it for staging
-	// in io.CopyBuffer
-	buf := make([]byte, ssz)
+	// The size of an individual sector tends to be quite small.  Rather than
+	// doing a zillion small writes, do medium-size-ish writes that are still
+	// sector aligned.  (Doing too many small writes can put pressure on the
+	// DMA subsystem (unless writes are able to be coalesced) by requiring large numbers of scatter-gather descriptors to be allocated.)
+	chunk_size := native_ssz
 
-	w, err := io.CopyBuffer(b, image, buf)
+	// Pick a multiple of the sector size that's around 1 MiB.
+	for chunk_size < 1*1024*1024 {
+		chunk_size = chunk_size * 2 // avoid doing logarithms...
+	}
+
+	log.Infof("native sector size of block device %s is %v, we will write in chunks of %v",
+		inactivePartition,
+		native_ssz,
+		chunk_size,
+	)
+
+	w, err := chunkedCopy(b, image, int64(chunk_size))
 	if err != nil {
 		log.Errorf("failed to write image data to device %v: %v",
 			inactivePartition, err)

--- a/device.go
+++ b/device.go
@@ -136,7 +136,12 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		inactivePartition = filepath.Join("/dev", inactivePartition)
 	}
 
-	b := &BlockDevice{Path: inactivePartition, typeUBI: typeUBI, ImageSize: size}
+	b := &BlockDevice{
+		Path:               inactivePartition,
+		typeUBI:            typeUBI,
+		ImageSize:          size,
+		FlushIntervalBytes: 4 * 1024 * 1024,
+	}
 
 	if bsz, err := b.Size(); err != nil {
 		log.Errorf("failed to read size of block device %s: %v",


### PR DESCRIPTION
This PR supersedes #339.

See: https://tracker.mender.io/browse/MEN-2285

Testing showed that writing to the block device in increments of single sectors (512 bytes on my eMMC device) contributed the prevalence of an OOM condition in the kernel when allocating DMA scatter-gather descriptors.
    
Rather than making a zillion small writes and expecting the kernel to coalesce them for us when we're easily able put this data into already (virtually) contiguous memory in userspace, we write to the block device in "medium-size chunks" (around 1 MiB) that are a power-of-two multiple of the sector size (obviating any concerns about sector misalignment causing reduced performance or undue wear on the underlying storage).

I have verified empirically (watching the `write` syscalls through `strace`) that with these changes the writes are actually going into the kernel with the intended size (1 MiB in my case).

Without the "medium-sized writes" change (even calling `write` in increments of 32768 bytes), I still saw the OOM issue on my kernel.