### PR TITLE
MEN-2721: FIX: `mender -sender-inventory` next state fix.

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -72,9 +72,11 @@ func (d *menderDaemon) Run() error {
 		select {
 		case nState := <-d.forceToState:
 			switch toState.(type) {
-			case *IdleState, *CheckWaitState:
+			case *IdleState, *CheckWaitState, *UpdateCheckState, *InventoryUpdateState:
 				log.Infof("Forcing state machine to: %s", nState)
 				toState = nState
+			default:
+				log.Debugf("State machine does not force state transitions from: %s state", toState)
 			}
 
 		default:


### PR DESCRIPTION
Previously the `mender -send-inventory` command did not force the state
machine to the correct state, since `checkWaitState` returns the next state
to be handled, and not itself. Therefore the woken state machine would simply
handle the next expected event, and not `send-inventory` as this was
completely random whether would happen or not. Unlucky users therefore
reported this as having to run `-send-inventory` twice in the cases that
`send-inventory` was not the next event scheduled to happen.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>