### PR TITLE
Rename setup flag --server-cert to --trusted-certs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -288,9 +288,9 @@ OPTIONS:
 					Destination: &runOptions.setupOptions.serverIP,
 					Usage:       "Server ip address."},
 				cli.StringFlag{
-					Name:        "server-cert, E",
+					Name:        "trusted-certs, E",
 					Destination: &runOptions.setupOptions.serverCert,
-					Usage:       "`PATH` to trusted server certificates"},
+					Usage:       "Trusted server certificates `FILE` path."},
 				cli.StringFlag{
 					Name:        "tenant-token",
 					Destination: &runOptions.setupOptions.tenantToken,

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -450,7 +450,7 @@ func (opts *setupOptionsType) askServerIP(ctx *cli.Context,
 func (opts *setupOptionsType) askServerCert(ctx *cli.Context,
 	stdin *stdinReader) (int, error) {
 	var err error
-	if ctx.IsSet("server-cert") {
+	if ctx.IsSet("trusted-certs") {
 		return statePolling, nil
 	}
 	opts.serverCert, err = stdin.promptUser(

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -35,7 +35,7 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.String("password", "", "")
 	flagSet.String("server-url", "", "")
 	flagSet.String("server-ip", "", "")
-	flagSet.String("server-cert", "", "")
+	flagSet.String("trusted-certs", "", "")
 	flagSet.String("tenant-token", "", "")
 	flagSet.Int("inventory-poll", defaultInventoryPoll, "")
 	flagSet.Int("retry-poll", defaultRetryPoll, "")
@@ -206,7 +206,7 @@ func TestSetupFlags(t *testing.T) {
 	opts.deviceType = "bgl-bn"
 	ctx.Set("demo", "false")
 	opts.demo = false
-	ctx.Set("server-cert", "/path/to/crt")
+	ctx.Set("trusted-certs", "/path/to/crt")
 	opts.serverCert = "/path/to/crt"
 	ctx.Set("update-poll", "123")
 	opts.updatePollInterval = 123


### PR DESCRIPTION
The two flags are the same with different names within the two flag
scopes.

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>