### PR TITLE
Download_Leave_02

### DIFF
--- a/examples/state-scripts/retain-systemd-network/Download_Leave_02
+++ b/examples/state-scripts/retain-systemd-network/Download_Leave_02
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Retain *.network files from the current root
+#
+
+echo "$(cat /etc/mender/artifact_info): Running $(basename "$0")" >&2
+
+if [ ! -x /sbin/fw_printenv ]; then
+    exit 1
+fi
+
+current=$(/sbin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+
+if [ $current = "2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+if [ -d /mnt/etc/systemd/network ]; then
+    networks=$(ls -l /mnt/etc/systemd/network/*.network 2>/dev/null | wc -l)
+
+    cp /etc/systemd/network/*.network /mnt/etc/systemd/network
+    echo "Copied /etc/systemd/network to newroot partition" >&2
+else
+    echo "Failed to find a /etc/systemd/network on newroot partition" >&2
+    exit 1
+fi
+
+umount $newroot
+


### PR DESCRIPTION
script file example for retaining *.network files with systemd

I modified the retain-ssh-keys script to do the same with network configuration files and want to provide it for other users. It works like a charm with my mender image.

Signed-off-by: Dirk Siegmund <siegmund@beckmann-gmbh.de>