### PR TITLE
Update rootfs to install

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -46,7 +46,7 @@ func doStandaloneInstall(device *deviceManager, args runOptionsType,
 	var upclient client.Updater
 
 	if args == (runOptionsType{}) {
-		return errors.New("rootfs called without needed parameters")
+		return errors.New("install called without needed parameters")
 	}
 
 	log.Debug("Starting device update.")


### PR DESCRIPTION
Since, the Mender 2.0 can take both file and rootfs as artifact, it is better to update the log with the corresponding CLI option (i.e. install). Otherwise, ' file update ' error also will show as "rootfs called without needed parameters"!

Changelog: None
Signed-off-by: Ajith P Venugopal <ajithpv@outlook.com>