### PR TITLE
Update modules: Implement `NeedsArtifactReboot` -> `Automatic`.

### DIFF
--- a/Documentation/update-modules-v3-file-api.md
+++ b/Documentation/update-modules-v3-file-api.md
@@ -105,14 +105,16 @@ The module should print one of the valid responses:
 
 * `No` - Mender will not run `ArtifactReboot`. This is the same as returning
   nothing, **and hence the default**.
-* `Yes` - Mender will run the update module with the `ArtifactReboot` argument
-* `Automatic` **[Unimplemented]** - Mender will not call the module with the
-  `ArtifactReboot` argument, but will instead perform one single reboot
-  itself. The intended use of this response is to group the reboots of several
-  update modules into one reboot. **This is usually the best choice** for all
-  modules that just require a normal reboot, but modules that reboot a
-  peripheral device may need to use `Yes` instead, and implement their own
-  method.
+* `Automatic` - Mender will not call the module with the `ArtifactReboot`
+  argument, but will instead perform one single reboot itself. The intended use
+  of this response is to group the reboots of several update modules into one
+  reboot. **This is usually the best choice** for all modules that just require
+  a normal reboot, but modules that reboot a peripheral device may need to use
+  `Yes` instead, and implement their own method.
+* `Yes` - Mender will run the update module with the `ArtifactReboot`
+  argument. Use this when you want to reboot a peripheral device that's
+  connected to the host. Don't use this if you want to reboot the host that
+  Mender runs on; use `Automatic` instead.
 
 **Note:** Even though the update module won't be called with the
 `ArtifactReboot` argument when using `Automatic`, it still counts as having

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,15 @@ INVENTORY_SCRIPTS = \
 MODULES = \
 	support/modules/deb \
 	support/modules/docker \
-	support/modules/file-install \
+	support/modules/file-tree-install \
+	support/modules/single-file-install \
 	support/modules/rpm \
 	support/modules/shell-command
 
 MODULES_ARTIFACT_GENERATORS = \
 	support/modules-artifact-gen/docker-artifact-gen \
-	support/modules-artifact-gen/file-install-artifact-gen
+	support/modules-artifact-gen/file-tree-install-artifact-gen \
+	support/modules-artifact-gen/single-file-install-artifact-gen
 
 build: mender
 

--- a/daemon.go
+++ b/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mendersoftware/log"
 	"github.com/mendersoftware/mender/datastore"
 	"github.com/mendersoftware/mender/store"
+	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +38,8 @@ func NewDaemon(mender Controller, store store.Store) *menderDaemon {
 	daemon := menderDaemon{
 		mender: mender,
 		sctx: StateContext{
-			store: store,
+			store:    store,
+			rebooter: system.NewSystemRebootCmd(system.OsCalls{}),
 		},
 		store:       store,
 		updateCheck: make(chan bool, 1),

--- a/support/modules/file-tree-install
+++ b/support/modules/file-tree-install
@@ -26,13 +26,20 @@ case "$STATE" in
         test "$dest_dir" = "/" && \
             echo "Error: destination dir is '/', install not supported." && exit 1
         mkdir -p $dest_dir
-        tar -cf ${prev_files_tar} -C ${dest_dir} .
+        if ! tar -cf ${prev_files_tar} -C ${dest_dir} .
+        then
+            ret=$?
+            # Make sure there is no half-backup lying around.
+            rm -f ${prev_files_tar}
+            exit $ret
+        fi
         rm -rf ${dest_dir}
         mkdir -p ${dest_dir}
         tar -xf ${update_files_tar} -C ${dest_dir}
         ;;
 
     ArtifactRollback)
+        test -f $prev_files_tar || exit 0
         dest_dir=$(cat $dest_dir_file)
         test -z "$dest_dir" && \
             echo "Fatal error: dest_dir is undefined." && exit 1
@@ -40,7 +47,6 @@ case "$STATE" in
             echo "Info: destination dir is '/', not performing rollback." && exit 0
         rm -rf ${dest_dir}
         mkdir -p ${dest_dir}
-        test -f $prev_files_tar || exit 0
         tar -xf ${prev_files_tar} -C ${dest_dir}
         ;;
 esac

--- a/support/modules/single-file-install
+++ b/support/modules/single-file-install
@@ -26,17 +26,26 @@ case "$STATE" in
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
         mkdir -p $dest_dir
         mkdir -p $tmp_dest_dir
-        test -f ${dest_dir}/${filename} && cp ${dest_dir}/${filename} ${tmp_dest_dir}
+        if test -f ${dest_dir}/${filename}
+        then
+            if ! cp ${dest_dir}/${filename} ${tmp_dest_dir}
+            then
+                ret=$?
+                # Make sure there is no half-backup lying around.
+                rm -rf ${tmp_dest_dir}
+                exit $ret
+            fi
+        fi
         cp "$FILES"/files/$filename ${dest_dir}/${filename}
         ;;
 
     ArtifactRollback)
+        test -f $tmp_dest_dir/$filename || exit 0
         dest_dir=$(cat $dest_dir_file)
         filename=$(cat $filename_file)
         test -z "$dest_dir" -o -z "$filename" && \
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
         rm ${dest_dir}/${filename}
-        test -f $tmp_dest_dir/$filename || exit 0
         cp $tmp_dest_dir/$filename ${dest_dir}/${filename}
         ;;
 esac

--- a/tests/rootfs-image-v2
+++ b/tests/rootfs-image-v2
@@ -34,13 +34,12 @@ bootcount 0
 EOF
         ;;
 
-    NeedsArtifactReboot|SupportsRollback)
-        echo "Yes"
+    NeedsArtifactReboot)
+        echo "Automatic"
         ;;
 
-    ArtifactReboot|ArtifactRollbackReboot)
-        reboot
-        sleep 600
+    SupportsRollback)
+        echo "Yes"
         ;;
 
     ArtifactVerifyReboot)


### PR DESCRIPTION
The motivation behind is change is to promote the use of `Automatic`
in all update modules. We want this because in order to support
multiple payloads, an update module should not reboot the host in its
`ArtifactReboot` script. Doing so means that `ArtifactReboot` scripts
in later payloads do not get to execute. Instead it should leave this
to Mender using the `Automatic` mechanism. Multiple payloads have not
been implemented yet, but since `Automatic` needs to be supported by
the update module itself, we implement this part now so that we don't
accumulate too many modules without it before we get multiple payload
support.

Note that the most important test of this feature is by changing the
`rootfs-image-v2` script, which is then used by the integration test
which already exists.

Changelog: Title

MEN-2011

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>