### PR TITLE
MEN-3277: Fix check-update and send-inventory options on deb install

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -141,11 +141,19 @@ func SetupCLI(args []string) error {
 			Name:  "check-update",
 			Usage: "Force update check.",
 			Action: func(_ *cli.Context) error {
-				return updateCheck(
+				err := updateCheck(
 					exec.Command("kill", "-USR1"),
 					exec.Command("systemctl",
 						"show", "-p",
 						"MainPID", "mender"))
+				if err != nil {
+					err = updateCheck(
+						exec.Command("kill", "-USR1"),
+						exec.Command("systemctl",
+							"show", "-p",
+							"MainPID", "mender-client"))
+				}
+				return err
 			},
 		},
 		{
@@ -182,11 +190,19 @@ func SetupCLI(args []string) error {
 			Name:  "send-inventory",
 			Usage: "Force inventory update.",
 			Action: func(_ *cli.Context) error {
-				return updateCheck(
+				err := updateCheck(
 					exec.Command("kill", "-USR2"),
 					exec.Command("systemctl",
 						"show", "-p",
 						"MainPID", "mender"))
+				if err != nil {
+					err = updateCheck(
+						exec.Command("kill", "-USR2"),
+						exec.Command("systemctl",
+							"show", "-p",
+							"MainPID", "mender-client"))
+				}
+				return err
 			},
 		},
 		{

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -63,6 +63,13 @@ func TestCheckUpdate(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSendInventory(t *testing.T) {
+	args := []string{"mender", "-send-inventory"}
+	err := SetupCLI(args)
+	// Should produce an error since daemon is not running
+	assert.Error(t, err)
+}
+
 func TestRunDaemon(t *testing.T) {
 	// create directory for storing deployments logs
 	tempDir, _ := ioutil.TempDir("", "logs")
@@ -81,7 +88,7 @@ func TestRunDaemon(t *testing.T) {
 		"check-update": {
 			signal: syscall.SIGUSR1,
 		},
-		"inventory-update": {
+		"send-inventory": {
 			signal: syscall.SIGUSR2,
 		},
 	}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -140,10 +140,11 @@ func getMenderDaemonPID(cmd *exec.Cmd) (string, error) {
 	if err != nil {
 		return "", errors.New("getMenderDaemonPID: Failed to run systemctl")
 	}
-	if buf.Len() == 0 {
+	pid := strings.Trim(buf.String(), "MainPID=\n")
+	if pid == "" || pid == "0" {
 		return "", errors.New("could not find the PID of the mender daemon")
 	}
-	return strings.Trim(buf.String(), "MainPID=\n"), nil
+	return pid, nil
 }
 
 func handleArtifactOperations(ctx *cli.Context, runOptions runOptionsType,
@@ -245,7 +246,7 @@ func runDaemon(d *app.MenderDaemon) error {
 func updateCheck(cmdKill, cmdGetPID *exec.Cmd) error {
 	pid, err := getMenderDaemonPID(cmdGetPID)
 	if err != nil {
-		return errors.Wrap(err, "failed to force updateCheck: ")
+		return errors.Wrap(err, "failed to force updateCheck")
 	}
 	cmdKill.Args = append(cmdKill.Args, pid)
 	err = cmdKill.Run()


### PR DESCRIPTION
Fixes https://tracker.mender.io/browse/MEN-3277

- MEN-3277: Fix check-update and send-inventory options on deb install
When installing mender client through deb package, the systemd service
is renamed to mender-client, so these two CLI options were failing in
sending the signal to the daemon.

- Generate an error message when MainPID is 0
For a non-existing process, systemctl returns MainPID=0 instead of an
empty string. Make the error clearer for these cases.