### PR TITLE
Silence annoying warning from lmdb.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ GOCYCLO ?= 15
 CGO_ENABLED=1
 export CGO_ENABLED
 
+# Get rid of useless warning in lmdb
+CGO_CFLAGS ?= -Wno-implicit-fallthrough
+export CGO_CFLAGS
+
 TOOLS = \
 	github.com/fzipp/gocyclo \
 	gitlab.com/opennota/check/cmd/varcheck \


### PR DESCRIPTION
```
mdb.c: In function ‘mdb_cursor_put’:
mdb.c:6535:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
      if (SIZELEFT(fp) < offset) {
         ^
mdb.c:6540:5: note: here
     case MDB_CURRENT:
     ^~~~
```

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>