### PR TITLE
Fix: Pass Go vet check on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,7 @@ gofmt:
 
 govet:
 	echo "-- checking with govet"
-	for file in $(PKGFILES_notest) ; do \
-		$(GO) vet -unsafeptr=false $$file; \
-	done
+	$(GO) vet -unsafeptr=false
 
 godeadcode:
 	echo "-- checking for dead code"

--- a/app/mender_test.go
+++ b/app/mender_test.go
@@ -630,8 +630,8 @@ func TestAuthToken(t *testing.T) {
 
 	ts.Update.Unauthorized = true
 	ts.Update.Current = client.CurrentUpdate{
-		"fake-id",
-		"foo-bar",
+		Artifact:   "fake-id",
+		DeviceType: "foo-bar",
 	}
 
 	td, _ := ioutil.TempDir("", "mender-install-update-")

--- a/client/update_resumer_test.go
+++ b/client/update_resumer_test.go
@@ -129,7 +129,10 @@ func testBrokenReadAndPartialDownload_oneCase(t *testing.T, h *testHandler) {
 	expected, err := ioutil.ReadAll(f)
 	assert.NoError(t, err)
 
-	backupServer := server
+	backupServer := http.Server{
+		Addr:    h.addr,
+		Handler: h,
+	}
 
 	server.SetKeepAlivesEnabled(false)
 	backupServer.SetKeepAlivesEnabled(false)

--- a/installer/modules_test.go
+++ b/installer/modules_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ func TestStreamsTree(t *testing.T) {
 
 	headerInfo := artifact.NewHeaderInfoV3([]artifact.UpdateType{
 		artifact.UpdateType{
-			"test-type",
+			Type: "test-type",
 		},
 	}, &prov, &dep)
 

--- a/inventory/inventory_data_test.go
+++ b/inventory/inventory_data_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -29,24 +29,38 @@ func TestInventoryDataDecoder(t *testing.T) {
 		"foo": []string{"bar"},
 	})
 
-	assert.Contains(t, idec.GetInventoryData(), client.InventoryAttribute{"foo", "bar"})
+	assert.Contains(t, idec.GetInventoryData(), client.InventoryAttribute{
+		Name:  "foo",
+		Value: "bar",
+	})
 
 	idec.AppendFromRaw(map[string][]string{
 		"foo": []string{"baz"},
 	})
 	assert.Contains(t, idec.data, "foo")
 	assert.Contains(t, idec.GetInventoryData(),
-		client.InventoryAttribute{"foo", []string{"bar", "baz"}})
+		client.InventoryAttribute{
+			Name:  "foo",
+			Value: []string{"bar", "baz"}})
 
 	idec.AppendFromRaw(map[string][]string{
 		"bar": []string{"zen"},
 	})
 	assert.Contains(t, idec.GetInventoryData(),
-		client.InventoryAttribute{"foo", []string{"bar", "baz"}})
-	assert.Contains(t, idec.GetInventoryData(), client.InventoryAttribute{"bar", "zen"})
+		client.InventoryAttribute{
+			Name:  "foo",
+			Value: []string{"bar", "baz"}})
+	assert.Contains(t, idec.GetInventoryData(), client.InventoryAttribute{
+		Name:  "bar",
+		Value: "zen",
+	})
 
 	idata := idec.GetInventoryData()
 	assert.Len(t, idata, 2)
-	assert.Contains(t, idata, client.InventoryAttribute{"foo", []string{"bar", "baz"}})
-	assert.Contains(t, idata, client.InventoryAttribute{"bar", "zen"})
+	assert.Contains(t, idata, client.InventoryAttribute{
+		Name:  "foo",
+		Value: []string{"bar", "baz"}})
+	assert.Contains(t, idata, client.InventoryAttribute{
+		Name:  "bar",
+		Value: "zen"})
 }


### PR DESCRIPTION
The newly added go vet check failed on master, due to a merge that was not
rebased. This fixes the vet errors, as well as adds it to all the test-files,
which was previously not done.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>