### PR TITLE
Make channel receiving user signals buffered

### DIFF
--- a/main.go
+++ b/main.go
@@ -556,11 +556,12 @@ func updateCheck(cmdKill, cmdGetPID *exec.Cmd) error {
 func runDaemon(d *menderDaemon) error {
 	// Handle user forcing update check.
 	go func() {
+		c := make(chan os.Signal, 2)
+		signal.Notify(c, syscall.SIGUSR1) // SIGUSR1 forces an update check.
+		signal.Notify(c, syscall.SIGUSR2) // SIGUSR2 forces an inventory update.
+		defer signal.Stop(c)
+
 		for {
-			c := make(chan os.Signal)
-			signal.Notify(c, syscall.SIGUSR1) // SIGUSR1 forces an update check.
-			signal.Notify(c, syscall.SIGUSR2) // SIGUSR2 forces an inventory update.
-			defer signal.Stop(c)
 			s := <-c // Block until a signal is received.
 			if s == syscall.SIGUSR1 {
 				log.Debug("SIGUSR1 signal received.")


### PR DESCRIPTION
This PR fixes improper usage of signal.Notify(...) func from Go std lib.
Channel must be buffered to properly receive signals:
https://golang.org/pkg/os/signal/#Notify
Also there is no need to reallocate channel each time user signal is received.
Deferring of signal.Stop(...) doesn't make any sense in the context.