### PR TITLE
Printing stderr as info and not as error

### DIFF
--- a/statescript/executor.go
+++ b/statescript/executor.go
@@ -243,9 +243,9 @@ func execute(name string, timeout time.Duration) error {
 
 	if len(bts) > 0 {
 		if len(bts) > 10*1024 {
-			log.Errorf("Collected standard-error while running script %s [%s] (Truncated to 10KB)", name, bts[:10*1024])
+			log.Infof("Collected output (stderr) while running script %s (Truncated to 10KB)\n%s\n---------- end of script output", name, bts[:10*1024])
 		} else {
-			log.Errorf("Collected standard-error while running script %s [%s]", name, string(bts))
+			log.Infof("Collected output (stderr) while running script %s\n%s\n---------- end of script output", name, string(bts))
 		}
 	}
 


### PR DESCRIPTION
Changelog : Printing stderr as info and not as error [[MEN-3316](https://tracker.mender.io/browse/MEN-3316)]


Signed-off-by: Christian Müller <christian.muller@wifx.net>
(cherry picked from commit 943bd81f96967ed7d1c94c802e12cc1d67600209)