### PR TITLE
Remove misleading warning message when ServerCert is missing.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -307,9 +307,8 @@ type Config struct {
 
 func loadServerTrust(conf Config) (*x509.CertPool, error) {
 	if conf.ServerCert == "" {
-		// TODO: this is for pre-production version only to simplify tests.
-		// Make sure to remove in production version.
-		log.Warn("Server certificate not provided. Trusting all servers.")
+		// Returning nil will make tls.Config.RootCAs nil, which causes
+		// tls module to use system certs.
 		return nil, nil
 	}
 


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>