### PR TITLE
New command: `snapshot ssh`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -311,6 +311,27 @@ func SetupCLI(args []string) error {
 			},
 		},
 		{
+			Name:        "snapshot",
+			Description: snapshotDescription,
+			Subcommands: []cli.Command{
+				{
+					Name:  "dump",
+					Usage: "Dumps rootfs to stdout.",
+					Action: func(ctx *cli.Context) error {
+						// Expected to return ENOTTY
+						_, err := unix.IoctlGetTermios(
+							int(os.Stdout.Fd()),
+							unix.TCGETS)
+						if err == nil {
+							return errDumpTerminal
+						}
+						return runOptions.
+							CopySnapshot(ctx, os.Stdout)
+					},
+				},
+			},
+		},
+		{
 			Name: "show-artifact",
 			Usage: "Print the current artifact name to the " +
 				"command line and exit.",

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -314,6 +314,14 @@ func SetupCLI(args []string) error {
 						return runOptions.
 							CopySnapshot(ctx, os.Stdout)
 					},
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name: "quiet, q",
+							Usage: "Suppress logs " +
+								"and output " +
+								"to stderr",
+						},
+					},
 				},
 				{
 					Name:        "ssh",
@@ -332,6 +340,14 @@ func SetupCLI(args []string) error {
 								"at target " +
 								"host.",
 							Required: true,
+						},
+						cli.BoolFlag{
+							Name: "quiet, q",
+							Usage: "Suppress logs " +
+								"and output " +
+								"to stderr " +
+								"(except ssh " +
+								"prompts)",
 						},
 					},
 				},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,23 +49,32 @@ const (
 	appDescription = "" +
 		"mender integrates both the mender daemon and commands " +
 		"for manually performing tasks performed by the daemon " +
-		"(see list of commands below).\n\n" +
+		"(see list of COMMANDS below).\n\n" +
 		"Global flag remarks.\n" +
 		"  - Supported log levels incudes: 'debug', 'info', " +
 		"'warning', 'error', 'panic' and 'fatal'.\n" +
 		"  - Debug log level is never logged to syslog."
 	snapshotDescription = "Creates a snapshot of the currently running " +
-		"rootfs. Refer to the list of commands to specify where to " +
-		"stream the image."
+		"rootfs. The snapshots can be passed as a rootfs-image to the " +
+		"mender-artifact tool to create an update based on THIS " +
+		"device's rootfs. Refer to the list of COMMANDS to specify " +
+		"where to stream the image.\n" +
+		"\t NOTE: If the process gets killed (e.g. by SIGKILL) " +
+		"while a snapshot is in progress, the system may freeze - " +
+		"forcing you to manually hard-reboot the device. " +
+		"Use at your own risk - preferably on a device that " +
+		"is physically accessible."
 	snapshotDumpDescription = "Dump rootfs to standard out. Exits if " +
 		"output isn't redirected."
-	snapshotSSHDescription = "Dump rootfs directly to an ssh host. " +
-		"Positional arguments are passed directly to ssh.\n" +
-		"\t See ssh(1) man page for a complete list of ssh " +
+	snapshotSSHDescription = "Dump currently mounted root filesystem " +
+		"directly to a host using ssh(1), where it can be packaged " +
+		"and uploaded as a Mender Artifact to Mender server. " +
+		"Positional arguments are passed directly to ssh. " +
+		"See ssh(1) man page for a complete list of " +
 		"options.\n\n" +
 		"EXAMPLE:\n" +
 		"\t mender snapshot ssh --file /tmp/rootfs.ext4 " +
-		"-- -i $PRIVATE_KEY $USER@$HOST"
+		"-- -i $PRIVATE_KEY $USER@$HOST:$PORT"
 )
 
 const (
@@ -113,6 +122,31 @@ func transformDeprecatedArgs(args []string) []string {
 
 func SetupCLI(args []string) error {
 	runOptions := &runOptionsType{}
+	// There's a bug in github.com/urfave/cli making all commands use
+	// SubCommandHelpTemplate - which has a nasty way of formating command
+	// descriptions
+	cli.SubcommandHelpTemplate = `NAME:
+   {{.HelpName}} {{if .Usage}}- {{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command` +
+		`{{if .VisibleFlags}} [command options]{{end}} ` +
+		`{{if .ArgsUsage}}{{.ArgsUsage}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
 	// Filter commandline arguments for backwards compatability.
 	// FIXME: Remove argument filtering in Mender v3.0
 	args = transformDeprecatedArgs(args)
@@ -349,27 +383,6 @@ func SetupCLI(args []string) error {
 								"(except ssh " +
 								"prompts)",
 						},
-					},
-				},
-			},
-		},
-		{
-			Name:        "snapshot",
-			Description: snapshotDescription,
-			Subcommands: []cli.Command{
-				{
-					Name:  "dump",
-					Usage: "Dumps rootfs to stdout.",
-					Action: func(ctx *cli.Context) error {
-						// Expected to return ENOTTY
-						_, err := unix.IoctlGetTermios(
-							int(os.Stdout.Fd()),
-							unix.TCGETS)
-						if err == nil {
-							return errDumpTerminal
-						}
-						return runOptions.
-							CopySnapshot(ctx, os.Stdout)
 					},
 				},
 			},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -59,6 +59,13 @@ const (
 		"stream the image."
 	snapshotDumpDescription = "Dump rootfs to standard out. Exits if " +
 		"output isn't redirected."
+	snapshotSSHDescription = "Dump rootfs directly to an ssh host. " +
+		"Positional arguments are passed directly to ssh.\n" +
+		"\t See ssh(1) man page for a complete list of ssh " +
+		"options.\n\n" +
+		"EXAMPLE:\n" +
+		"\t mender snapshot ssh --file /tmp/rootfs.ext4 " +
+		"-- -i $PRIVATE_KEY $USER@$HOST"
 )
 
 const (
@@ -306,6 +313,26 @@ func SetupCLI(args []string) error {
 						}
 						return runOptions.
 							CopySnapshot(ctx, os.Stdout)
+					},
+				},
+				{
+					Name:        "ssh",
+					Description: snapshotSSHDescription,
+					Usage:       "Write rootfs to ssh host",
+					UsageText: "mender snapshot ssh " +
+						"[command options] -- " +
+						"<user@host> [ssh options]",
+					Action: func(ctx *cli.Context) error {
+						return runOptions.DumpSSH(ctx)
+					},
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name: "output-file, o",
+							Usage: "File `PATH` " +
+								"at target " +
+								"host.",
+							Required: true,
+						},
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ func doMain() int {
 			log.Warnln(err.Error())
 			return 2
 		} else {
-			log.Errorln(err.Error())
+			log.Fatalln(err.Error())
 			return 1
 		}
 	}


### PR DESCRIPTION
New sub-command that redirects the snapshot to a remote host over ssh.

I also included a quiet flag to the `snapshot [dump|ssh]` command