### PR TITLE
store: Handle mender-artifact ArtifactProvides attribute in headerinfo

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -609,7 +609,7 @@ func transitionState(to State, ctx *StateContext, c Controller) (State, bool) {
 
 	// If this is an update state, store new state in database.
 	if us, ok := to.(UpdateState); ok {
-		err := StoreStateData(ctx.Store, datastore.StateData{
+		err := datastore.StoreStateData(ctx.Store, datastore.StateData{
 			Name:       us.Id(),
 			UpdateInfo: *us.Update(),
 		})

--- a/app/mender.go
+++ b/app/mender.go
@@ -275,6 +275,55 @@ func (m *Mender) FetchUpdate(url string) (io.ReadCloser, int64, error) {
 	return m.updater.FetchUpdate(m.api, url, m.GetRetryPollInterval())
 }
 
+func verifyArtifactDependencies(depends, provides map[string]interface{}) error {
+	// Generic closure for checking if element is present in slice.
+	elemInSlice := func(elem string, slice []string) bool {
+		for _, s := range slice {
+			if s == elem {
+				return true
+			}
+		}
+		return false
+	}
+
+	for key, depend := range depends {
+		if key == "compatible_devices" {
+			// handled elsewhere
+			continue
+		}
+		switch depend.(type) {
+		case []string:
+			if len(depend.([]string)) == 0 {
+				continue
+			}
+		case string:
+			if depend.(string) == "" {
+				continue
+			}
+		default:
+			return errors.Errorf(
+				"Invalid type for dependency with name %s", key)
+		}
+		if p, ok := provides[key]; ok {
+			switch depend.(type) {
+			case []string:
+				if elemInSlice(p.(string), depend.([]string)) {
+					continue
+				}
+			case string:
+				if p == depend {
+					continue
+				}
+			}
+			return errors.Errorf(errMsgDependencyNotSatisfiedF,
+				key, depend, provides[key])
+		}
+		return errors.Errorf(errMsgDependencyNotSatisfiedF,
+			key, depend, nil)
+	}
+	return nil
+}
+
 // Check if new update is available. In case of errors, returns nil and error
 // that occurred. If no update is available *UpdateInfo is nil, otherwise it
 // contains update information.

--- a/app/mender_test.go
+++ b/app/mender_test.go
@@ -820,7 +820,7 @@ func MakeRootfsImageArtifact(version int, signed bool) (io.ReadCloser, error) {
 	var u handlers.Composer
 	switch version {
 	case 1:
-		u = handlers.NewRootfsV1(upd)
+		return nil, errors.New("Artifact version 1 is deprecated")
 	case 2:
 		u = handlers.NewRootfsV2(upd)
 	case 3:
@@ -888,7 +888,7 @@ func TestMenderStoreUpdate(t *testing.T) {
 	assert.Error(t, err)
 
 	// make a fake update artifact
-	upd, err := MakeRootfsImageArtifact(1, false)
+	upd, err := MakeRootfsImageArtifact(2, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, upd)
 
@@ -898,7 +898,7 @@ func TestMenderStoreUpdate(t *testing.T) {
 	assert.Error(t, err)
 
 	// try with a legit device_type
-	upd, err = MakeRootfsImageArtifact(1, false)
+	upd, err = MakeRootfsImageArtifact(2, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, upd)
 
@@ -909,7 +909,7 @@ func TestMenderStoreUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// now try with device throwing errors durin ginstall
-	upd, err = MakeRootfsImageArtifact(1, false)
+	upd, err = MakeRootfsImageArtifact(2, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, upd)
 

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -35,8 +35,10 @@ import (
 )
 
 type standaloneData struct {
-	artifactName string
-	installers   []installer.PayloadUpdatePerformer
+	artifactName         string
+	artifactGroup        string
+	artifactTypeProvides map[string]interface{}
+	installers           []installer.PayloadUpdatePerformer
 }
 
 // This will be run manually from command line ONLY
@@ -120,6 +122,32 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 	}
 
 	standaloneData.artifactName = installer.GetArtifactName()
+	standaloneData.artifactTypeProvides, err = installer.GetArtifactProvides()
+	if err != nil {
+		return nil, err
+	}
+	if standaloneData.artifactTypeProvides != nil {
+		if _, ok := standaloneData.artifactTypeProvides["artifact_name"]; ok {
+			delete(standaloneData.artifactTypeProvides, "artifact_name")
+		}
+		if grp, ok := standaloneData.artifactTypeProvides["artifact_group"]; ok {
+			standaloneData.artifactGroup = grp.(string)
+			delete(standaloneData.artifactTypeProvides, "artifact_group")
+		}
+	}
+	depends, err := installer.GetArtifactDepends()
+	if err != nil {
+		return nil, err
+	} else if depends != nil {
+		currentProvides, err := datastore.LoadProvidesFromStore(device.Store)
+		if err != nil {
+			return nil, err
+		}
+		if err = verifyArtifactDependencies(depends, currentProvides); err != nil {
+			log.Error(err.Error())
+			return nil, err
+		}
+	}
 
 	err = installer.StorePayloads()
 	if err != nil {
@@ -438,7 +466,23 @@ func doStandaloneCleanup(device *dev.DeviceManager, standaloneData *standaloneDa
 			return err
 		}
 		if standaloneData.artifactName != "" {
-			return txn.WriteAll(datastore.ArtifactNameKey, []byte(standaloneData.artifactName))
+			err = txn.WriteAll(datastore.ArtifactNameKey,
+				[]byte(standaloneData.artifactName))
+			if err != nil {
+				return err
+			}
+			err = txn.WriteAll(datastore.ArtifactGroupKey,
+				[]byte(standaloneData.artifactGroup))
+			if err != nil {
+				return err
+			}
+			providesBuf, err := json.Marshal(
+				standaloneData.artifactTypeProvides)
+			if err != nil {
+				return err
+			}
+			return txn.WriteAll(datastore.ArtifactTypeProvidesKey,
+				providesBuf)
 		}
 		return nil
 	})

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -35,10 +35,10 @@ import (
 )
 
 type standaloneData struct {
-	artifactName         string
-	artifactGroup        string
-	artifactTypeProvides map[string]interface{}
-	installers           []installer.PayloadUpdatePerformer
+	artifactName             string
+	artifactGroup            string
+	artifactTypeInfoProvides map[string]interface{}
+	installers               []installer.PayloadUpdatePerformer
 }
 
 // This will be run manually from command line ONLY
@@ -122,24 +122,28 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 	}
 
 	standaloneData.artifactName = installer.GetArtifactName()
-	standaloneData.artifactTypeProvides, err = installer.GetArtifactProvides()
+	standaloneData.artifactTypeInfoProvides, err = installer.GetArtifactProvides()
 	if err != nil {
 		return nil, err
 	}
-	if standaloneData.artifactTypeProvides != nil {
-		if _, ok := standaloneData.artifactTypeProvides["artifact_name"]; ok {
-			delete(standaloneData.artifactTypeProvides, "artifact_name")
+	if standaloneData.artifactTypeInfoProvides != nil {
+		if _, ok := standaloneData.
+			artifactTypeInfoProvides["artifact_name"]; ok {
+			delete(standaloneData.artifactTypeInfoProvides,
+				"artifact_name")
 		}
-		if grp, ok := standaloneData.artifactTypeProvides["artifact_group"]; ok {
+		if grp, ok := standaloneData.
+			artifactTypeInfoProvides["artifact_group"]; ok {
 			standaloneData.artifactGroup = grp.(string)
-			delete(standaloneData.artifactTypeProvides, "artifact_group")
+			delete(standaloneData.artifactTypeInfoProvides,
+				"artifact_group")
 		}
 	}
 	depends, err := installer.GetArtifactDepends()
 	if err != nil {
 		return nil, err
 	} else if depends != nil {
-		currentProvides, err := datastore.LoadProvidesFromStore(device.Store)
+		currentProvides, err := datastore.LoadProvides(device.Store)
 		if err != nil {
 			return nil, err
 		}
@@ -477,11 +481,11 @@ func doStandaloneCleanup(device *dev.DeviceManager, standaloneData *standaloneDa
 				return err
 			}
 			providesBuf, err := json.Marshal(
-				standaloneData.artifactTypeProvides)
+				standaloneData.artifactTypeInfoProvides)
 			if err != nil {
 				return err
 			}
-			return txn.WriteAll(datastore.ArtifactTypeProvidesKey,
+			return txn.WriteAll(datastore.ArtifactTypeInfoProvidesKey,
 				providesBuf)
 		}
 		return nil

--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -161,7 +161,7 @@ func Test_doManualUpdate_existingFile_updateSuccess(t *testing.T) {
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
 
-	artifact, err := MakeRootfsImageArtifact(1, false)
+	artifact, err := MakeRootfsImageArtifact(2, false)
 	require.NoError(t, err)
 	require.NotNil(t, artifact)
 

--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -15,6 +15,7 @@
 package app
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"os"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
+	"github.com/mendersoftware/mender/datastore"
 	dev "github.com/mendersoftware/mender/device"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/statescript"
@@ -194,6 +196,84 @@ func Test_doManualUpdate_existingFile_updateSuccess(t *testing.T) {
 		imageFileName, client.Config{},
 		nil, dev.NewStateScriptExecutor(&config))
 	assert.NoError(t, err)
+}
+
+func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
+	// setup
+	deviceType := zeroLengthDeviceTypeFile(t)
+	defer os.Remove(deviceType)
+
+	artifactProvides := &tests.ArtifactProvides{
+		ArtifactName:  "testName",
+		ArtifactGroup: "testGroup",
+	}
+	artifactDepends := &tests.ArtifactDepends{
+		ArtifactName:      []string{"OldArtifact"},
+		ArtifactGroup:     []string{"testGroup"},
+		CompatibleDevices: []string{"qemux86-64"},
+	}
+	typeInfoDepends := &map[string]interface{}{
+		"testKey": "testValue",
+	}
+
+	artifactStream, err := tests.CreateTestArtifactV3("test", "gzip",
+		artifactProvides, artifactDepends, nil, typeInfoDepends)
+	require.NoError(t, err)
+	require.NotNil(t, artifactStream)
+
+	tmpdir, err := ioutil.TempDir("", "mendertest")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	f, err := ioutil.TempFile("", "update")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	_, err = io.Copy(f, artifactStream)
+	assert.NoError(t, err)
+	f.Close()
+
+	// test
+	dbdir, err := ioutil.TempDir("", "menderDbdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(dbdir)
+
+	fakeDev := FakeDevice{ConsumeUpdate: true}
+	imageFileName := f.Name()
+	config := conf.MenderConfig{
+		ArtifactScriptsPath: tmpdir,
+	}
+
+	// First check that unmet dependencies returns an error, and add
+	// one dependency at the time untill the artifact should be accepted.
+	testDevMgr := getTestDeviceManager(fakeDev, &config, deviceType, dbdir)
+	err = DoStandaloneInstall(testDevMgr,
+		imageFileName, client.Config{},
+		nil, dev.NewStateScriptExecutor(&config))
+	assert.Error(t, err)
+
+	testDevMgr.Store.WriteAll(datastore.ArtifactNameKey,
+		[]byte("OldArtifact"))
+	err = DoStandaloneInstall(testDevMgr,
+		imageFileName, client.Config{},
+		nil, dev.NewStateScriptExecutor(&config))
+	assert.Error(t, err)
+	testDevMgr.Store.WriteAll(datastore.ArtifactGroupKey,
+		[]byte("testGroup"))
+	err = DoStandaloneInstall(testDevMgr,
+		imageFileName, client.Config{},
+		nil, dev.NewStateScriptExecutor(&config))
+	assert.Error(t, err)
+
+	typeProvidesBuf, err := json.Marshal(typeInfoDepends)
+	assert.NoError(t, err)
+	testDevMgr.Store.WriteAll(
+		datastore.ArtifactTypeInfoProvidesKey, typeProvidesBuf)
+	err = DoStandaloneInstall(testDevMgr,
+		imageFileName, client.Config{},
+		nil, dev.NewStateScriptExecutor(&config))
+	assert.NoError(t, err)
+
 }
 
 type standaloneModuleInstallCase struct {

--- a/app/state.go
+++ b/app/state.go
@@ -261,7 +261,7 @@ type initState struct {
 
 func (i *initState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	// restore previous state information
-	sd, sdErr := LoadStateData(ctx.Store)
+	sd, sdErr := datastore.LoadStateData(ctx.Store)
 
 	// handle easy case first: no previous state stored,
 	// means no update was in progress; we should continue from idle
@@ -270,7 +270,7 @@ func (i *initState) Handle(ctx *StateContext, c Controller) (State, bool) {
 		return States.Idle, false
 	}
 
-	if sdErr != nil && sdErr != maximumStateDataStoreCountExceeded {
+	if sdErr != nil && sdErr != datastore.MaximumStateDataStoreCountExceeded {
 		log.Errorf("failed to restore state data: %v", sdErr)
 		me := NewFatalError(errors.Wrapf(sdErr, "failed to restore state data"))
 		return NewUpdateErrorState(me, &datastore.UpdateInfo{
@@ -285,7 +285,7 @@ func (i *initState) Handle(ctx *StateContext, c Controller) (State, bool) {
 		log.Errorf("failed to enable deployment logger: %s", err)
 	}
 
-	if sdErr == maximumStateDataStoreCountExceeded {
+	if sdErr == datastore.MaximumStateDataStoreCountExceeded {
 		// State argument not needed since we already know that maximum
 		// count was exceeded and a different state will be returned.
 		return handleStateDataError(ctx, nil, false, sd.Name, &sd.UpdateInfo, sdErr)
@@ -508,34 +508,36 @@ func (uc *updateCommitState) Handle(ctx *StateContext, c Controller) (State, boo
 
 	// And then store the data together with the new artifact name,
 	// indicating that we have now migrated to a new artifact!
-	err = StoreStateDataAndTransaction(ctx.Store, datastore.StateData{
-		Name:       uc.Id(),
-		UpdateInfo: *uc.Update(),
-	}, func(txn store.Transaction) error {
-		log.Debugf("Committing new artifact name: %s",
-			uc.Update().ArtifactName())
-		if err := txn.WriteAll(datastore.ArtifactNameKey,
-			[]byte(uc.Update().ArtifactName())); err != nil {
-			return err
-		}
-		log.Debugf("Committing new artifact group name: %s",
-			uc.Update().ArtifactGroup())
-		if err := txn.WriteAll(datastore.ArtifactGroupKey,
-			[]byte(uc.Update().ArtifactGroup())); err != nil {
-			return err
-		}
-		log.Debug("Committing new artifact type-info provides")
-		providesBuf, err := json.Marshal(uc.Update().ArtifactTypeProvides())
-		if err != nil {
-			return errors.Wrapf(err,
-				"Error encoding ArtifactTypeProvides to JSON.")
-		}
-		if err = txn.WriteAll(datastore.ArtifactTypeProvidesKey,
-			providesBuf); err != nil {
-			return err
-		}
-		return nil
-	})
+	err = datastore.StoreStateDataAndTransaction(ctx.Store,
+		datastore.StateData{
+			Name:       uc.Id(),
+			UpdateInfo: *uc.Update(),
+		}, func(txn store.Transaction) error {
+			log.Debugf("Committing new artifact name: %s",
+				uc.Update().ArtifactName())
+			if err := txn.WriteAll(datastore.ArtifactNameKey,
+				[]byte(uc.Update().ArtifactName())); err != nil {
+				return err
+			}
+			log.Debugf("Committing new artifact group name: %s",
+				uc.Update().ArtifactGroup())
+			if err := txn.WriteAll(datastore.ArtifactGroupKey,
+				[]byte(uc.Update().ArtifactGroup())); err != nil {
+				return err
+			}
+			log.Debug("Committing new artifact type-info provides")
+			providesBuf, err := json.Marshal(
+				uc.Update().ArtifactTypeInfoProvides())
+			if err != nil {
+				return errors.Wrapf(err,
+					"Error encoding ArtifactTypeInfoProvides to JSON.")
+			}
+			if err = txn.WriteAll(datastore.ArtifactTypeInfoProvidesKey,
+				providesBuf); err != nil {
+				return err
+			}
+			return nil
+		})
 	if err != nil {
 		log.Error("Could not write state data to persistent storage: ", err.Error())
 		return handleStateDataError(ctx, NewUpdateErrorState(NewTransientError(err), uc.Update()),
@@ -796,7 +798,7 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 	// Store state so that all the payload handlers are recorded there. This
 	// is important since they need to call their Cleanup functions after we
 	// have started the download.
-	err = StoreStateData(ctx.Store, datastore.StateData{
+	err = datastore.StoreStateData(ctx.Store, datastore.StateData{
 		Name:       u.Id(),
 		UpdateInfo: u.update,
 	})
@@ -831,7 +833,7 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 	return NewUpdateAfterStoreState(&u.update), false
 }
 
-func (u *updateStoreState) maybeHandleArtifactVersion3(
+func (u *updateStoreState) maybeVerifyArtifactDependsAndProvides(
 	ctx *StateContext, installer *installer.Installer) error {
 	// For artifact version >= 3 we need to fetch the artifact provides of
 	// the previous artifact from the datastore, and verify that the
@@ -842,7 +844,7 @@ func (u *updateStoreState) maybeHandleArtifactVersion3(
 	} else if depends != nil {
 		var provides map[string]interface{}
 		// load header-info provides
-		provides, err = datastore.LoadProvidesFromStore(ctx.Store)
+		provides, err = datastore.LoadProvides(ctx.Store)
 		if err != nil {
 			log.Error(err.Error())
 			return err
@@ -871,7 +873,7 @@ func (u *updateStoreState) maybeHandleArtifactVersion3(
 			// remove duplication
 			delete(provides, "artifact_group")
 		}
-		u.update.Artifact.TypeProvides = provides
+		u.update.Artifact.TypeInfoProvides = provides
 	}
 	return nil
 }
@@ -897,7 +899,7 @@ func (u *updateStoreState) handleSupportsRollback(ctx *StateContext, c Controlle
 	}
 
 	// Make sure SupportsRollback status is stored
-	err := StoreStateData(ctx.Store, datastore.StateData{
+	err := datastore.StoreStateData(ctx.Store, datastore.StateData{
 		Name:       u.Id(),
 		UpdateInfo: u.update,
 	})
@@ -1023,7 +1025,7 @@ func (is *updateInstallState) handleRebootType(ctx *StateContext, c Controller) 
 		}
 	}
 	// Make sure RebootRequested status is stored
-	err := StoreStateData(ctx.Store, datastore.StateData{
+	err := datastore.StoreStateData(ctx.Store, datastore.StateData{
 		Name:       datastore.MenderStateUpdateInstall,
 		UpdateInfo: *is.Update(),
 	})
@@ -1798,182 +1800,6 @@ func (f *finalState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	panic("reached final state")
 }
 
-func StoreStateData(dbStore store.Store, sd datastore.StateData) error {
-	return StoreStateDataAndTransaction(dbStore, sd, nil)
-}
-
-// Execute storing the state and a custom transaction function atomically.
-func StoreStateDataAndTransaction(dbStore store.Store, sd datastore.StateData,
-	txnFunc func(txn store.Transaction) error) error {
-
-	// if the verions is not filled in, use the current one
-	if sd.Version == 0 {
-		sd.Version = datastore.StateDataVersion
-	}
-
-	var storeCountExceeded bool
-
-	err := dbStore.WriteTransaction(func(txn store.Transaction) error {
-		// Perform custom transaction operations, if any.
-		if txnFunc != nil {
-			err := txnFunc(txn)
-			if err != nil {
-				return err
-			}
-		}
-
-		var key string
-		if sd.UpdateInfo.HasDBSchemaUpdate {
-			key = datastore.StateDataKeyUncommitted
-		} else {
-			key = datastore.StateDataKey
-		}
-
-		// See if there is an existing entry and update the store count.
-		existingData, err := txn.ReadAll(key)
-		if err == nil {
-			var existing datastore.StateData
-			err := json.Unmarshal(existingData, &existing)
-			if err == nil {
-				sd.UpdateInfo.StateDataStoreCount = existing.UpdateInfo.StateDataStoreCount
-			}
-		}
-
-		if sd.UpdateInfo.StateDataStoreCount >= maximumStateDataStoreCount {
-			// Reset store count to prevent subsequent states from
-			// hitting the same error.
-			sd.UpdateInfo.StateDataStoreCount = 0
-			storeCountExceeded = true
-		}
-
-		sd.UpdateInfo.StateDataStoreCount++
-		data, err := json.Marshal(sd)
-		if err != nil {
-			return err
-		}
-
-		if !sd.UpdateInfo.HasDBSchemaUpdate {
-			err = txn.Remove(datastore.StateDataKeyUncommitted)
-			if err != nil {
-				return err
-			}
-		}
-		return txn.WriteAll(key, data)
-	})
-
-	if storeCountExceeded {
-		return maximumStateDataStoreCountExceeded
-	}
-
-	return err
-}
-
-// This number should be kept quite a lot higher than the number of expected
-// state storage operations, which is usually roughly equivalent to the number
-// of state transitions.
-const maximumStateDataStoreCount int = 30
-
-// Special kind of error: When this error is returned by LoadStateData, the
-// StateData will also be valid, and can be used to handle the error.
-var maximumStateDataStoreCountExceeded error = errors.New("State data stored and retrieved maximum number of times")
-
-func loadStateData(txn store.Transaction, key string) (datastore.StateData, error) {
-	var sd datastore.StateData
-
-	data, err := txn.ReadAll(key)
-	if err != nil {
-		return sd, err
-	}
-
-	// we are relying on the fact that Unmarshal will decode all and only the fields
-	// that it can find in the destination type.
-	err = json.Unmarshal(data, &sd)
-	if err != nil {
-		return sd, err
-	}
-
-	return sd, nil
-}
-
-func LoadStateData(dbStore store.Store) (datastore.StateData, error) {
-	var sd datastore.StateData
-	var storeCountExceeded bool
-
-	// We do the state data loading in a write transaction so that we can
-	// update the StateDataStoreCount.
-	err := dbStore.WriteTransaction(func(txn store.Transaction) error {
-		var err error
-		sd, err = loadStateData(txn, datastore.StateDataKey)
-		if err != nil {
-			return err
-		}
-
-		switch sd.Version {
-		case 0, 1:
-			// We need to upgrade the schema. Check if we have
-			// already written an updated one.
-			uncommSd, err := loadStateData(txn, datastore.StateDataKeyUncommitted)
-			if err == nil {
-				// Verify that the update IDs are equal,
-				// otherwise this may be a leftover remnant from
-				// an earlier update.
-				if sd.UpdateInfo.ID == uncommSd.UpdateInfo.ID {
-					// Use the uncommitted one instead.
-					sd = uncommSd
-				}
-			} else if err != os.ErrNotExist {
-				return err
-			}
-
-			// If we are upgrading the schema, we know for a fact
-			// that we came from a rootfs-image update, because it
-			// was the only thing that was supported there. Store
-			// this, since this information will be missing in
-			// databases before version 2.
-			sd.UpdateInfo.Artifact.PayloadTypes = []string{"rootfs-image"}
-			sd.UpdateInfo.RebootRequested = []datastore.RebootType{datastore.RebootTypeCustom}
-			sd.UpdateInfo.SupportsRollback = datastore.RollbackSupported
-
-			sd.UpdateInfo.HasDBSchemaUpdate = true
-
-		case 2:
-			sd.UpdateInfo.HasDBSchemaUpdate = false
-
-		default:
-			return errors.New("unsupported state data version")
-		}
-
-		sd.Version = datastore.StateDataVersion
-
-		if sd.UpdateInfo.StateDataStoreCount >= maximumStateDataStoreCount {
-			// Reset store count to prevent subsequent states from
-			// hitting the same error.
-			sd.UpdateInfo.StateDataStoreCount = 0
-			storeCountExceeded = true
-		}
-
-		sd.UpdateInfo.StateDataStoreCount++
-		data, err := json.Marshal(sd)
-		if err != nil {
-			return err
-		}
-
-		// Store the updated count back in the database.
-		if sd.UpdateInfo.HasDBSchemaUpdate {
-			return txn.WriteAll(datastore.StateDataKeyUncommitted, data)
-		} else {
-			return txn.WriteAll(datastore.StateDataKey, data)
-		}
-
-	})
-
-	if storeCountExceeded {
-		return sd, maximumStateDataStoreCountExceeded
-	}
-
-	return sd, err
-}
-
 func RemoveStateData(store store.Store) error {
 	if store == nil {
 		return nil
@@ -1986,7 +1812,7 @@ func handleStateDataError(ctx *StateContext, newState State, cancelled bool,
 	stateName datastore.MenderState,
 	update *datastore.UpdateInfo, err error) (State, bool) {
 
-	if err == maximumStateDataStoreCountExceeded {
+	if err == datastore.MaximumStateDataStoreCountExceeded {
 		log.Errorf("State transition loop detected in state %s: Forcefully aborting "+
 			"update. The system is likely to be in an inconsistent "+
 			"state after this.", stateName)

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -716,7 +716,7 @@ func TestStateUpdateFetch(t *testing.T) {
 	assert.IsType(t, &fetchStoreRetryState{}, s)
 	assert.False(t, c)
 
-	ud, err := LoadStateData(ms)
+	ud, err := datastore.LoadStateData(ms)
 	assert.NoError(t, err)
 	// Ignore state data store count.
 	ud.UpdateInfo.StateDataStoreCount = 0
@@ -830,7 +830,7 @@ func TestStateUpdateStore(t *testing.T) {
 	assert.False(t, c)
 	assert.Equal(t, client.StatusDownloading, sc.reportStatus)
 
-	ud, err := LoadStateData(ms)
+	ud, err := datastore.LoadStateData(ms)
 	assert.NoError(t, err)
 	newUpdate := datastore.StateData{
 		Version:    datastore.StateDataVersion,
@@ -1040,9 +1040,9 @@ func TestStateData(t *testing.T) {
 			ID: "foobar",
 		},
 	}
-	err := StoreStateData(ms, sd)
+	err := datastore.StoreStateData(ms, sd)
 	assert.NoError(t, err)
-	rsd, err := LoadStateData(ms)
+	rsd, err := datastore.LoadStateData(ms)
 	assert.NoError(t, err)
 	modSd := sd
 	modSd.UpdateInfo.StateDataStoreCount = 2
@@ -1054,13 +1054,13 @@ func TestStateData(t *testing.T) {
 	assert.Contains(t, string(data), `"Name":"init"`)
 
 	sd.Version = 999
-	err = StoreStateData(ms, sd)
+	err = datastore.StoreStateData(ms, sd)
 	assert.NoError(t, err)
-	rsd, err = LoadStateData(ms)
+	rsd, err = datastore.LoadStateData(ms)
 	assert.Error(t, err)
 
 	ms.Remove(datastore.StateDataKey)
-	_, err = LoadStateData(ms)
+	_, err = datastore.LoadStateData(ms)
 	assert.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
 }
@@ -1085,7 +1085,7 @@ func TestStateReportError(t *testing.T) {
 
 	// store some state data, failing to report status with a failed update
 	// will just clean that up and
-	StoreStateData(ms, datastore.StateData{
+	datastore.StoreStateData(ms, datastore.StateData{
 		Name:       datastore.MenderStateReportStatusError,
 		UpdateInfo: *update,
 	})
@@ -1096,12 +1096,12 @@ func TestStateReportError(t *testing.T) {
 	assert.IsType(t, &idleState{}, s)
 	assert.False(t, c)
 
-	_, err := LoadStateData(ms)
+	_, err := datastore.LoadStateData(ms)
 	assert.Equal(t, err, nil)
 
 	// store some state data, failing to report status with an update that
 	// is already installed will also clean it up
-	StoreStateData(ms, datastore.StateData{
+	datastore.StoreStateData(ms, datastore.StateData{
 		Name:       datastore.MenderStateReportStatusError,
 		UpdateInfo: *update,
 	})
@@ -1113,7 +1113,7 @@ func TestStateReportError(t *testing.T) {
 	assert.IsType(t, &idleState{}, s)
 	assert.False(t, c)
 
-	_, err = LoadStateData(ms)
+	_, err = datastore.LoadStateData(ms)
 	assert.Equal(t, err, nil)
 }
 
@@ -4787,8 +4787,8 @@ func TestDBSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, StoreStateData(db, sd))
-	sd, err = LoadStateData(db)
+	require.NoError(t, datastore.StoreStateData(db, sd))
+	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
 	_, err = db.ReadAll(datastore.StateDataKeyUncommitted)
@@ -4811,8 +4811,8 @@ func TestDBSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, StoreStateData(db, sd))
-	sd, err = LoadStateData(db)
+	require.NoError(t, datastore.StoreStateData(db, sd))
+	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
 	// Now both should be stored.
@@ -4836,7 +4836,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: true,
 		},
 	}
-	require.NoError(t, StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd))
 
 	// Check manually for both.
 	data, err := db.ReadAll(datastore.StateDataKeyUncommitted)
@@ -4860,7 +4860,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 	assert.False(t, sd.UpdateInfo.HasDBSchemaUpdate)
 
 	// Check loading.
-	sd, err = LoadStateData(db)
+	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
 	assert.Equal(t, "abc", sd.UpdateInfo.ID)
@@ -4879,7 +4879,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: true,
 		},
 	}
-	require.NoError(t, StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd))
 
 	data, err = db.ReadAll(datastore.StateDataKeyUncommitted)
 	require.NoError(t, err)
@@ -4901,7 +4901,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 	assert.Equal(t, 1, sd.Version)
 	assert.False(t, sd.UpdateInfo.HasDBSchemaUpdate)
 
-	sd, err = LoadStateData(db)
+	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
 	assert.Equal(t, "abc", sd.UpdateInfo.ID)
@@ -4919,7 +4919,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: false,
 		},
 	}
-	require.NoError(t, StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd))
 
 	data, err = db.ReadAll(datastore.StateDataKeyUncommitted)
 	assert.Error(t, err)
@@ -4934,7 +4934,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 	assert.Equal(t, datastore.StateDataVersion, sd.Version)
 	assert.False(t, sd.UpdateInfo.HasDBSchemaUpdate)
 
-	sd, err = LoadStateData(db)
+	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
 	assert.Equal(t, "abc", sd.UpdateInfo.ID)

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -432,7 +432,7 @@ func TestStateUpdateCommit(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	DeploymentLogger = NewDeploymentLogManager(tempDir)
 
-	artifactTypeProvides := map[string]interface{}{
+	artifactTypeInfoProvides := map[string]interface{}{
 		"test-kwrd": "test-value",
 	}
 
@@ -443,7 +443,7 @@ func TestStateUpdateCommit(t *testing.T) {
 			ArtifactGroup:     "TestGroup",
 			CompatibleDevices: []string{"vexpress-qemu"},
 			PayloadTypes:      []string{"rootfs-image"},
-			TypeProvides:      artifactTypeProvides,
+			TypeInfoProvides:  artifactTypeInfoProvides,
 		},
 		SupportsRollback: datastore.RollbackSupported,
 	}
@@ -468,11 +468,11 @@ func TestStateUpdateCommit(t *testing.T) {
 	storeBuf, err = ms.ReadAll(datastore.ArtifactGroupKey)
 	artifactGroup := string(storeBuf)
 	assert.Equal(t, artifactGroup, "TestGroup")
-	storeBuf, err = ms.ReadAll(datastore.ArtifactTypeProvidesKey)
+	storeBuf, err = ms.ReadAll(datastore.ArtifactTypeInfoProvidesKey)
 	var typeProvides map[string]interface{}
 	err = json.Unmarshal(storeBuf, &typeProvides)
 	assert.NoError(t, err)
-	assert.Equal(t, typeProvides, artifactTypeProvides)
+	assert.Equal(t, typeProvides, artifactTypeInfoProvides)
 }
 
 func TestStateInvetoryUpdate(t *testing.T) {
@@ -787,12 +787,12 @@ func TestStateUpdateStore(t *testing.T) {
 		ArtifactGroup:     []string{"TestGroup"},
 		CompatibleDevices: []string{"vexpress-qemu"},
 	}
-	artifactTypeProvides := map[string]interface{}{
+	artifactTypeInfoProvides := map[string]interface{}{
 		"test": "moar-test",
 	}
 
-	stream, err := tests.CreateTestArtifactV3(artifactProvides,
-		artifactDepends, &artifactTypeProvides, nil, "test")
+	stream, err := tests.CreateTestArtifactV3("test", "gzip",
+		artifactProvides, artifactDepends, &artifactTypeInfoProvides, nil)
 	require.NoError(t, err)
 
 	update := &datastore.UpdateInfo{
@@ -802,7 +802,7 @@ func TestStateUpdateStore(t *testing.T) {
 			ArtifactGroup:     "TestGroup",
 			CompatibleDevices: []string{"vexpress-qemu"},
 			PayloadTypes:      []string{"rootfs-image"},
-			TypeProvides:      artifactTypeProvides,
+			TypeInfoProvides:  artifactTypeInfoProvides,
 		},
 		SupportsRollback: datastore.RollbackSupported,
 	}
@@ -865,8 +865,8 @@ func TestUpdateStoreDependencies(t *testing.T) {
 		CompatibleDevices: []string{"vexpress-qemu"},
 	}
 
-	stream, err := tests.CreateTestArtifactV3(artifactProvides,
-		artifactDepends, nil, nil, "test-image")
+	stream, err := tests.CreateTestArtifactV3("test-image", "gzip",
+		artifactProvides, artifactDepends, nil, nil)
 	require.NoError(t, err)
 
 	update := &datastore.UpdateInfo{
@@ -929,8 +929,8 @@ func TestStateWrongArtifactNameFromServer(t *testing.T) {
 		CompatibleDevices: []string{"vexpress-qemu"},
 	}
 
-	stream, err := tests.CreateTestArtifactV3(artifactProvides, artifactDepends,
-		nil, nil, "test")
+	stream, err := tests.CreateTestArtifactV3("test-image", "gzip",
+		artifactProvides, artifactDepends, nil, nil)
 	require.NoError(t, err)
 
 	update := &datastore.UpdateInfo{

--- a/app/transition_test.go
+++ b/app/transition_test.go
@@ -107,7 +107,7 @@ func TestTransitions(t *testing.T) {
 	tdir, err := ioutil.TempDir("", "mendertmp")
 	require.Nil(t, err)
 	st := store.NewDBStore(tdir)
-	require.Nil(t, StoreStateData(st, datastore.StateData{
+	require.Nil(t, datastore.StoreStateData(st, datastore.StateData{
 		Name:       datastore.MenderStateInit,
 		UpdateInfo: datastore.UpdateInfo{},
 	}))
@@ -186,7 +186,7 @@ func TestTransitions(t *testing.T) {
 			assert.IsType(t, tt.expectedS, s)
 			assert.False(t, c)
 			if tt.stateStored != datastore.MenderStateInit {
-				sd, err := LoadStateData(st)
+				sd, err := datastore.LoadStateData(st)
 				require.Nil(t, err)
 				assert.EqualValues(t, tt.stateStored, sd.Name, "Unexpected menderstate stored")
 			}

--- a/app/transition_test.go
+++ b/app/transition_test.go
@@ -259,15 +259,7 @@ func (sexec *stateScriptReportExecutor) CheckRootfsScriptsVersion() error {
 func TestTransitionReporting(t *testing.T) {
 
 	update := &datastore.UpdateInfo{
-		Artifact: struct {
-			Source struct {
-				URI    string
-				Expire string
-			}
-			CompatibleDevices []string `json:"device_types_compatible"`
-			ArtifactName      string   `json:"artifact_name"`
-			PayloadTypes      []string
-		}{
+		Artifact: datastore.Artifact{
 			Source: struct {
 				URI    string
 				Expire string

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -23,12 +23,23 @@ import (
 
 const (
 	errMsgReadingFromStoreF = "Error reading %q from datastore."
+
+	// This number should be kept quite a lot higher than the number of
+	// expected state storage operations, which is usually roughly
+	// equivalent to the number of state transitions.
+	MaximumStateDataStoreCount = 30
+)
+
+var (
+	// Special kind of error: When this error is returned by LoadStateData,
+	// the StateData will also be valid, and can be used to handle the error.
+	MaximumStateDataStoreCountExceeded error = errors.New(
+		"State data stored and retrieved maximum number of times")
 )
 
 // Loads artifact-provides (including artifact name) needed for dependency
 // checking before proceeding with installation of an artifact (version >= 3).
-func LoadProvidesFromStore(
-	store store.Store) (map[string]interface{}, error) {
+func LoadProvides(store store.Store) (map[string]interface{}, error) {
 	var providesBuf []byte
 	var provides = make(map[string]interface{})
 	var err error
@@ -48,14 +59,181 @@ func LoadProvidesFromStore(
 		provides["artifact_group"] = interface{}(string(providesBuf))
 	}
 	providesBuf, err = store.ReadAll(
-		ArtifactTypeProvidesKey)
+		ArtifactTypeInfoProvidesKey)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, errors.Wrapf(err, errMsgReadingFromStoreF,
-			"ArtifactTypeProvides")
+			"ArtifactTypeInfoProvides")
 	} else if err == nil {
 		if err = json.Unmarshal(providesBuf, &provides); err != nil {
 			return nil, err
 		}
 	}
 	return provides, nil
+}
+
+func StoreStateData(dbStore store.Store, sd StateData) error {
+	return StoreStateDataAndTransaction(dbStore, sd, nil)
+}
+
+// Execute storing the state and a custom transaction function atomically.
+func StoreStateDataAndTransaction(dbStore store.Store, sd StateData,
+	txnFunc func(txn store.Transaction) error) error {
+
+	// if the verions is not filled in, use the current one
+	if sd.Version == 0 {
+		sd.Version = StateDataVersion
+	}
+
+	var storeCountExceeded bool
+
+	err := dbStore.WriteTransaction(func(txn store.Transaction) error {
+		// Perform custom transaction operations, if any.
+		if txnFunc != nil {
+			err := txnFunc(txn)
+			if err != nil {
+				return err
+			}
+		}
+
+		var key string
+		if sd.UpdateInfo.HasDBSchemaUpdate {
+			key = StateDataKeyUncommitted
+		} else {
+			key = StateDataKey
+		}
+
+		// See if there is an existing entry and update the store count.
+		existingData, err := txn.ReadAll(key)
+		if err == nil {
+			var existing StateData
+			err := json.Unmarshal(existingData, &existing)
+			if err == nil {
+				sd.UpdateInfo.StateDataStoreCount = existing.UpdateInfo.StateDataStoreCount
+			}
+		}
+
+		if sd.UpdateInfo.StateDataStoreCount >= MaximumStateDataStoreCount {
+			// Reset store count to prevent subsequent states from
+			// hitting the same error.
+			sd.UpdateInfo.StateDataStoreCount = 0
+			storeCountExceeded = true
+		}
+
+		sd.UpdateInfo.StateDataStoreCount++
+		data, err := json.Marshal(sd)
+		if err != nil {
+			return err
+		}
+
+		if !sd.UpdateInfo.HasDBSchemaUpdate {
+			err = txn.Remove(StateDataKeyUncommitted)
+			if err != nil {
+				return err
+			}
+		}
+		return txn.WriteAll(key, data)
+	})
+
+	if storeCountExceeded {
+		return MaximumStateDataStoreCountExceeded
+	}
+
+	return err
+}
+
+func loadStateData(txn store.Transaction, key string) (StateData, error) {
+	var sd StateData
+
+	data, err := txn.ReadAll(key)
+	if err != nil {
+		return sd, err
+	}
+
+	// We are relying on the fact that Unmarshal will decode all and only
+	// the fields that it can find in the destination type.
+	err = json.Unmarshal(data, &sd)
+	if err != nil {
+		return sd, err
+	}
+
+	return sd, nil
+}
+
+func LoadStateData(dbStore store.Store) (StateData, error) {
+	var sd StateData
+	var storeCountExceeded bool
+
+	// We do the state data loading in a write transaction so that we can
+	// update the StateDataStoreCount.
+	err := dbStore.WriteTransaction(func(txn store.Transaction) error {
+		var err error
+		sd, err = loadStateData(txn, StateDataKey)
+		if err != nil {
+			return err
+		}
+
+		switch sd.Version {
+		case 0, 1:
+			// We need to upgrade the schema. Check if we have
+			// already written an updated one.
+			uncommSd, err := loadStateData(txn, StateDataKeyUncommitted)
+			if err == nil {
+				// Verify that the update IDs are equal,
+				// otherwise this may be a leftover remnant from
+				// an earlier update.
+				if sd.UpdateInfo.ID == uncommSd.UpdateInfo.ID {
+					// Use the uncommitted one instead.
+					sd = uncommSd
+				}
+			} else if err != os.ErrNotExist {
+				return err
+			}
+
+			// If we are upgrading the schema, we know for a fact
+			// that we came from a rootfs-image update, because it
+			// was the only thing that was supported there. Store
+			// this, since this information will be missing in
+			// databases before version 2.
+			sd.UpdateInfo.Artifact.PayloadTypes = []string{"rootfs-image"}
+			sd.UpdateInfo.RebootRequested = []RebootType{RebootTypeCustom}
+			sd.UpdateInfo.SupportsRollback = RollbackSupported
+
+			sd.UpdateInfo.HasDBSchemaUpdate = true
+
+		case 2:
+			sd.UpdateInfo.HasDBSchemaUpdate = false
+
+		default:
+			return errors.New("unsupported state data version")
+		}
+
+		sd.Version = StateDataVersion
+
+		if sd.UpdateInfo.StateDataStoreCount >= MaximumStateDataStoreCount {
+			// Reset store count to prevent subsequent states from
+			// hitting the same error.
+			sd.UpdateInfo.StateDataStoreCount = 0
+			storeCountExceeded = true
+		}
+
+		sd.UpdateInfo.StateDataStoreCount++
+		data, err := json.Marshal(sd)
+		if err != nil {
+			return err
+		}
+
+		// Store the updated count back in the database.
+		if sd.UpdateInfo.HasDBSchemaUpdate {
+			return txn.WriteAll(StateDataKeyUncommitted, data)
+		} else {
+			return txn.WriteAll(StateDataKey, data)
+		}
+
+	})
+
+	if storeCountExceeded {
+		return sd, MaximumStateDataStoreCountExceeded
+	}
+
+	return sd, err
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package datastore
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/mendersoftware/mender/store"
+	"github.com/pkg/errors"
+)
+
+const (
+	errMsgReadingFromStoreF = "Error reading %q from datastore."
+)
+
+// Loads artifact-provides (including artifact name) needed for dependency
+// checking before proceeding with installation of an artifact (version >= 3).
+func LoadProvidesFromStore(
+	store store.Store) (map[string]interface{}, error) {
+	var providesBuf []byte
+	var provides = make(map[string]interface{})
+	var err error
+
+	providesBuf, err = store.ReadAll(ArtifactNameKey)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, errMsgReadingFromStoreF,
+			"ArtifactName")
+	} else if err == nil {
+		provides["artifact_name"] = interface{}(string(providesBuf))
+	}
+	providesBuf, err = store.ReadAll(ArtifactGroupKey)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, errMsgReadingFromStoreF,
+			"ArtifactGroup")
+	} else if err == nil {
+		provides["artifact_group"] = interface{}(string(providesBuf))
+	}
+	providesBuf, err = store.ReadAll(
+		ArtifactTypeProvidesKey)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, errMsgReadingFromStoreF,
+			"ArtifactTypeProvides")
+	} else if err == nil {
+		if err = json.Unmarshal(providesBuf, &provides); err != nil {
+			return nil, err
+		}
+	}
+	return provides, nil
+}

--- a/datastore/dbkeys.go
+++ b/datastore/dbkeys.go
@@ -33,7 +33,7 @@ const (
 	// artifact version >= 3.
 	// NOTE: These provides are held in a separate key due to the header-
 	// info provides overlap with previous versions of mender artifact.
-	ArtifactTypeProvidesKey = "artifact-provides"
+	ArtifactTypeInfoProvidesKey = "artifact-provides"
 
 	// Key used to store the auth token.
 	AuthTokenName = "authtoken"

--- a/datastore/dbkeys.go
+++ b/datastore/dbkeys.go
@@ -24,6 +24,17 @@ const (
 	// Name of artifact currently installed. Introduced in Mender 2.0.0.
 	ArtifactNameKey = "artifact-name"
 
+	// Name of the group the currently installed artifact belongs to. For
+	// artifact version >= 3, this is held in the header-info artifact-
+	// provides field
+	ArtifactGroupKey = "artifact-group"
+
+	// Holds the current artifact provides from the type-info header of
+	// artifact version >= 3.
+	// NOTE: These provides are held in a separate key due to the header-
+	// info provides overlap with previous versions of mender artifact.
+	ArtifactTypeProvidesKey = "artifact-provides"
+
 	// Key used to store the auth token.
 	AuthTokenName = "authtoken"
 

--- a/datastore/standalone_data.go
+++ b/datastore/standalone_data.go
@@ -16,7 +16,9 @@ package datastore
 const StandaloneStateDataVersion = 1
 
 type StandaloneStateData struct {
-	Version      int
-	ArtifactName string
-	PayloadTypes []string
+	Version              int
+	ArtifactName         string
+	ArtifactGroup        string
+	ArtifactTypeProvides map[string]interface{}
+	PayloadTypes         []string
 }

--- a/datastore/standalone_data.go
+++ b/datastore/standalone_data.go
@@ -16,9 +16,9 @@ package datastore
 const StandaloneStateDataVersion = 1
 
 type StandaloneStateData struct {
-	Version              int
-	ArtifactName         string
-	ArtifactGroup        string
-	ArtifactTypeProvides map[string]interface{}
-	PayloadTypes         []string
+	Version                  int
+	ArtifactName             string
+	ArtifactGroup            string
+	ArtifactTypeInfoProvides map[string]interface{}
+	PayloadTypes             []string
 }

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -238,7 +238,7 @@ type Artifact struct {
 	ArtifactName  string `json:"artifact_name"`
 	ArtifactGroup string `json:"artifact_group"`
 	// Holds optional provides fields in the type-info header
-	TypeProvides map[string]interface{} `json:"artifact_provides,omitempty"`
+	TypeInfoProvides map[string]interface{} `json:"artifact_provides,omitempty"`
 }
 
 // Info about the update in progress.
@@ -279,8 +279,8 @@ func (ur *UpdateInfo) ArtifactGroup() string {
 	return ur.Artifact.ArtifactGroup
 }
 
-func (ur *UpdateInfo) ArtifactTypeProvides() map[string]interface{} {
-	return ur.Artifact.TypeProvides
+func (ur *UpdateInfo) ArtifactTypeInfoProvides() map[string]interface{} {
+	return ur.Artifact.TypeInfoProvides
 }
 
 func (ur *UpdateInfo) URI() string {

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -227,9 +227,18 @@ type Artifact struct {
 		URI    string
 		Expire string
 	}
+	// Compatible devices for dependency checking.
 	CompatibleDevices []string `json:"device_types_compatible"`
-	ArtifactName      string   `json:"artifact_name"`
-	PayloadTypes      []string
+	// What kind of payloads are embedded in the artifact
+	// (e.g. rootfs-image).
+	PayloadTypes []string
+	// The following two properties implements ArtifactProvides header-info
+	// field of artifact version >= 3. The Attributes are moved to the root
+	// of the Artifact structure for backwards compatability.
+	ArtifactName  string `json:"artifact_name"`
+	ArtifactGroup string `json:"artifact_group"`
+	// Holds optional provides fields in the type-info header
+	TypeProvides map[string]interface{} `json:"artifact_provides,omitempty"`
 }
 
 // Info about the update in progress.
@@ -264,6 +273,14 @@ func (ur *UpdateInfo) CompatibleDevices() []string {
 
 func (ur *UpdateInfo) ArtifactName() string {
 	return ur.Artifact.ArtifactName
+}
+
+func (ur *UpdateInfo) ArtifactGroup() string {
+	return ur.Artifact.ArtifactGroup
+}
+
+func (ur *UpdateInfo) ArtifactTypeProvides() map[string]interface{} {
+	return ur.Artifact.TypeProvides
 }
 
 func (ur *UpdateInfo) URI() string {

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -208,6 +208,23 @@ func (i *Installer) GetArtifactName() string {
 	return i.ar.GetArtifactName()
 }
 
+// Returns a list of compatible devices
+func (i *Installer) GetCompatibleDevices() []string {
+	return i.ar.GetCompatibleDevices()
+}
+
+// Returns the merged artifact provides header-info and type-info fields
+// for artifact version >= 3. Returns nil if version < 3
+func (i *Installer) GetArtifactProvides() (map[string]interface{}, error) {
+	return i.ar.MergeArtifactProvides()
+}
+
+// Returns the merged artifact depends header-info and type-info fields
+// for artifact version >= 3. Returns nil if version < 3
+func (i *Installer) GetArtifactDepends() (map[string]interface{}, error) {
+	return i.ar.MergeArtifactDepends()
+}
+
 func registerHandlers(ar *areader.Reader, inst *AllModules) error {
 
 	// Built-in rootfs handler.

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -35,7 +35,7 @@ func TestInstall(t *testing.T) {
 		DualRootfs: new(fDevice),
 	}
 
-	art, err := MakeRootfsImageArtifact(1, false, false)
+	art, err := MakeRootfsImageArtifact(2, false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, art)
 
@@ -45,7 +45,7 @@ func TestInstall(t *testing.T) {
 	assert.Contains(t, errors.Cause(err).Error(),
 		"not compatible with device fake-device")
 
-	art, err = MakeRootfsImageArtifact(1, false, false)
+	art, err = MakeRootfsImageArtifact(2, false, false)
 	assert.NoError(t, err)
 	_, err = Install(art, "vexpress-qemu", nil, "", &updateProducers)
 	assert.NoError(t, err)
@@ -81,7 +81,7 @@ func TestInstallSigned(t *testing.T) {
 	assert.NoError(t, err)
 
 	// have a key but artifact is v1
-	art, err = MakeRootfsImageArtifact(1, false, false)
+	art, err = MakeRootfsImageArtifact(2, false, false)
 	assert.NoError(t, err)
 	_, err = Install(art, "vexpress-qemu", []byte(PublicRSAKey), "", &updateProducers)
 	assert.Error(t, err)
@@ -303,7 +303,7 @@ func MakeRootfsImageArtifact(version int, signed bool,
 	var u handlers.Composer
 	switch version {
 	case 1:
-		u = handlers.NewRootfsV1(upd)
+		return nil, errors.New("Artifact version 1 is deprecated")
 	case 2:
 		u = handlers.NewRootfsV2(upd)
 	}

--- a/tests/artifact_utils.go
+++ b/tests/artifact_utils.go
@@ -1,0 +1,111 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package tests
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/awriter"
+	"github.com/mendersoftware/mender-artifact/handlers"
+)
+
+type ArtifactDepends artifact.ArtifactDepends
+type ArtifactProvides artifact.ArtifactProvides
+
+type artifactReadCloser struct {
+	*bytes.Reader
+}
+
+func (rc *artifactReadCloser) Close() error {
+	return nil
+}
+
+// Creates a test rootfs artifact (version 3) with rootfs content @data, and the
+// provided depends and provides.
+func CreateTestArtifactV3(artifactProvides *ArtifactProvides,
+	artifactDepends *ArtifactDepends,
+	typeProvides, typeDepends *map[string]interface{},
+	data string) (*artifactReadCloser, error) {
+	var artifactArgs *awriter.WriteArtifactArgs
+	buf := bytes.NewBuffer(nil)
+	compress := artifact.NewCompressorNone()
+	artifactWriter := awriter.NewWriter(buf, compress)
+	updateFile, err := createFakeUpdateFile(data)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(updateFile)
+	u := handlers.NewRootfsV3(updateFile)
+
+	artifactArgs = &awriter.WriteArtifactArgs{
+		Format:   "mender",
+		Version:  3,
+		Provides: (*artifact.ArtifactProvides)(artifactProvides),
+		Depends:  (*artifact.ArtifactDepends)(artifactDepends),
+		TypeInfoV3: &artifact.TypeInfoV3{
+			Type:             "rootfs-image",
+			ArtifactProvides: (*artifact.TypeInfoProvides)(typeProvides),
+			ArtifactDepends:  (*artifact.TypeInfoDepends)(typeDepends),
+		},
+		Updates: &awriter.Updates{Updates: []handlers.Composer{u}},
+	}
+	err = artifactWriter.WriteArtifact(artifactArgs)
+	if err != nil {
+		return nil, err
+	}
+	bufReadCloser := &artifactReadCloser{bytes.NewReader(buf.Bytes())}
+	return bufReadCloser, nil
+}
+
+// Creates a test rootfs artifact (version 2) with rootfs-content @data, and the
+// provided depends and provides.
+func CreateTestArtifactV2(artifactName string,
+	compatDevices []string) *bytes.Buffer {
+	var artifactArgs *awriter.WriteArtifactArgs
+	updateFile, err := createFakeUpdateFile("test")
+	if err != nil {
+		return nil
+	}
+	defer os.Remove(updateFile)
+	u := handlers.NewRootfsV2(updateFile)
+	artifactArgs = &awriter.WriteArtifactArgs{
+		Devices: compatDevices,
+		Format:  "mender",
+		Name:    artifactName,
+		Updates: &awriter.Updates{Updates: []handlers.Composer{u}},
+		Version: 2,
+	}
+	buf := bytes.NewBuffer(nil)
+	compress := artifact.NewCompressorNone()
+	artifactWriter := awriter.NewWriter(buf, compress)
+	artifactWriter.WriteArtifact(artifactArgs)
+	return buf
+}
+
+func createFakeUpdateFile(content string) (string, error) {
+	f, err := ioutil.TempFile("", "test_update")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if len(content) > 0 {
+		if _, err := f.WriteString(content); err != nil {
+			return "", err
+		}
+	}
+	return f.Name(), nil
+}

--- a/vendor/github.com/mendersoftware/mender-artifact/awriter/signer.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/awriter/signer.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package awriter
+
+import (
+	"archive/tar"
+	"io"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/pkg/errors"
+)
+
+var ErrAlreadyExistingSignature = errors.New("The Artifact is already signed, will not overwrite existing signature")
+var ErrManifestNotFound = errors.New("`manifest` not found. Corrupt Artifact?")
+
+// Special fast-track to just sign, nothing else. This skips all the expensive
+// and complicated repacking, and simply adds the manifest.sig file.
+func SignExisting(src io.Reader, dst io.Writer, key []byte, overwrite bool) error {
+	var foundManifest bool
+	rTar := tar.NewReader(src)
+	wTar := tar.NewWriter(dst)
+	for {
+		header, err := rTar.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrap(err, "Could not read tar header")
+		}
+
+		switch header.Name {
+		case "manifest":
+			err = signManifestAndOutputSignature(header, rTar, wTar, key)
+			if err != nil {
+				return err
+			}
+			foundManifest = true
+			continue
+		case "manifest.sig":
+			if overwrite {
+				continue
+			} else {
+				return ErrAlreadyExistingSignature
+			}
+		}
+
+		err = wTar.WriteHeader(header)
+		if err != nil {
+			return errors.Wrap(err, "Could not write tar header")
+		}
+
+		_, err = io.Copy(wTar, rTar)
+		if err != nil {
+			return errors.Wrap(err, "Failed to copy tar body")
+		}
+	}
+
+	err := wTar.Close()
+	if err != nil {
+		return errors.Wrap(err, "Could not finalize tar archive")
+	}
+
+	if !foundManifest {
+		return ErrManifestNotFound
+	}
+
+	return nil
+}
+
+func signManifestAndOutputSignature(header *tar.Header, src *tar.Reader, dst *tar.Writer, key []byte) error {
+	signer := artifact.NewSigner(key)
+	buf := make([]byte, header.Size)
+	read, err := src.Read(buf)
+	if err != nil && err != io.EOF {
+		return errors.Wrap(err, "Could not read manifest")
+	} else if int64(read) != header.Size {
+		return errors.New("Unexpected mismatch between header size and read size")
+	}
+
+	err = dst.WriteHeader(header)
+	if err != nil {
+		return errors.Wrap(err, "Could not write manifest header")
+	}
+	written, err := dst.Write(buf)
+	if err != nil {
+		return errors.Wrap(err, "Could not write manifest")
+	} else if written != read {
+		return errors.New("Could not write entire manifest")
+	}
+
+	signedBuf, err := signer.Sign(buf)
+	if err != nil {
+		return errors.Wrap(err, "Could not sign manifest")
+	}
+
+	signedHeader := &tar.Header{
+		Name: "manifest.sig",
+		Size: int64(len(signedBuf)),
+		Mode: 0644,
+	}
+
+	err = dst.WriteHeader(signedHeader)
+	if err != nil {
+		return errors.Wrap(err, "Could not write signature header")
+	}
+	written, err = dst.Write(signedBuf)
+	if err != nil {
+		return errors.Wrap(err, "Could not write signature")
+	} else if written != len(signedBuf) {
+		return errors.New("Could not write entire manifest.sig")
+	}
+
+	read, err = src.Read(buf)
+	if err != io.EOF || read != 0 {
+		return errors.New("File bigger than its header size")
+	}
+
+	return nil
+}

--- a/vendor/github.com/mendersoftware/mender-artifact/handlers/common.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/handlers/common.go
@@ -236,14 +236,3 @@ func writeTypeInfoV3(args *WriteInfoArgs) error {
 	}
 	return nil
 }
-
-func writeChecksums(tw *tar.Writer, files [](*DataFile), dir string) error {
-	for _, f := range files {
-		w := artifact.NewTarWriterStream(tw)
-		if err := w.Write(f.Checksum,
-			filepath.Join(dir, filepath.Base(f.Name)+".sha256sum")); err != nil {
-			return errors.Wrapf(err, "Payload: can not tar checksum for %v", f)
-		}
-	}
-	return nil
-}

--- a/vendor/github.com/mendersoftware/mender-artifact/handlers/rootfs_image.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/handlers/rootfs_image.go
@@ -32,21 +32,12 @@ type Rootfs struct {
 	regularHeaderRead bool
 
 	typeInfoV3 *artifact.TypeInfoV3
+	metaData   map[string]interface{}
 
 	// If this is augmented instance: The original instance.
 	original ArtifactUpdate
 
 	installerBase
-}
-
-func NewRootfsV1(updFile string) *Rootfs {
-	uf := &DataFile{
-		Name: updFile,
-	}
-	return &Rootfs{
-		update:  uf,
-		version: 1,
-	}
 }
 
 func NewRootfsV2(updFile string) *Rootfs {
@@ -139,7 +130,26 @@ func (rp *Rootfs) ReadHeader(r io.Reader, path string, version int, augmented bo
 		}
 
 	case filepath.Base(path) == "meta-data":
-		// TODO: implement when needed
+		dec := json.NewDecoder(r)
+		var data interface{}
+		err := dec.Decode(&data)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrap(err, "error reading meta-data")
+		}
+		jsonObj, ok := data.(map[string]interface{})
+		if !ok {
+			return errors.New("Top level object in meta-data must be a JSON object")
+		}
+		if augmented {
+			err = rp.setUpdateAugmentMetaData(jsonObj)
+		} else {
+			err = rp.setUpdateOriginalMetaData(jsonObj)
+		}
+		if err != nil {
+			return err
+		}
 	case match(artifact.HeaderDirectory+"/*/signatures/*", path),
 		match(artifact.HeaderDirectory+"/*/scripts/*/*", path):
 		if augmented {
@@ -247,6 +257,23 @@ func (rfs *Rootfs) GetUpdateMetaData() (map[string]interface{}, error) {
 	return rfs.GetUpdateOriginalMetaData(), nil
 }
 
+func (rfs *Rootfs) setUpdateOriginalMetaData(jsonObj map[string]interface{}) error {
+	if rfs.original != nil {
+		return errors.New("setUpdateOriginalMetaData() called on non-original instance.")
+	} else {
+		rfs.metaData = jsonObj
+	}
+	return nil
+}
+
+func (rfs *Rootfs) setUpdateAugmentMetaData(jsonObj map[string]interface{}) error {
+	if rfs.original == nil {
+		return errors.New("Called setUpdateAugmentMetaData() on non-augment instance")
+	}
+	rfs.metaData = jsonObj
+	return nil
+}
+
 func (rfs *Rootfs) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
 	if rfs.typeInfoV3 == nil {
 		return nil
@@ -262,7 +289,11 @@ func (rfs *Rootfs) GetUpdateOriginalProvides() *artifact.TypeInfoProvides {
 }
 
 func (rfs *Rootfs) GetUpdateOriginalMetaData() map[string]interface{} {
-	return nil
+	if rfs.original != nil {
+		return rfs.original.GetUpdateOriginalMetaData()
+	} else {
+		return rfs.metaData
+	}
 }
 
 func (rfs *Rootfs) GetUpdateAugmentDepends() *artifact.TypeInfoDepends {
@@ -274,7 +305,11 @@ func (rfs *Rootfs) GetUpdateAugmentProvides() *artifact.TypeInfoProvides {
 }
 
 func (rfs *Rootfs) GetUpdateAugmentMetaData() map[string]interface{} {
-	return nil
+	if rfs.original == nil {
+		return nil
+	} else {
+		return rfs.metaData
+	}
 }
 
 func (rfs *Rootfs) ComposeHeader(args *ComposeHeaderArgs) error {
@@ -323,13 +358,6 @@ func (rfs *Rootfs) ComposeHeader(args *ComposeHeaderArgs) error {
 		return errors.Wrap(err, "Payload: can not store meta-data")
 	}
 
-	if rfs.version == 1 {
-		// store checksums
-		if err := writeChecksums(args.TarWriter, [](*DataFile){rfs.update},
-			filepath.Join(path, "checksums")); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -41,28 +41,28 @@
 			"revisionTime": "2018-04-03T08:42:46Z"
 		},
 		{
-			"checksumSHA1": "khFSop9rQYVvpsyXaZlI3VVqS14=",
+			"checksumSHA1": "+2/9lrKx8K9Ea4wF7sXo3L10Byg=",
 			"path": "github.com/mendersoftware/mender-artifact/areader",
-			"revision": "ba8e1fa6557ce64076163c7eaa35f8381284b866",
-			"revisionTime": "2019-05-23T12:49:42Z"
+			"revision": "7c541c8f8348d6a11487c47e8c824ab55fbae5ae",
+			"revisionTime": "2019-11-18T11:56:43Z"
 		},
 		{
-			"checksumSHA1": "BQT3jSfjct9nFoq2y2ixs/wIDh0=",
+			"checksumSHA1": "8LsMfbSGddvwkqnTKFFrWXQnql0=",
 			"path": "github.com/mendersoftware/mender-artifact/artifact",
-			"revision": "ba8e1fa6557ce64076163c7eaa35f8381284b866",
-			"revisionTime": "2019-05-23T12:49:42Z"
+			"revision": "7c541c8f8348d6a11487c47e8c824ab55fbae5ae",
+			"revisionTime": "2019-11-18T11:56:43Z"
 		},
 		{
-			"checksumSHA1": "RUFJgDMsz3n2Wtz136UrpipDeRc=",
+			"checksumSHA1": "COqUP9VoKuMnKRdMwmBaurB5WJs=",
 			"path": "github.com/mendersoftware/mender-artifact/awriter",
-			"revision": "ba8e1fa6557ce64076163c7eaa35f8381284b866",
-			"revisionTime": "2019-05-23T12:49:42Z"
+			"revision": "7c541c8f8348d6a11487c47e8c824ab55fbae5ae",
+			"revisionTime": "2019-11-18T11:56:43Z"
 		},
 		{
-			"checksumSHA1": "oO9JrIxwr2b4ElOP9V+p3JcViVw=",
+			"checksumSHA1": "J1M72/QocbHblhT4TwyVpTO3gQs=",
 			"path": "github.com/mendersoftware/mender-artifact/handlers",
-			"revision": "ba8e1fa6557ce64076163c7eaa35f8381284b866",
-			"revisionTime": "2019-05-23T12:49:42Z"
+			"revision": "7c541c8f8348d6a11487c47e8c824ab55fbae5ae",
+			"revisionTime": "2019-11-18T11:56:43Z"
 		},
 		{
 			"checksumSHA1": "YGYg7j9+kmKncdC5UsI5FV237ts=",


### PR DESCRIPTION
The ArtifactName attribute is moved to the provides sub-structure of
statedata, keeping the old ArtifactName attribute for comatibility in
the base structure (NOTE: renamed the old attribute to
ArtifactNameAlias to mark it as an unused attribute).

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>