### PR TITLE
 Mender Client HTTP Proxy Support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -252,7 +252,9 @@ func New(conf Config) (*ApiClient, error) {
 	}
 
 	if client.Transport == nil {
-		client.Transport = &http.Transport{}
+		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
 	}
 	// set connection timeout
 	client.Timeout = defaultClientReadingTimeout

--- a/client/client.go
+++ b/client/client.go
@@ -291,6 +291,7 @@ func newHttpsClient(conf Config) (*http.Client, error) {
 	}
 	transport := http.Transport{
 		TLSClientConfig: &tlsc,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client.Transport = &transport


### PR DESCRIPTION
In discussion at https://groups.google.com/a/lists.mender.io/forum/m/#!msg/mender/hYak9bd3rXE/EoN9nmZVAwAJ Mirza Krak proposed using `http.ProxyFromEnvironment` to enable the Mender Client operating behind a HTTP proxy. I can confirm with the simple changes of this PR the Mender client is working correctly using HTTP proxies including proxy authentication .

For configuration of `http_proxy` and `https_proxy` environment variables when Mender runs as a system service I created a systemd drop-in placed under `/lib/systemd/system/mender.service.d/10-http_proxy.conf` with the following content:
```
[Service]
EnvironmentFile=-/etc/mender/mender.env
PassEnvironment=http_proxy https_proxy
```