### PR TITLE
Update modules fixes

### DIFF
--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -7,7 +7,7 @@ show_help() {
 
 Simple tool to generate Mender Artifact suitable for directory Update Module
 
-Usage: $0 [options] directory
+Usage: $0 [options] directory [-- [options-for-mender-artifact] ]
 
     Options: [ -n|artifact-name -t|--device-type -d|--dest-dir -o|--output_path -h|--help ]
 
@@ -17,6 +17,8 @@ Usage: $0 [options] directory
         --output-path       - Path to output file. Default: file-install-artifact.mender
         --help              - Show help and exit
         directory           - File tree to bundle in the update
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
 
 EOF
 }
@@ -39,8 +41,16 @@ output_path="directory-artifact.mender"
 update_files_tar="update.tar"
 dest_dir_file="dest_dir"
 file_tree=""
+passthrough=0
+passthrough_args=""
 
 while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
   case "$1" in
     --device-type | -t)
       if [ -z "$2" ]; then
@@ -73,6 +83,10 @@ while (( "$#" )); do
     -h | --help)
       show_help
       exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
       ;;
     -*)
       echo "Error: unsupported option $1"
@@ -146,7 +160,8 @@ mender-artifact write module-image \
   -o $output_path \
   -n $artifact_name \
   -f $update_files_tar \
-  -f $dest_dir_file
+  -f $dest_dir_file \
+  $passthrough_args
 
 rm $update_files_tar
 rm $dest_dir_file

--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -12,7 +12,7 @@ Usage: $0 [options] directory
     Options: [ -n|artifact-name -t|--device-type -d|--dest-dir -o|--output_path -h|--help ]
 
         --artifact-name     - Artifact name
-        --device-type       - Target device type identification
+        --device-type       - Target device type identification (can be given more than once)
         --dest-dir          - Target destination directory where to deploy the update
         --output-path       - Path to output file. Default: file-install-artifact.mender
         --help              - Show help and exit

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -7,7 +7,7 @@ show_help() {
 
 Simple tool to generate Mender Artifact suitable for docker Update Module
 
-Usage: $0 [options] IMAGE [IMAGES...]
+Usage: $0 [options] IMAGE [IMAGES...] [-- [options-for-mender-artifact] ]
 
     Options: [ -n|artifact-name -t|--device-type -o|--output_path -h|--help ]
 
@@ -16,6 +16,8 @@ Usage: $0 [options] IMAGE [IMAGES...]
         --output-path       - Path to output file. Default: docker-artifact.mender
         --help              - Show help and exit
         IMAGE [IMAGES...]   - Docker container images to add to the Artifact
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
 
 EOF
 }
@@ -38,8 +40,16 @@ artifact_name=""
 output_path="docker-artifact.mender"
 meta_data_file="meta-data.json"
 IMAGES=""
+passthrough=0
+passthrough_args=""
 
 while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
   case "$1" in
     --device-type | -t)
       if [ -z "$2" ]; then
@@ -65,6 +75,10 @@ while (( "$#" )); do
     -h | --help)
       show_help
       exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
       ;;
     -*)
       echo "Error: unsupported option $1"
@@ -106,7 +120,8 @@ mender-artifact write module-image \
   $device_types \
   -o $output_path \
   -n $artifact_name \
-  -m $meta_data_file
+  -m $meta_data_file \
+  $passthrough_args
 
 rm $meta_data_file
 

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -12,7 +12,7 @@ Usage: $0 [options] IMAGE [IMAGES...]
     Options: [ -n|artifact-name -t|--device-type -o|--output_path -h|--help ]
 
         --artifact-name     - Artifact name
-        --device-type       - Target device type identification
+        --device-type       - Target device type identification (can be given more than once)
         --output-path       - Path to output file. Default: docker-artifact.mender
         --help              - Show help and exit
         IMAGE [IMAGES...]   - Docker container images to add to the Artifact

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -38,6 +38,7 @@ dest_dir=""
 output_path="single-file-artifact.mender"
 dest_dir_file="dest_dir"
 filename_file="filename"
+permissions_file="permissions"
 file=""
 
 while (( "$#" )); do
@@ -140,6 +141,9 @@ echo "$dest_dir" > $dest_dir_file
 # Create single_file file in plain text
 echo "$filename" > $filename_file
 
+# Create permissions file in plain text
+stat -c %a "${file}" > $permissions_file
+
 mender-artifact write module-image \
   -T single-file \
   $device_types \
@@ -147,6 +151,7 @@ mender-artifact write module-image \
   -n $artifact_name \
   -f $dest_dir_file \
   -f $filename_file \
+  -f $permissions_file \
   -f $file
 
 rm $dest_dir_file

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -12,7 +12,7 @@ Usage: $0 [options] file
     Options: [ -n|artifact-name -t|--device-type -d|--dest-dir -o|--output_path -h|--help ]
 
         --artifact-name     - Artifact name
-        --device-type       - Target device type identification
+        --device-type       - Target device type identification (can be given more than once)
         --dest-dir          - Target destination directory where to deploy the update
         --output-path       - Path to output file. Default: file-install-artifact.mender
         --help              - Show help and exit

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -7,7 +7,7 @@ show_help() {
 
 Simple tool to generate Mender Artifact suitable for single-file Update Module
 
-Usage: $0 [options] file
+Usage: $0 [options] file [-- [options-for-mender-artifact] ]
 
     Options: [ -n|artifact-name -t|--device-type -d|--dest-dir -o|--output_path -h|--help ]
 
@@ -17,6 +17,8 @@ Usage: $0 [options] file
         --output-path       - Path to output file. Default: file-install-artifact.mender
         --help              - Show help and exit
         file                - Single file to bundle in the update
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
 
 EOF
 }
@@ -40,8 +42,16 @@ dest_dir_file="dest_dir"
 filename_file="filename"
 permissions_file="permissions"
 file=""
+passthrough=0
+passthrough_args=""
 
 while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
   case "$1" in
     --device-type | -t)
       if [ -z "$2" ]; then
@@ -74,6 +84,10 @@ while (( "$#" )); do
     -h | --help)
       show_help
       exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
       ;;
     -*)
       echo "Error: unsupported option $1"
@@ -152,7 +166,8 @@ mender-artifact write module-image \
   -f $dest_dir_file \
   -f $filename_file \
   -f $permissions_file \
-  -f $file
+  -f $file \
+  $passthrough_args
 
 rm $dest_dir_file
 rm $filename_file

--- a/support/modules/single-file
+++ b/support/modules/single-file
@@ -8,6 +8,7 @@ FILES="$2"
 tmp_dest_dir="$FILES"/tmp/dest_dir
 dest_dir_file="$FILES"/files/dest_dir
 filename_file="$FILES"/files/filename
+permissions_file="$FILES"/files/permissions
 
 case "$STATE" in
 
@@ -28,7 +29,7 @@ case "$STATE" in
         mkdir -p $tmp_dest_dir
         if test -f ${dest_dir}/${filename}
         then
-            if ! cp ${dest_dir}/${filename} ${tmp_dest_dir}
+            if ! cp -a ${dest_dir}/${filename} ${tmp_dest_dir}
             then
                 ret=$?
                 # Make sure there is no half-backup lying around.
@@ -37,6 +38,12 @@ case "$STATE" in
             fi
         fi
         cp "$FILES"/files/$filename ${dest_dir}/${filename}
+        # Previous revisions of this update module did not use the
+        # permissions_file, so it might not exist.
+        if test -f $permissions_file
+        then
+            chmod $(cat $permissions_file) ${dest_dir}/${filename}
+        fi
         ;;
 
     ArtifactRollback)
@@ -46,7 +53,7 @@ case "$STATE" in
         test -z "$dest_dir" -o -z "$filename" && \
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
         rm ${dest_dir}/${filename}
-        cp $tmp_dest_dir/$filename ${dest_dir}/${filename}
+        cp -a $tmp_dest_dir/$filename ${dest_dir}/${filename}
         ;;
 esac
 


### PR DESCRIPTION
```
commit e2ff07c375bde3b7a0d6d4bd89f107b0bd28ab90
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon May 13 11:00:34 2019

    Artifact gen: Support argument passthrough to `mender-artifact`.
    
    Use `--` to signal that remaining arguments should be passed directly
    to `mender-artifact`.
    
    Changelog: Commit
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 0e62b78c176fdd91e0b94b6796fa2e6dce358369
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu May 9 14:45:39 2019

    single-file module: Make sure permissions are preserved.
    
    Also make sure that backup preserves permissions.
    
    Changelog: Commit
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 888299194bc37ac571d2c1c5b57157f689479316
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu May 9 14:07:01 2019

    module-artifact-gen: Document that one can specify more than one device_type
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```