### PR TITLE
2.0.x cherry-picks

### DIFF
--- a/support/mender-inventory-os
+++ b/support/mender-inventory-os
@@ -19,13 +19,15 @@ for file in /etc/os-release /usr/lib/os-release; do
     fi
 done
 
-if [ -x /usr/bin/lsb_release ]; then
-    OS="$(/usr/bin/lsb_release -sd)"
-    if [ -n "$OS" ]; then
-        echo "os=$OS"
-        exit 0
+for lsb_release in /bin/lsb_release /usr/bin/lsb_release; do
+    if [ -x $lsb_release ]; then
+        OS="$($lsb_release -sd)"
+        if [ -n "$OS" ]; then
+            echo "os=$OS"
+            exit 0
+        fi
     fi
-fi
+done
 
 if [ -e /etc/issue ]; then
     OS="$(cat /etc/issue)"


### PR DESCRIPTION
Fix `/bin/lsb_release` not being picked up by inventory script.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 4d3e3a6f0f0a254423c33352c46273210a538c52)