### PR TITLE
Modify rootfs to 'Image file'

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -46,7 +46,7 @@ func doStandaloneInstall(device *deviceManager, args runOptionsType,
 	var upclient client.Updater
 
 	if args == (runOptionsType{}) {
-		return errors.New("rootfs called without needed parameters")
+		return errors.New("Image file called without needed parameters")
 	}
 
 	log.Debug("Starting device update.")


### PR DESCRIPTION
Since, the Mender 2.0 can take both file and rootfs as update files, it is better to update the log with a generic name (Image file). Otherwise, 'file update' error also will show as "rootfs called without needed parameters"

Changelog: None
Signed-off-by: Ajith P V ajithpv@outlook.com