### PR TITLE
Fix Stat_t.Dev/Rdev type assumption

### DIFF
--- a/system/ioctl.go
+++ b/system/ioctl.go
@@ -162,7 +162,7 @@ func GetDeviceIDFromPath(path string) ([2]uint32, error) {
 		unix.S_IFIFO,
 		unix.S_IFSOCK:
 		return [2]uint32{
-			unix.Major(stat.Rdev), unix.Minor(stat.Rdev)}, nil
+			unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev))}, nil
 
 	// If path refers to a regular file, then st_dev gives the device number
 	// of the underlying block device.
@@ -170,7 +170,7 @@ func GetDeviceIDFromPath(path string) ([2]uint32, error) {
 		unix.S_IFREG,
 		unix.S_IFLNK:
 		return [2]uint32{
-			unix.Major(stat.Dev), unix.Minor(stat.Dev)}, nil
+			unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev))}, nil
 	}
 	return [2]uint32{^uint32(0), ^uint32(0)},
 		fmt.Errorf("invalid stat(2) st_mode %04X", devType)


### PR DESCRIPTION
The unix.Major and unix.Minor functions takes an argument of type uint64 and the code currently passes in either stat.Rdev or stat.Dev into these. While stat.Dev and stat.Rdev are often defined as uint64 this is not so for every architecture. See for example mips64el where the fields instead are uint32 [1]. This causes a build failure (atleast with golang 1.14) on architectures where the assumtion doesn't hold true. This change simply casts the value to uint64 before passing it into unix.Major/Minor to fix the build problem.

[1]: https://sources.debian.org/src/golang-1.14/1.14-2/src/syscall/ztypes_linux_mips64le.go/#L107

Changelog: Title

Signed-off-by: Andreas Henriksson <andreas@fatal.se>