### PR TITLE
Fix File Install UM to not wipe out dest_dir on single file installs

### DIFF
--- a/support/modules-artifact-gen/file-install-artifact-gen
+++ b/support/modules-artifact-gen/file-install-artifact-gen
@@ -124,6 +124,10 @@ esac
 single_file=""
 if [ -e "${file_tree}" ]; then
   if [ -d "${file_tree}" ]; then
+    if [ "$dest_dir" == "/" ]; then
+      echo "Error: this Update Module does not support file tree deployment at /"
+      exit 1
+    fi
     tar -cf ${update_files_tar} -C "${file_tree}" .
     single_file="false"
   elif [ -f "${file_tree}" ]; then

--- a/support/modules-artifact-gen/file-install-artifact-gen
+++ b/support/modules-artifact-gen/file-install-artifact-gen
@@ -38,6 +38,7 @@ dest_dir=""
 output_path="file-install-artifact.mender"
 update_files_tar="update.tar"
 dest_dir_file="dest_dir"
+single_file_file="single_file"
 file_tree=""
 
 while (( "$#" )); do
@@ -120,11 +121,14 @@ case $dest_dir in
 esac
 
 # Create tarball, accepts single file or directory.
+single_file=""
 if [ -e "${file_tree}" ]; then
   if [ -d "${file_tree}" ]; then
     tar -cf ${update_files_tar} -C "${file_tree}" .
+    single_file="false"
   elif [ -f "${file_tree}" ]; then
     tar -cf ${update_files_tar} -C $(dirname "${file_tree}") $(basename "${file_tree}")
+    single_file="true"
   else
     echo "Error: unrecognized file/directory type \"${file_tree}\". Aborting."
     exit 1
@@ -138,16 +142,21 @@ fi
 # Create dest_dir file in plain text
 echo "$dest_dir" > $dest_dir_file
 
+# Create single_file file in plain text
+echo "$single_file" > $single_file_file
+
 mender-artifact write module-image \
   -T file-install \
   -t $device_type \
   -o $output_path \
   -n $artifact_name \
   -f $update_files_tar \
-  -f $dest_dir_file
+  -f $dest_dir_file \
+  -f $single_file_file
 
 rm $update_files_tar
 rm $dest_dir_file
+rm $single_file_file
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read $output_path

--- a/support/modules/file-install
+++ b/support/modules/file-install
@@ -6,8 +6,10 @@ STATE="$1"
 FILES="$2"
 
 prev_files_tar="$FILES"/tmp/prev_files.tar
+tmp_dest_dir="$FILES"/tmp/tmp_dest_dir
 update_files_tar="$FILES"/files/update.tar
 dest_dir_file="$FILES"/files/dest_dir
+single_file_file="$FILES"/files/single_file
 
 case "$STATE" in
 
@@ -21,19 +23,33 @@ case "$STATE" in
 
     ArtifactInstall)
         dest_dir=$(cat $dest_dir_file)
-        [[ -d $dest_dir ]] || install -d $dest_dir
-        tar -cf ${prev_files_tar} -C ${dest_dir} .
-        rm -rf ${dest_dir}
-        mkdir -p ${dest_dir}
+        single_file=$(cat $single_file_file)
+        test -z "$dest_dir" -o -z "$single_file" && exit 1
+        mkdir -p $dest_dir
+        if [ $single_file == "true" ]; then
+            mkdir -p $tmp_dest_dir
+            filename=$(tar -tf ${update_files_tar})
+            [[ -f ${dest_dir}/${filename} ]] && tar -cf ${prev_files_tar} -C ${dest_dir} ${filename}
+        else
+            tar -cf ${prev_files_tar} -C ${dest_dir} .
+            rm -rf ${dest_dir}
+            mkdir -p ${dest_dir}
+        fi
         tar -xf ${update_files_tar} -C ${dest_dir}
         ;;
 
     ArtifactRollback)
         dest_dir=$(cat $dest_dir_file)
+        single_file=$(cat $single_file_file)
+        test -z "$dest_dir" -o -z "$single_file" && exit 1
+        if [ $single_file == "true" ]; then
+            filename=$(tar -tf ${update_files_tar})
+            rm ${dest_dir}/${filename}
+        else
+            rm -rf ${dest_dir}
+            mkdir -p ${dest_dir}
+        fi
         [[ -f $prev_files_tar ]] || exit 0
-        [[ -n "$dest_dir" ]] || exit 1
-        rm -rf ${dest_dir}
-        mkdir -p ${dest_dir}
         tar -xf ${prev_files_tar} -C ${dest_dir}
         ;;
 esac

--- a/support/modules/file-install
+++ b/support/modules/file-install
@@ -24,13 +24,16 @@ case "$STATE" in
     ArtifactInstall)
         dest_dir=$(cat $dest_dir_file)
         single_file=$(cat $single_file_file)
-        test -z "$dest_dir" -o -z "$single_file" && exit 1
+        test -z "$dest_dir" -o -z "$single_file" && \
+        echo "Fatal error: dest_dir or single_file are undefined." && exit 1
         mkdir -p $dest_dir
         if [ $single_file == "true" ]; then
             mkdir -p $tmp_dest_dir
             filename=$(tar -tf ${update_files_tar})
             [[ -f ${dest_dir}/${filename} ]] && tar -cf ${prev_files_tar} -C ${dest_dir} ${filename}
         else
+            test "$dest_dir" == "/" && \
+            echo "Error: destination dir is '/', install not supported." && exit 1
             tar -cf ${prev_files_tar} -C ${dest_dir} .
             rm -rf ${dest_dir}
             mkdir -p ${dest_dir}
@@ -41,11 +44,14 @@ case "$STATE" in
     ArtifactRollback)
         dest_dir=$(cat $dest_dir_file)
         single_file=$(cat $single_file_file)
-        test -z "$dest_dir" -o -z "$single_file" && exit 1
+        test -z "$dest_dir" -o -z "$single_file" && \
+        echo "Fatal error: dest_dir or single_file are undefined." && exit 1
         if [ $single_file == "true" ]; then
             filename=$(tar -tf ${update_files_tar})
             rm ${dest_dir}/${filename}
         else
+            test "$dest_dir" == "/" && \
+            echo "Info: destination dir is '/', not performing rollback." && exit 0
             rm -rf ${dest_dir}
             mkdir -p ${dest_dir}
         fi


### PR DESCRIPTION
For the single file install use case, the user will probably want to add
the file in a directory rather than to replace the contents of it with
the file.

Removed also the "install" dependency, using mkdir instead

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>