### PR TITLE
Mender Client HTTP Proxy Support as proposed by Mirza Krak on 07/26/2…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -252,7 +252,9 @@ func New(conf Config) (*ApiClient, error) {
 	}
 
 	if client.Transport == nil {
-		client.Transport = &http.Transport{}
+		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
 	}
 	// set connection timeout
 	client.Timeout = defaultClientReadingTimeout
@@ -299,6 +301,7 @@ func newHttpsClient(conf Config) (*http.Client, error) {
 	}
 	transport := http.Transport{
 		TLSClientConfig: &tlsc,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client.Transport = &transport


### PR DESCRIPTION
…018 at https://groups.google.com/a/lists.mender.io/forum/m/#!msg/mender/hYak9bd3rXE/EoN9nmZVAwAJ

Mender Client HTTP Proxy Support when ClientProtocol is HTTP instead of HTTPS

Changelog: When set, HTTP proxy settings in http_proxy/https_proxy environment variables are respected now.

Signed-off-by: Thomas Beckmann <t.beckmann@mwaysolutions.com>