### PR TITLE
Make the device type file location configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,8 @@ type menderConfigFromFile struct {
 	// Rootfs device path
 	RootfsPartA string
 	RootfsPartB string
+	// Path to the device type file
+	DeviceTypeFile string
 
 	// Poll interval for checking for new updates
 	UpdatePollIntervalSeconds int
@@ -87,6 +89,9 @@ type menderConfig struct {
 
 func NewMenderConfig() *menderConfig {
 	return &menderConfig{
+		menderConfigFromFile: menderConfigFromFile{
+			DeviceTypeFile: defaultDeviceTypeFile,
+		},
 		ModulesPath:         defaultModulesPath,
 		ModulesWorkPath:     defaultModulesWorkPath,
 		ArtifactInfoFile:    defaultArtifactInfoFile,

--- a/config_test.go
+++ b/config_test.go
@@ -36,7 +36,8 @@ var testConfig = `{
   "InventoryPollIntervalSeconds": 60,
   "ServerURL": "mender.io",
   "ServerCertificate": "/var/lib/mender/server.crt",
-  "UpdateLogPath": "/var/lib/mender/log/deployment.log"
+  "UpdateLogPath": "/var/lib/mender/log/deployment.log",
+  "DeviceTypeFile": "/var/lib/mender/test_device_type"
 }`
 
 var testBrokenConfig = `{
@@ -104,6 +105,7 @@ func validateConfiguration(t *testing.T, actual *menderConfig) {
 		ServerURL:                    "mender.io",
 		ServerCertificate:            "/var/lib/mender/server.crt",
 		UpdateLogPath:                "/var/lib/mender/log/deployment.log",
+		DeviceTypeFile:               "/var/lib/mender/test_device_type",
 		Servers:                      []client.MenderServer{{ServerURL: "mender.io"}},
 	}
 	if !assert.True(t, reflect.DeepEqual(actual, expectedConfig)) {

--- a/device.go
+++ b/device.go
@@ -56,7 +56,7 @@ type deviceManager struct {
 func NewDeviceManager(dualRootfsDevice installer.DualRootfsDevice, config *menderConfig, store store.Store) *deviceManager {
 	d := &deviceManager{
 		artifactInfoFile: config.ArtifactInfoFile,
-		deviceTypeFile:   defaultDeviceTypeFile,
+		deviceTypeFile:   config.DeviceTypeFile,
 		config:           *config,
 		stateScriptPath:  config.ArtifactScriptsPath,
 		store:            store,
@@ -161,7 +161,7 @@ func (d *deviceManager) ReadArtifactHeaders(from io.ReadCloser) (*installer.Inst
 
 	deviceType, err := d.GetDeviceType()
 	if err != nil {
-		log.Errorf("Unable to verify the existing hardware. Update will continue anyway: %v : %v", defaultDeviceTypeFile, err)
+		log.Errorf("Unable to verify the existing hardware. Update will continue anyway: %v : %v", d.config.DeviceTypeFile, err)
 	}
 
 	var i *installer.Installer

--- a/mender.go
+++ b/mender.go
@@ -290,7 +290,7 @@ func (m *mender) CheckUpdate() (*datastore.UpdateInfo, menderError) {
 
 	deviceType, err := m.GetDeviceType()
 	if err != nil {
-		log.Errorf("Unable to verify the existing hardware. Update will continue anyways: %v : %v", defaultDeviceTypeFile, err)
+		log.Errorf("Unable to verify the existing hardware. Update will continue anyways: %v : %v", m.config.DeviceTypeFile, err)
 	}
 	haveUpdate, err := m.updater.GetScheduledUpdate(m.api.Request(m.authToken, nextServerIterator(m), reauthorize(m)),
 		m.config.Servers[0].ServerURL, client.CurrentUpdate{
@@ -605,7 +605,7 @@ func (m *mender) InventoryRefresh() error {
 
 	deviceType, err := m.GetDeviceType()
 	if err != nil {
-		log.Errorf("Unable to verify the existing hardware. Update will continue anyways: %v : %v", defaultDeviceTypeFile, err)
+		log.Errorf("Unable to verify the existing hardware. Update will continue anyways: %v : %v", m.config.DeviceTypeFile, err)
 	}
 	reqAttr := []client.InventoryAttribute{
 		{Name: "device_type", Value: deviceType},


### PR DESCRIPTION
This adds a new 'DeviceTypeFile' parameter to /etc/mender.conf to enable the device_type file to be positioned somewhere other that its default location of /var/lib/mender/device_type (aka /data/mender/device_type).

In our setup the data partition will be completely erased upon factory reset, or in case of filesystem corruption. We have a dedicated read-only partition for permanent data such as hardware revisions, so this patch allows us to point Mender there instead.