### PR TITLE
[2.0.x] Make sure ARM64 is included in bootloader integration inventory.

### DIFF
--- a/support/mender-inventory-bootloader-integration
+++ b/support/mender-inventory-bootloader-integration
@@ -5,7 +5,7 @@
 
 if [ -d /boot/efi/EFI/BOOT/mender_grubenv1 ]; then
     case "$(uname -m)" in
-        arm*)
+        arm*|aarch*)
             echo mender_bootloader_integration=uboot_uefi_grub
             ;;
         *86*)


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 42d2f29e499570fe54ccbfe15e27d2f4a89eb59b)