### PR TITLE
Accept running the unit tests as root user

### DIFF
--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -219,7 +219,8 @@ func TestDeviceVerifyReboot(t *testing.T) {
 		nil,
 		config)
 	err := testDevice.VerifyReboot()
-	assert.EqualError(t, err, "failed to read environment variable: requires root privileges: exit status 255")
+	assert.Contains(t, err.Error(), "failed to read environment variable:")
+	assert.Contains(t, err.Error(), ": exit status 255")
 
 	runner = stest.NewTestOSCalls("upgrade_available=0", 0)
 	testDevice = NewDualRootfsDevice(


### PR DESCRIPTION
By not requiring explicitly the substring "requires root privileges" in
the error message.

The intention of the test remains unchanged, and now we can run the unit
tests from Docker containers or other privilaged scenarios.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>