### PR TITLE
Move Mender state machine to a producer-consumer pattern

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -39,6 +39,7 @@ func NewDaemon(mender Controller, store store.Store) *menderDaemon {
 			store:      store,
 			rebooter:   system.NewSystemRebootCmd(system.OsCalls{}),
 			wakeupChan: make(chan bool, 1),
+			eventChan:  make(chan EventProducer),
 		},
 		store:        store,
 		forceToState: make(chan State, 1),
@@ -72,7 +73,7 @@ func (d *menderDaemon) Run() error {
 		select {
 		case nState := <-d.forceToState:
 			switch toState.(type) {
-			case *IdleState, *CheckWaitState, *UpdateCheckState, *InventoryUpdateState:
+			case *IdleState, *UpdateCheckState, *InventoryUpdateState:
 				log.Infof("Forcing state machine to: %s", nState)
 				toState = nState
 			default:


### PR DESCRIPTION
NO-RUN-TESTS

This move will enable getting rid of all the storing of time, and
checking before and after, and weird handling of the special cases related
to null-time (events that should happen straight away). It is by no means
finished!! But more like a suggestion draft, as to whether I should follow this
up.

This will reduce the number of internal states significantly, and make
it easier to maintain (I think).

Feedback most welcome :)

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>