### PR TITLE
rootfs-image-v2: Make sure to follow the spec regarding `stream-next`.

### DIFF
--- a/tests/rootfs-image-v2
+++ b/tests/rootfs-image-v2
@@ -24,6 +24,10 @@ case "$1" in
     Download)
         file="$(cat stream-next)"
         cat "$file" > $passive
+        if [ "$(cat stream-next)" != "" ]; then
+            echo "More than one file in payload"
+            exit 1
+        fi
         ;;
 
     ArtifactInstall)


### PR DESCRIPTION
We should to read the final empty entry to make sure the client does
not block.

Changelog: commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>