### PR TITLE
MEN-3047: Fix crash when specified certificate can't be opened.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -603,7 +603,6 @@ func checkWritePermissions(dir string) error {
 			"permission to write to data store "+
 			"directory %q", dir)
 	} else if err != nil {
-		os.Remove(f.Name())
 		return errors.Wrapf(err,
 			"Error checking write permissions to "+
 				"directory %q", dir)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -52,12 +52,6 @@ type runOptionsType struct {
 	setupOptions setupOptionsType // Options for setup subcommand
 }
 
-const (
-	errMissingServerCertstr = "IGNORING ERROR: The client server-certificate can not be loaded error: (%s). The client will " +
-		"continue running, but will not be able to communicate with the server. If this is not your intention " +
-		"please add a valid server certificate"
-)
-
 func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPieces, error) {
 
 	tentok := config.GetTenantToken()
@@ -195,13 +189,8 @@ func initDaemon(config *conf.MenderConfig,
 
 	controller, err := app.NewMender(config, *mp)
 	if err != nil {
-		// Ignore server certificate error  (See: MEN-2378)
-		if _, ok := errors.Cause(err).(*client.ClientServerCertificateError); ok {
-			log.Warningf(errMissingServerCertstr, err)
-		} else {
-			mp.Store.Close()
-			return nil, errors.Wrap(err, "error initializing mender controller")
-		}
+		mp.Store.Close()
+		return nil, errors.Wrap(err, "error initializing mender controller")
 	}
 
 	if opts.bootstrapForce {

--- a/client/client.go
+++ b/client/client.go
@@ -33,10 +33,14 @@ import (
 
 const (
 	apiPrefix = "/api/devices/v1/"
-)
 
-var (
-	errorAddingServerCertificateToPool = errors.New("Error adding trusted server certificate to pool.")
+	errMissingServerCertF = "IGNORING ERROR: The client server-certificate can not be " +
+		"loaded: (%s). The client will continue running, but may not be able to " +
+		"communicate with the server. If this is not your intention please add a valid " +
+		"server certificate"
+	errMissingCerts = "No trusted certificates. The client will continue running, but will " +
+		"not be able to communicate with the server. Either specify ServerCertificate in " +
+		"mender.conf, or make sure that CA certificates are installed on the system"
 )
 
 var (
@@ -276,21 +280,10 @@ func newHttpClient() *http.Client {
 	return &http.Client{}
 }
 
-type ClientServerCertificateError struct {
-	err error
-}
-
-func (s *ClientServerCertificateError) Error() string {
-	return errors.Wrapf(s.err, "cannot initialize server trust").Error()
-}
-
 func newHttpsClient(conf Config) (*http.Client, error) {
 	client := newHttpClient()
 
-	trustedcerts, err := loadServerTrust(conf)
-	if err != nil {
-		return nil, &ClientServerCertificateError{err}
-	}
+	trustedcerts := loadServerTrust(&conf)
 
 	if conf.NoVerify {
 		log.Warnf("certificate verification skipped..")
@@ -316,39 +309,31 @@ type Config struct {
 	NoVerify   bool
 }
 
-func loadServerTrust(conf Config) (*x509.CertPool, error) {
-	if conf.ServerCert == "" {
-		// Returning nil will make tls.Config.RootCAs nil, which causes
-		// tls module to use system certs.
-		return nil, nil
-	}
+type systemCertPoolGetter interface {
+	GetSystemCertPool() (*x509.CertPool, error)
+}
 
-	syscerts, err := x509.SystemCertPool()
+type systemCertPool struct{}
+
+func (systemCertPool) GetSystemCertPool() (*x509.CertPool, error) {
+	return x509.SystemCertPool()
+}
+
+func loadServerTrust(conf *Config) *x509.CertPool {
+	return loadServerTrustImpl(conf, systemCertPool{})
+}
+
+func loadServerTrustImpl(conf *Config, scp systemCertPoolGetter) *x509.CertPool {
+	syscerts, err := scp.GetSystemCertPool()
 	if err != nil {
-		return nil, err
+		log.Warnf("Error when loading system certificates: %s", err.Error())
 	}
 
 	// Read certificate file.
 	servcert, err := ioutil.ReadFile(conf.ServerCert)
 	if err != nil {
-		log.Errorf("%s is inaccessible: %s", conf.ServerCert, err.Error())
-		return nil, err
-	}
-
-	if len(servcert) == 0 {
-		log.Errorf("Both %s and the system certificate pool are empty.",
-			conf.ServerCert)
-		return nil, errors.New("server certificate is empty")
-	}
-
-	block, _ := pem.Decode([]byte(servcert))
-	if block != nil {
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err == nil {
-			log.Infof("API Gateway certificate (in PEM format): \n%s", string(servcert))
-			log.Infof("Issuer: %s, Valid from: %s, Valid to: %s",
-				cert.Issuer.Organization, cert.NotBefore, cert.NotAfter)
-		}
+		// Ignore server certificate error  (See: MEN-2378)
+		log.Warnf(errMissingServerCertF, err.Error())
 	}
 
 	if syscerts == nil {
@@ -356,12 +341,24 @@ func loadServerTrust(conf Config) (*x509.CertPool, error) {
 		syscerts = x509.NewCertPool()
 	}
 
-	syscerts.AppendCertsFromPEM(servcert)
+	if len(servcert) > 0 {
+		block, _ := pem.Decode([]byte(servcert))
+		if block != nil {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err == nil {
+				log.Infof("API Gateway certificate (in PEM format): \n%s", string(servcert))
+				log.Infof("Issuer: %s, Valid from: %s, Valid to: %s",
+					cert.Issuer.Organization, cert.NotBefore, cert.NotAfter)
+			}
+		}
+
+		syscerts.AppendCertsFromPEM(servcert)
+	}
 
 	if len(syscerts.Subjects()) == 0 {
-		return nil, errorAddingServerCertificateToPool
+		log.Error(errMissingCerts)
 	}
-	return syscerts, nil
+	return syscerts
 }
 
 func buildURL(server string) string {

--- a/client/client.go
+++ b/client/client.go
@@ -349,6 +349,8 @@ func loadServerTrustImpl(conf *Config, scp systemCertPoolGetter) *x509.CertPool 
 				log.Infof("API Gateway certificate (in PEM format): \n%s", string(servcert))
 				log.Infof("Issuer: %s, Valid from: %s, Valid to: %s",
 					cert.Issuer.Organization, cert.NotBefore, cert.NotAfter)
+			} else {
+				log.Warnf("Unparseable certificate '%s': %s", conf.ServerCert, err.Error())
 			}
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -342,7 +342,7 @@ func loadServerTrustImpl(conf *Config, scp systemCertPoolGetter) *x509.CertPool 
 	}
 
 	if len(servcert) > 0 {
-		block, _ := pem.Decode([]byte(servcert))
+		block, _ := pem.Decode(servcert)
 		if block != nil {
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err == nil {

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -175,7 +175,6 @@ func TestClientAuthNoCert(t *testing.T) {
 	ac, err := NewApiClient(
 		Config{"server.non-existing.crt", true, false},
 	)
-	assert.Nil(t, ac)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot initialize server trust")
+	assert.NotNil(t, ac)
+	assert.NoError(t, err)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,13 +15,12 @@ package client
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -60,12 +59,12 @@ func TestHttpClient(t *testing.T) {
 	cl, _ = NewApiClient(Config{})
 	assert.NotNil(t, cl)
 
-	// missing cert in config should yield an error
+	// missing cert in config should still yield usable client
 	cl, err := NewApiClient(
 		Config{"missing.crt", true, false},
 	)
-	assert.Nil(t, cl)
-	assert.NotNil(t, err)
+	assert.NotNil(t, cl)
+	assert.NoError(t, err)
 }
 
 func TestApiClientRequest(t *testing.T) {
@@ -194,8 +193,7 @@ func TestCaLoading(t *testing.T) {
 		ServerCert: "server.crt",
 	}
 
-	certs, err := loadServerTrust(conf)
-	assert.NoError(t, err)
+	certs := loadServerTrust(&conf)
 
 	// Verify that at least one of the certificates belong to us, and one
 	// belongs to a well known certificate authority.
@@ -215,6 +213,12 @@ func TestCaLoading(t *testing.T) {
 	assert.True(t, oursOK)
 }
 
+type nullSystemCert struct{}
+
+func (nullSystemCert) GetSystemCertPool() (*x509.CertPool, error) {
+	return x509.NewCertPool(), nil
+}
+
 func TestEmptySystemCertPool(t *testing.T) {
 	version := runtime.Version()
 	if strings.HasPrefix(version, "1.6") || strings.HasPrefix(version, "1.7") || strings.HasPrefix(version, "1.8") {
@@ -222,23 +226,17 @@ func TestEmptySystemCertPool(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tmpdir, err := ioutil.TempDir("", "nocertsfolder")
-	assert.NoError(t, err)
-
-	// Fake the environment variables, to override ssl-cert lookup
-	err = os.Setenv("SSL_CERT_DIR", tmpdir)
-	assert.NoError(t, err)
-
-	err = os.Setenv("SSL_CERT_FILE", tmpdir+"idonotexist.crt") // fakes a non existing cert-file
-	assert.NoError(t, err)
-
 	conf := Config{
 		ServerCert: "server.crt",
 	}
 
-	certs, err := loadServerTrust(conf)
-	assert.NoError(t, err)
-	assert.NotZero(t, certs)
+	certs := loadServerTrustImpl(&conf, nullSystemCert{})
+	assert.Equal(t, 1, len(certs.Subjects()))
+
+	conf.ServerCert = "does-not-exist.crt"
+
+	certs = loadServerTrustImpl(&conf, nullSystemCert{})
+	assert.Equal(t, 0, len(certs.Subjects()))
 }
 
 func TestExponentialBackoffTimeCalculation(t *testing.T) {


### PR DESCRIPTION
```
commit 8b74abe167b13ca3dc02cd179d2b37a8bef63959
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Jan 20 14:04:58 2020

    MEN-3047: Fix crash when specified certificate can't be opened.
    
    Changelog: Fix crash when specified certificate can't be opened.
    Both the `ServerCertificate` setting and the system certificates are
    now optional, in the sense that the client will run without them.
    However, the client will not be able to connect without the right
    certificates, so the main usecase of this change is to have a workable
    client that will roll back if connections can't be made, instead of
    exiting.
    
    Also redid the `TestEmptySystemCertPool` test. This test actually
    never worked as intended, because Go caches the system certificates
    behind the scenes, so it only worked if you ran the test by itself.
    The pass condition was not specific enough to catch this failure.
    Reworked the test to work with an interface instead.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b3fe9dd71905e2c4983fb3a33c339d40bea5e736
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jan 16 13:14:37 2020

    Fix segfault after temporary file creation fails.
    
    It is an error to access the file object when the TempFile call has
    failed. It won't exist in this case anyway, so the call is not needed.
    
    Changelog: Fix segfault when running `mender setup` on a read-only
    filesystem.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```