### PR TITLE
[2.0.x] Restore error code 2 behavior when there is nothing to commit.

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -538,7 +538,7 @@ func handlePreDatabaseRestore(device *deviceManager) (*standaloneData, error) {
 	// VerifyReboot() is what would be used to verify we have rebooted into
 	// a new update.
 	if !ok || dualRootfs.VerifyReboot() != nil {
-		return nil, errors.New("No artifact installation in progress")
+		return nil, installer.ErrorNothingToCommit
 	}
 
 	// Forcibly sidestep the database for artifact name query and fetch it


### PR DESCRIPTION
The exact error is picked up in main.go.

Changelog: Title

Reported-by: Cedric Veilleux <mender@discoursemail.com>
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 0918ddc7c0861cbfc1e416be1b15bcf9ecb3cb47)