### PR TITLE
module/single-file: make sure filename is well defined

### DIFF
--- a/support/modules/single-file
+++ b/support/modules/single-file
@@ -47,9 +47,9 @@ case "$STATE" in
         ;;
 
     ArtifactRollback)
+        filename=$(cat $filename_file)
         test -f $tmp_dest_dir/$filename || exit 0
         dest_dir=$(cat $dest_dir_file)
-        filename=$(cat $filename_file)
         test -z "$dest_dir" -o -z "$filename" && \
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
         rm ${dest_dir}/${filename}


### PR DESCRIPTION
Without this commit, ArtifactRollback() state is not
executed until the end.

Fixes:

root@nitrogen8m:~# mender -rollback -debug
...
INFO[0000] Update module output: + test -f /var/lib/mender/modules/v3/payloads/0000/tree/tmp/dest_dir/  module=modules
INFO[0000] Update module output: + exit 0                module=modules

Changelog: Commit

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>