### PR TITLE
Skip special device "rootfs" when determining rootfs type

### DIFF
--- a/support/mender-inventory-rootfs-type
+++ b/support/mender-inventory-rootfs-type
@@ -3,4 +3,7 @@
 # Determines what the root filesystem type is.
 
 FS_TYPE="$(grep ' / ' /proc/mounts | grep -v "^rootfs" | awk '{print $3}')"
+if [ -z "${FS_TYPE}" ]; then
+    FS_TYPE=Unknown
+fi
 echo rootfs_type="$FS_TYPE"

--- a/support/mender-inventory-rootfs-type
+++ b/support/mender-inventory-rootfs-type
@@ -2,5 +2,5 @@
 
 # Determines what the root filesystem type is.
 
-FS_TYPE="$(grep ' / ' /proc/mounts | awk '{print $3}')"
+FS_TYPE="$(grep ' / ' /proc/mounts | grep -v "^rootfs" | awk '{print $3}')"
 echo rootfs_type="$FS_TYPE"


### PR DESCRIPTION
Some kernels (confirmed on at least 2.6.37) have a special "rootfs" device
in /proc/mounts:
```
rootfs / rootfs rw 0 0
ubi0_0 / ubifs ro,relatime 0 0
devtmpfs /dev devtmpfs rw,relatime,size=121740k,nr_inodes=30435,mode=755 0 0
proc /proc proc rw,relatime 0 0
devpts /dev/pts devpts rw,relatime,gid=5,mode=620 0 0
tmpfs /dev/shm tmpfs rw,relatime,mode=777 0 0
tmpfs /tmp tmpfs rw,relatime 0 0
tmpfs /run tmpfs rw,nosuid,nodev,relatime,mode=755 0 0
sysfs /sys sysfs rw,relatime 0 0
ubi0:data /data ubifs rw,relatime 0 0
```
Make sure to skip this "rootfs" device when determining rootfs type.