### PR TITLE
Trigger mender-dist-packages Pipeline on master builds also

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,3 +68,4 @@ trigger:mender-dist-packages:
       https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
   only:
     - tags
+    - master


### PR DESCRIPTION
Trigger mender-dist-packages Pipeline on master builds also

The intention was to rebuild mender-dist-packages on master always to be
able to early catch regressions. So the condition was just missing.