### PR TITLE
MEN-3047: Fix crash when specified certificate can't be opened.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -603,7 +603,6 @@ func checkWritePermissions(dir string) error {
 			"permission to write to data store "+
 			"directory %q", dir)
 	} else if err != nil {
-		os.Remove(f.Name())
 		return errors.Wrapf(err,
 			"Error checking write permissions to "+
 				"directory %q", dir)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -52,12 +52,6 @@ type runOptionsType struct {
 	setupOptions setupOptionsType // Options for setup subcommand
 }
 
-const (
-	errMissingServerCertstr = "IGNORING ERROR: The client server-certificate can not be loaded error: (%s). The client will " +
-		"continue running, but will not be able to communicate with the server. If this is not your intention " +
-		"please add a valid server certificate"
-)
-
 func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPieces, error) {
 
 	tentok := config.GetTenantToken()
@@ -195,13 +189,8 @@ func initDaemon(config *conf.MenderConfig,
 
 	controller, err := app.NewMender(config, *mp)
 	if err != nil {
-		// Ignore server certificate error  (See: MEN-2378)
-		if _, ok := errors.Cause(err).(*client.ClientServerCertificateError); ok {
-			log.Warningf(errMissingServerCertstr, err)
-		} else {
-			mp.Store.Close()
-			return nil, errors.Wrap(err, "error initializing mender controller")
-		}
+		mp.Store.Close()
+		return nil, errors.Wrap(err, "error initializing mender controller")
 	}
 
 	if opts.bootstrapForce {

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -175,7 +175,6 @@ func TestClientAuthNoCert(t *testing.T) {
 	ac, err := NewApiClient(
 		Config{"server.non-existing.crt", true, false},
 	)
-	assert.Nil(t, ac)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot initialize server trust")
+	assert.NotNil(t, ac)
+	assert.NoError(t, err)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -60,12 +60,12 @@ func TestHttpClient(t *testing.T) {
 	cl, _ = NewApiClient(Config{})
 	assert.NotNil(t, cl)
 
-	// missing cert in config should yield an error
+	// missing cert in config should still yield usable client
 	cl, err := NewApiClient(
 		Config{"missing.crt", true, false},
 	)
-	assert.Nil(t, cl)
-	assert.NotNil(t, err)
+	assert.NotNil(t, cl)
+	assert.NoError(t, err)
 }
 
 func TestApiClientRequest(t *testing.T) {
@@ -239,6 +239,12 @@ func TestEmptySystemCertPool(t *testing.T) {
 	certs, err := loadServerTrust(conf)
 	assert.NoError(t, err)
 	assert.NotZero(t, certs)
+
+	conf.ServerCert = "does-not-exist.crt"
+
+	certs, err = loadServerTrust(conf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "No trusted certificates")
 }
 
 func TestExponentialBackoffTimeCalculation(t *testing.T) {


### PR DESCRIPTION
```
commit 282ccabca28c4c21006c420b1c0dcfe0e8d41bfa
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Jan 20 12:17:00 2020

    MEN-3047: Fix crash when specified certificate can't be opened.
    
    It behaves essentially the same as if the certificate was not
    specified, and uses only the system CA certificates (though with a big
    warning in the log). However, if it cannot find *any* certificates, it
    will fail with an error message.
    
    Changelog: Commit
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 1c8202451e89ee8768e2b2483d0a71fe5c20a5ec
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jan 16 14:21:59 2020

    setup: Treat read-only filesystem the same as normal permission error.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b3fe9dd71905e2c4983fb3a33c339d40bea5e736
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jan 16 13:14:37 2020

    Fix segfault after temporary file creation fails.
    
    It is an error to access the file object when the TempFile call has
    failed. It won't exist in this case anyway, so the call is not needed.
    
    Changelog: Fix segfault when running `mender setup` on a read-only
    filesystem.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```