### PR TITLE
Don't push network interfaces without a mac address to inventory

### DIFF
--- a/support/mender-inventory-network
+++ b/support/mender-inventory-network
@@ -37,7 +37,9 @@ for devpath in $SCN/*; do
     if [ $dev = "lo" ]; then
         continue
     fi
-    echo "mac_$dev=$(cat $devpath/address)"
+    if ! [ "x$(cat $devpath/address)x" = "xx" ]; then
+    	echo "mac_$dev=$(cat $devpath/address)"
+    fi
     echo "network_interfaces=$dev"
 
     ip addr show dev $dev | awk -v dev=$dev '


### PR DESCRIPTION
Some network interfaces may not have a mac address (e.g. CAN adapters). If these are pushed to the hosted mender backend it returns a 400-error and nothing is written to the inventory.