### PR TITLE
Setup fixup

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -278,8 +278,8 @@ func SetupCLI(args []string) error {
 					Destination: &runOptions.setupOptions.demo,
 					Usage:       "Use demo configuration."},
 				cli.BoolFlag{
-					Name:  "run-daemon",
-					Usage: "Run daemon after setup."},
+					Name:  "quiet",
+					Usage: "Suppress informative prompts."},
 			},
 		},
 		{
@@ -425,19 +425,7 @@ func (runOptions *runOptionsType) handleCLIOptions(ctx *cli.Context) error {
 			&runOptions.setupOptions); err != nil {
 			return err
 		}
-		if ctx.Bool("run-daemon") {
-			// Run daemon daemon
-			d, err := initDaemon(config, dualRootfsDevice,
-				env, runOptions)
-			if err != nil {
-				return err
-			}
-			fmt.Printf(promptDoneRunDaemon,
-				runOptions.setupOptions.deviceType,
-				runOptions.setupOptions.serverURL)
-			defer d.Cleanup()
-			return runDaemon(d)
-		} else {
+		if !ctx.Bool("quiet") {
 			fmt.Println(promptDone)
 		}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -256,7 +256,7 @@ func SetupCLI(args []string) error {
 				cli.StringFlag{
 					Name:        "tenant-token",
 					Destination: &runOptions.setupOptions.tenantToken,
-					Usage:       "Mender Professional tenanant `token`"},
+					Usage:       "Hosted Mender tenanant `token`"},
 				cli.IntFlag{
 					Name:        "inventory-poll",
 					Destination: &runOptions.setupOptions.invPollInterval,
@@ -270,9 +270,9 @@ func SetupCLI(args []string) error {
 					Destination: &runOptions.setupOptions.updatePollInterval,
 					Usage:       "Update poll interval in `sec`onds."},
 				cli.BoolFlag{
-					Name:        "mender-professional",
-					Destination: &runOptions.setupOptions.menderProfessional,
-					Usage:       "Setup device towards Mender Professional."},
+					Name:        "hosted-mender",
+					Destination: &runOptions.setupOptions.hostedMender,
+					Usage:       "Setup device towards Hosted Mender."},
 				cli.BoolFlag{
 					Name:        "demo",
 					Destination: &runOptions.setupOptions.demo,

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -52,7 +52,6 @@ type setupOptionsType struct {
 // ------------------------------ Setup constants ------------------------------
 const ( // state enum
 	stateDeviceType = iota
-	stateDeviceTypeConfirm
 	stateHostedMender
 	stateDemoMode
 	stateServerURL
@@ -97,16 +96,12 @@ const (
 	// Prompt constants
 	promptWizard = "Mender Client Setup\n" +
 		"===================\n\n" +
-		"Setting up the Mender client daemon: the daemon will " +
+		"Setting up the Mender client: The client will " +
 		"regularly poll the server to check for updates and report " +
 		"its inventory data.\nGet started by first configuring the " +
-	promptDoneRunDaemon = "Starting Mender client…\n" + // NOTE: format
-		"Your device should show up at %s within the next few " +
-		"minutes.\nLog in to your Mender UI at %s to accept it.\n"
 		"device type and settings for communicating with the server.\n"
 	promptDone         = "Mender setup successfully."
 	promptDeviceType   = "Device type (for example raspberrypi3-raspbian): "
-	promptConfirmDev   = "Confirm devicetype as %s? [Y/n] " // NOTE: format
 	promptHostedMender = "\nAre you connecting this device to " +
 		"hosted.mender.io? [Y/n] "
 	promptCredentials = "Enter your Hosted Mender credentials"
@@ -314,20 +309,7 @@ func (opts *setupOptionsType) askDeviceType(ctx *cli.Context,
 			return stateInvalid, err
 		}
 	}
-	return stateDeviceTypeConfirm, nil
-}
-
-func (opts *setupOptionsType) askConfirmDeviceType(ctx *cli.Context,
-	stdin *stdinReader) (int, error) {
-	prompt := fmt.Sprintf(promptConfirmDev, opts.deviceType)
-	ret, err := stdin.promptYN(prompt, true)
-	if err != nil {
-		return stateInvalid, err
-	}
-	if ret {
-		return stateHostedMender, nil
-	}
-	return stateDeviceType, nil
+	return stateHostedMender, nil
 }
 
 func (opts *setupOptionsType) askHostedMender(ctx *cli.Context,
@@ -726,16 +708,15 @@ func doSetup(ctx *cli.Context, config *conf.MenderConfigFromFile,
 	}
 
 	// Prompt 'wizard' message
-	fmt.Println(promptWizard)
+	if !ctx.Bool("quiet") {
+		fmt.Println(promptWizard)
+	}
 
 	// Prompt the user for config options if not specified by flags
 	for state != stateDone {
 		switch state {
 		case stateDeviceType:
 			state, err = opts.askDeviceType(ctx, stdin)
-
-		case stateDeviceTypeConfirm:
-			state, err = opts.askConfirmDeviceType(ctx, stdin)
 
 		case stateHostedMender:
 			state, err = opts.askHostedMender(ctx, stdin)

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -15,7 +15,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -41,7 +40,7 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.Int("inventory-poll", defaultInventoryPoll, "")
 	flagSet.Int("retry-poll", defaultRetryPoll, "")
 	flagSet.Int("update-poll", defaultUpdatePoll, "")
-	flagSet.Bool("mender-professional", false, "")
+	flagSet.Bool("hosted-mender", false, "")
 	flagSet.Bool("demo", false, "")
 	flagSet.Bool("run-daemon", false, "")
 	return flagSet
@@ -81,16 +80,16 @@ func TestSetupInteractiveMode(t *testing.T) {
 	opts := &runOptions.setupOptions
 
 	// Need to set tenant token to skip username/password
-	// prompt in case of Mender Professional=Y
+	// prompt in case of Hosted Mender=Y
 	ctx.Set("tenant-token", "dummy-token")
 	// NOTE: we also need to set the setupOptions which cli.App otherwise
 	//       handles for us.
 	opts.tenantToken = "dummy-token"
 
-	// Demo mode no Mender Professional
+	// Demo mode no Hosted Mender
 	stdinW.WriteString("blueberry-pi\n") // Device type?
 	stdinW.WriteString("Y\n")            // Confirm device?
-	stdinW.WriteString("N\n")            // Mender Professional?
+	stdinW.WriteString("N\n")            // Hosted Mender?
 	stdinW.WriteString("Y\n")            // Demo mode?
 	stdinW.WriteString("\n")             // Server IP? (default)
 	err = doSetup(ctx, config, opts)
@@ -100,10 +99,10 @@ func TestSetupInteractiveMode(t *testing.T) {
 	assert.Equal(t, demoRetryPoll, config.RetryPollIntervalSeconds)
 	assert.Equal(t, demoServerCertificate, config.ServerCertificate)
 
-	// Demo mode with Mender Professional
+	// Demo mode with Hosted Mender
 	stdinW.WriteString("banana-pi\n") // Device type?
 	stdinW.WriteString("Y\n")         // Confirm device?
-	stdinW.WriteString("Y\n")         // Mender Professional?
+	stdinW.WriteString("Y\n")         // Hosted Mender?
 	stdinW.WriteString("Y\n")         // Demo mode?
 	err = doSetup(ctx, config, opts)
 	assert.NoError(t, err)
@@ -112,10 +111,10 @@ func TestSetupInteractiveMode(t *testing.T) {
 	assert.Equal(t, demoRetryPoll, config.RetryPollIntervalSeconds)
 	assert.Equal(t, "", config.ServerCertificate)
 
-	// Mender Professional no demo
+	// Hosted Mender no demo
 	stdinW.WriteString("raspberrypi3\n") // Device type?
 	stdinW.WriteString("Y\n")            // Confirm device?
-	stdinW.WriteString("Y\n")            // Mender Professional?
+	stdinW.WriteString("Y\n")            // Hosted Mender?
 	stdinW.WriteString("N\n")            // Demo mode?
 	stdinW.WriteString("100\n")          // Update poll interval
 	stdinW.WriteString("200\n")          // Inventory poll interval
@@ -137,10 +136,10 @@ func TestSetupInteractiveMode(t *testing.T) {
 	assert.Equal(t, "dummy-token", config.TenantToken)
 	assert.Equal(t, "", config.ServerCertificate)
 
-	// No demo nor Mender Professional
+	// No demo nor Hosted Mender
 	stdinW.WriteString("beagle-pi\n")               // Device type?
 	stdinW.WriteString("Y\n")                       // Confirm device?
-	stdinW.WriteString("N\n")                       // Mender Professional?
+	stdinW.WriteString("N\n")                       // Hosted Mender?
 	stdinW.WriteString("N\n")                       // Demo mode?
 	stdinW.WriteString("https://acme.mender.io/\n") // ServerURL
 	stdinW.WriteString("\n")                        // Server certificate
@@ -172,9 +171,8 @@ func TestSetupFlags(t *testing.T) {
 
 	ctx.Set("tenant-token", "dummy-token")
 	opts.tenantToken = "dummy-token"
-	fmt.Println(ctx.String("tenant-token"))
-	ctx.Set("mender-professional", "true")
-	opts.menderProfessional = true
+	ctx.Set("hosted-mender", "true")
+	opts.hostedMender = true
 	ctx.Set("device-type", "acme-pi")
 	opts.deviceType = "acme-pi"
 	ctx.Set("demo", "true")
@@ -192,8 +190,8 @@ func TestSetupFlags(t *testing.T) {
 
 	ctx.Set("device-type", "bagel-bone")
 	opts.deviceType = "bagel-bone"
-	ctx.Set("mender-professional", "false")
-	opts.menderProfessional = false
+	ctx.Set("hosted-mender", "false")
+	opts.hostedMender = false
 	ctx.Set("server-ip", "1.2.3.4")
 	opts.serverIP = "1.2.3.4"
 	err = doSetup(ctx, config, opts)
@@ -218,9 +216,8 @@ func TestSetupFlags(t *testing.T) {
 	opts.invPollInterval = 456
 	ctx.Set("retry-poll", "789")
 	opts.retryPollInterval = 789
-	ctx.Set("mender-professional", "false")
-	fmt.Println(ctx.Bool("mender-professional"))
-	opts.menderProfessional = false
+	ctx.Set("hosted-mender", "false")
+	opts.hostedMender = false
 	ctx.Set("server-url", "https://docker.menderine.io")
 	opts.serverURL = "https://docker.menderine.io"
 	err = doSetup(ctx, config, opts)
@@ -234,9 +231,9 @@ func TestSetupFlags(t *testing.T) {
 	assert.Equal(t, "https://docker.menderine.io",
 		config.Servers[0].ServerURL)
 
-	// Mender Professional no demo -- same parameters as above
-	ctx.Set("mender-professional", "true")
-	opts.menderProfessional = true
+	// Hosted Mender no demo -- same parameters as above
+	ctx.Set("hosted-mender", "true")
+	opts.hostedMender = true
 	err = doSetup(ctx, config, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://hosted.mender.io", config.Servers[0].ServerURL)

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -42,6 +42,7 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.Int("update-poll", defaultUpdatePoll, "")
 	flagSet.Bool("hosted-mender", false, "")
 	flagSet.Bool("demo", false, "")
+	flagSet.Bool("quiet", false, "")
 	flagSet.Bool("run-daemon", false, "")
 	return flagSet
 }
@@ -49,6 +50,7 @@ func newFlagSet() *flag.FlagSet {
 func initCLITest(t *testing.T, flagSet *flag.FlagSet) (*cli.Context,
 	*conf.MenderConfigFromFile, *runOptionsType) {
 	ctx := cli.NewContext(&cli.App{}, flagSet, nil)
+	ctx.Set("quiet", "true")
 	tmpDir, err := ioutil.TempDir("", "tmpConf")
 	assert.NoError(t, err)
 	confPath := path.Join(tmpDir, "mender.conf")


### PR DESCRIPTION
Rename `--mender-professional` flag to `--hosted-mender`, and adding a `quiet` option to suppress informative prompts.
I also removed the `run-daemon` option from setup flags as it seems redundant.