### PR TITLE
Fix `mender --version` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
 
 GO_LDFLAGS = \
-	-ldflags "-X main.Version=$(VERSION)"
+	-ldflags "-X github.com/mendersoftware/mender/conf.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v


### PR DESCRIPTION
It was returning unknown. The definition of Version was moved to a conf
package while refactoring in 8a75a8c and the Makefile was not updated
accordingly.