### PR TITLE
Remove useless conditions to simplify code

### DIFF
--- a/installer/dual_rootfs_device.go
+++ b/installer/dual_rootfs_device.go
@@ -285,9 +285,7 @@ func (d *dualRootfsDeviceImpl) StoreUpdate(image io.Reader, info os.FileInfo) er
 
 	if cerr := b.Close(); cerr != nil {
 		log.Errorf("closing device %v failed: %v", inactivePartition, cerr)
-		if cerr != nil {
-			return cerr
-		}
+		return cerr
 	}
 
 	return err

--- a/standalone.go
+++ b/standalone.go
@@ -280,9 +280,7 @@ func doStandaloneRollback(device *deviceManager, stateExec statescript.Executor)
 
 	err = doStandaloneRollbackState(standaloneData, stateExec)
 	if err != nil {
-		if firstErr == nil {
-			firstErr = err
-		}
+		firstErr = err
 		log.Errorf("Error rolling back: %s", err.Error())
 	}
 
@@ -310,9 +308,7 @@ func doStandaloneRollbackState(standaloneData *standaloneData, stateExec statesc
 
 	err := stateExec.ExecuteAll("ArtifactRollback", "Enter", false, nil)
 	if err != nil {
-		if firstErr == nil {
-			firstErr = err
-		}
+		firstErr = err
 		log.Errorf("Error when executing ArtifactRollback_Enter scripts: %s", err.Error())
 	}
 	for _, inst := range standaloneData.installers {
@@ -364,9 +360,7 @@ func doStandaloneFailureStatesFailure(standaloneData *standaloneData,
 
 	err = stateExec.ExecuteAll("ArtifactFailure", "Enter", true, nil)
 	if err != nil {
-		if firstErr == nil {
-			firstErr = err
-		}
+		firstErr = err
 		log.Errorf("Error when executing ArtifactFailure_Enter scripts: %s", err.Error())
 	}
 	for _, inst := range standaloneData.installers {

--- a/statescript/store.go
+++ b/statescript/store.go
@@ -47,7 +47,7 @@ func (s *Store) Clear() error {
 	}
 
 	err := os.RemoveAll(s.location)
-	if err == nil || (err != nil && os.IsNotExist(err)) {
+	if err == nil || os.IsNotExist(err) {
 		return os.MkdirAll(s.location, 0755)
 	}
 	return err


### PR DESCRIPTION
This PR is just a code simplification. There are several places in the code base where conditions don't have any impact on logic. Thus it's safe to remove them to simplify code.
Also Go uses short circuit evaluation for logical operators:
https://kuree.gitbooks.io/the-go-programming-language-report/content/22/text.html
That's why conditions like
if err == nil || (err != nil && ...)
may be shortened to
if err == nil || (...)