### PR TITLE
Enable coverage reports for sub packages as well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ htmlcover: coverage
 
 coverage:
 	rm -f coverage.txt
-	$(GO) test -coverprofile=coverage.txt ./...
+	$(GO) test -coverprofile=coverage.txt -coverpkg=github.com/mendersoftware/... ./...
 
 .PHONY: build clean get-tools test check \
 	cover htmlcover coverage

--- a/block_device.go
+++ b/block_device.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is important for us since some packages are being mainly tested
by being included in higher level package code.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 37afcbb9a143e9884b6619328b66ab1c1256fa10)