### PR TITLE
MEN-3007: Improved error message when an update-module is missing

### DIFF
--- a/vendor/github.com/mendersoftware/mender-artifact/areader/reader.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/areader/reader.go
@@ -655,8 +655,12 @@ func (ar *Reader) setInstallers(upd []artifact.UpdateType, augmented bool) error
 				ar.installers[i] = w.NewInstance()
 			}
 		} else if ar.ForbidUnknownHandlers {
-			return fmt.Errorf("Cannot load handler for unknown Payload type '%s'",
-				update.Type)
+			errstr := fmt.Sprintf("Artifact Payload type '%s' is not supported by this Mender Client", update.Type)
+			if update.Type == "rootfs-image" {
+				return errors.New(errstr + ". Ensure that the Mender Client is fully integrated and that the RootfsPartA/B configuration variables are set correctly in 'mender.conf'")
+			} else {
+				return errors.New(errstr)
+			}
 		} else {
 			err := ar.makeInstallersForUnknownTypes(update.Type, i, augmented)
 			if err != nil {


### PR DESCRIPTION
The previous error message does not really make sense to people unfamiliar with
the source code. The message read:

“Fetching Artifact headers failed: installer: failed to read Artifact:
readHeaderV3: handleHeaderReads: Cannot load handler for unknown Payload type
'rootfs-image'"

Which to outsiders does not really make much sense without some serious head

“Fetching Artifact headers failed: installer: failed to read Artifact:
readHeaderV3: handleHeaderReads: Artifact Payload type 'update-type' is not
supported by this Mender Client"

for the generic case. And with a special addition to the most common
rootfs-image type:

“Fetching Artifact headers failed: installer: failed to read Artifact:
readHeaderV3: handleHeaderReads: Artifact Payload type 'rootfs-image' is not
supported by this Mender Client. Ensure that the Mender Client is fully
integrated and that the RootfsPartA/B configuration is set correctly in
mender.conf".

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>