### PR TITLE
MEN-2587: Added Client provides to deployments/next API call

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -330,11 +330,11 @@ func verifyArtifactDependencies(depends, provides map[string]interface{}) error 
 func (m *Mender) CheckUpdate() (*datastore.UpdateInfo, menderError) {
 	currentArtifactName, err := m.GetCurrentArtifactName()
 	if err != nil || currentArtifactName == "" {
-		log.Error("could not get the current artifact name")
+		log.Error("could not get the current Artifact name")
 		if err == nil {
 			err = errors.New("artifact name is empty")
 		}
-		return nil, NewTransientError(fmt.Errorf("could not read the artifact name. This is a necessary condition in order for a mender update to finish safely. Please give the current artifact a name (This can be done by adding a name to the file /etc/mender/artifact_info) err: %v", err))
+		return nil, NewTransientError(fmt.Errorf("could not read the Artifact name. This is a necessary condition in order for a Mender update to finish safely. Please give the current Artifact a name (This can be done by adding a name to the file /etc/mender/artifact_info) err: %v", err))
 	}
 
 	deviceType, err := m.GetDeviceType()
@@ -640,9 +640,9 @@ func (m *Mender) InventoryRefresh() error {
 	artifactName, err := m.GetCurrentArtifactName()
 	if err != nil || artifactName == "" {
 		if err == nil {
-			err = errors.New("artifact name is empty")
+			err = errors.New("Artifact name is empty")
 		}
-		errstr := fmt.Sprintf("could not read the artifact name. This is a necessary condition in order for a mender update to finish safely. Please give the current artifact a name (This can be done by adding a name to the file /etc/mender/artifact_info) err: %v", err)
+		errstr := fmt.Sprintf("could not read the artifact name. This is a necessary condition in order for a Mender update to finish safely. Please give the current Artifact a name (This can be done by adding a name to the file /etc/mender/artifact_info) err: %v", err)
 		return errors.Wrap(errNoArtifactName, errstr)
 	}
 

--- a/client/client_update.go
+++ b/client/client_update.go
@@ -229,6 +229,8 @@ func makeUpdateCheckRequest(server string, current CurrentUpdate) (*http.Request
 		return nil, nil, err
 	}
 
+	ent_req.Header.Add("Content-Type", "application/json")
+
 	if len(vals) != 0 {
 		ep = ep + "?" + vals.Encode()
 	}

--- a/client/client_update.go
+++ b/client/client_update.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -56,6 +57,7 @@ func NewUpdate() *UpdateClient {
 type CurrentUpdate struct {
 	Artifact   string
 	DeviceType string
+	Provides   map[string]interface{}
 }
 
 func (u *UpdateClient) GetScheduledUpdate(api ApiRequester, server string,
@@ -64,21 +66,43 @@ func (u *UpdateClient) GetScheduledUpdate(api ApiRequester, server string,
 	return u.getUpdateInfo(api, processUpdateResponse, server, current)
 }
 
+// getUpdateInfo Tries to get the next update information from the backend. This
+// is done in two stages. First it tries a POST request with the devices provide
+// parameters. Then if this fails with a 404 response, then it falls back to the
+// open source version with GET, and the parameters encoded in the URL.
 func (u *UpdateClient) getUpdateInfo(api ApiRequester, process RequestProcessingFunc,
 	server string, current CurrentUpdate) (interface{}, error) {
-	req, err := makeUpdateCheckRequest(server, current)
+	ent_req, req, err := makeUpdateCheckRequest(server, current)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create update check request")
 	}
 
-	r, err := api.Do(req)
-
+	r, err := api.Do(ent_req)
 	if err != nil {
-		log.Debug("Sending request error: ", err)
-		return nil, errors.Wrapf(err, "update check request failed")
+		log.Debugf("Failed sending device provides to the backend: Error: %v", err)
+		return nil, errors.Wrapf(err, "enterprise update check request failed")
 	}
 
 	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
+		if r.StatusCode == http.StatusNotFound {
+			// 404 - Fall back to the old GET request
+			log.Debug("device provides not accepted by the server")
+
+			r, err = api.Do(req)
+
+			if err != nil {
+				log.Debug("Sending request error: ", err)
+				return nil, errors.Wrapf(err, "update check request failed")
+			}
+
+			defer r.Body.Close()
+
+		} else {
+			return nil, fmt.Errorf("failed to post update info to the server. Response: %v", r)
+		}
+	}
 
 	respdata, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -180,7 +204,7 @@ func processUpdateResponse(response *http.Response) (interface{}, error) {
 	}
 }
 
-func makeUpdateCheckRequest(server string, current CurrentUpdate) (*http.Request, error) {
+func makeUpdateCheckRequest(server string, current CurrentUpdate) (*http.Request, *http.Request, error) {
 	vals := url.Values{}
 	if current.DeviceType != "" {
 		vals.Add("device_type", current.DeviceType)
@@ -189,16 +213,31 @@ func makeUpdateCheckRequest(server string, current CurrentUpdate) (*http.Request
 		vals.Add("artifact_name", current.Artifact)
 	}
 
+	providesBody, err := json.Marshal(current.Provides)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := bytes.NewBuffer(providesBody)
+
 	ep := "/deployments/device/deployments/next"
+
+	url := buildApiURL(server, ep)
+
+	ent_req, err := http.NewRequest(http.MethodPost, url, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if len(vals) != 0 {
 		ep = ep + "?" + vals.Encode()
 	}
-	url := buildApiURL(server, ep)
+	url = buildApiURL(server, ep)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return req, nil
+	return ent_req, req, nil
 }
 
 func makeUpdateFetchRequest(url string) (*http.Request, error) {

--- a/client/client_update.go
+++ b/client/client_update.go
@@ -86,7 +86,7 @@ func (u *UpdateClient) getUpdateInfo(api ApiRequester, process RequestProcessing
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
-		if r.StatusCode == http.StatusNotFound {
+		if r.StatusCode == http.StatusNotFound || r.StatusCode == http.StatusMethodNotAllowed {
 			// 404 - Fall back to the old GET request
 			log.Debug("device provides not accepted by the server")
 

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -416,19 +416,6 @@ func TestGetUpdateInfo(t *testing.T) {
 			},
 			errorFunc: assert.NoError,
 		},
-		"Enterprise - Failure 500": {
-			httpHandlerFunc: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(500)
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, "")
-			},
-			currentUpdateInfo: CurrentUpdate{
-				Provides: map[string]interface{}{
-					"artifact_name": "release-1",
-					"device_type":   "qemu"},
-			},
-			errorFunc: assert.Error,
-		},
 		"Open source - Success": {
 			httpHandlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == "POST" {
@@ -448,7 +435,7 @@ func TestGetUpdateInfo(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for name, test := range tests {
 
 		// Test server that always responds with 200 code, and specific payload
 		ts := httptest.NewTLSServer(http.HandlerFunc(test.httpHandlerFunc))
@@ -466,7 +453,7 @@ func TestGetUpdateInfo(t *testing.T) {
 		fakeProcessUpdate := func(response *http.Response) (interface{}, error) { return nil, nil }
 
 		_, err = client.getUpdateInfo(ac, fakeProcessUpdate, ts.URL, test.currentUpdateInfo)
-		test.errorFunc(t, err)
+		test.errorFunc(t, err, "Test name: %s", name)
 
 	}
 

--- a/device/device.go
+++ b/device/device.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -111,6 +111,10 @@ func GetManifestData(dataType, manifestFile string) (string, error) {
 	} else {
 		return *found, nil
 	}
+}
+
+func (d *DeviceManager) GetProvides() (map[string]interface{}, error) {
+	return datastore.LoadProvides(d.Store)
 }
 
 func (d *DeviceManager) GetCurrentArtifactName() (string, error) {


### PR DESCRIPTION
This will add the device provides from the datastore, encode them in the request
body, and send them along with the deployments/next API call, in which the
deployments endpoint will decide upon what to do. If it is to treat it like an
old API call, or handle the provides is up to the backend.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>