### PR TITLE
MEN-2378: Print warning on an invalid server certificate.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -274,12 +274,20 @@ func newHttpClient() *http.Client {
 	return &http.Client{}
 }
 
+type ClientServerCertificateError struct {
+	err error
+}
+
+func (s *ClientServerCertificateError) Error() string {
+	return errors.Wrapf(s.err, "cannot initialize server trust").Error()
+}
+
 func newHttpsClient(conf Config) (*http.Client, error) {
 	client := newHttpClient()
 
 	trustedcerts, err := loadServerTrust(conf)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot initialize server trust")
+		return nil, &ClientServerCertificateError{err}
 	}
 
 	if conf.NoVerify {


### PR DESCRIPTION
Changelog: Title Instead of bailing out on an invalid server certificate,
the client now prints a verbose error message, and then starts up the daemon,
as opposed to dying.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>