### PR TITLE
MEN-2302: Only resolve symlinks in /dev/disk/by-partuuid.

### DIFF
--- a/device.go
+++ b/device.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ func NewDevice(env BootEnvReadWriter, sc StatCommander, config deviceConfig) *de
 	partitions := partitions{
 		StatCommander:     sc,
 		BootEnvReadWriter: env,
-		rootfsPartA:       resolveLink(config.rootfsPartA),
-		rootfsPartB:       resolveLink(config.rootfsPartB),
+		rootfsPartA:       maybeResolveLink(config.rootfsPartA),
+		rootfsPartB:       maybeResolveLink(config.rootfsPartB),
 		active:            "",
 		inactive:          "",
 	}


### PR DESCRIPTION
Changelog: Mender no longer misidentifies LVM volumes.

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>