### PR TITLE
Support module cleanup.

### DIFF
--- a/support/modules/deb
+++ b/support/modules/deb
@@ -5,9 +5,9 @@ set -e
 STATE="$1"
 FILES="$2"
 
-case "$STATE" in
+case "${STATE}" in
     ArtifactInstall)
-        dpkg -i "$FILES"/files/*.deb
+        dpkg -i "${FILES}"/files/*.deb
         ;;
 esac
 exit 0

--- a/support/modules/directory
+++ b/support/modules/directory
@@ -5,9 +5,9 @@ set -e
 STATE="$1"
 FILES="$2"
 
-prev_files_tar="$FILES"/tmp/prev_files.tar
-update_files_tar="$FILES"/files/update.tar
-dest_dir_file="$FILES"/files/dest_dir
+prev_files_tar="${FILES}"/tmp/prev_files.tar
+update_files_tar="${FILES}"/files/update.tar
+dest_dir_file="${FILES}"/files/dest_dir
 
 case "$STATE" in
 
@@ -20,34 +20,34 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
-        dest_dir=$(cat $dest_dir_file)
-        test -z "$dest_dir" && \
+        dest_dir=$(cat "${dest_dir_file}")
+        test -z "${dest_dir}" && \
             echo "Fatal error: dest_dir is undefined." && exit 1
-        test "$dest_dir" = "/" && \
+        test "${dest_dir}" = "/" && \
             echo "Error: destination dir is '/', install not supported." && exit 1
-        mkdir -p $dest_dir
-        if ! tar -cf ${prev_files_tar} -C ${dest_dir} .
+        mkdir -p "${dest_dir}"
+        if ! tar -cf "${prev_files_tar}" -C "${dest_dir}" .
         then
             ret=$?
             # Make sure there is no half-backup lying around.
-            rm -f ${prev_files_tar}
+            rm -f "${prev_files_tar}"
             exit $ret
         fi
-        rm -rf ${dest_dir}
-        mkdir -p ${dest_dir}
-        tar -xf ${update_files_tar} -C ${dest_dir}
+        rm -rf "${dest_dir}"
+        mkdir -p "${dest_dir}"
+        tar -xf "${update_files_tar}" -C "${dest_dir}"
         ;;
 
     ArtifactRollback)
-        test -f $prev_files_tar || exit 0
-        dest_dir=$(cat $dest_dir_file)
-        test -z "$dest_dir" && \
+        test -f "${prev_files_tar}" || exit 0
+        dest_dir=$(cat "${dest_dir_file}")
+        test -z "${dest_dir}" && \
             echo "Fatal error: dest_dir is undefined." && exit 1
-        test "$dest_dir" = "/" && \
+        test "${dest_dir}" = "/" && \
             echo "Info: destination dir is '/', not performing rollback." && exit 0
-        rm -rf ${dest_dir}
-        mkdir -p ${dest_dir}
-        tar -xf ${prev_files_tar} -C ${dest_dir}
+        rm -rf "${dest_dir}"
+        mkdir -p "${dest_dir}"
+        tar -xf "${prev_files_tar}" -C "${dest_dir}"
         ;;
 esac
 

--- a/support/modules/docker
+++ b/support/modules/docker
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 STATE="$1"
 FILES="$2"
 
-prev_containers_file="$FILES"/tmp/prev_containers.list
+prev_containers_file="${FILES}"/tmp/prev_containers.list
 
-case "$STATE" in
+case "${STATE}" in
 
     NeedsArtifactReboot)
         echo "No"
@@ -18,18 +18,18 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
-        docker ps -q > $prev_containers_file
-        [[ -n $(cat $prev_containers_file) ]] && docker stop $(cat $prev_containers_file)
-        for container in $(jq -r ".containers[]" "$FILES"/header/meta-data); do
-            docker pull $container
-            docker run -dt $container
+        docker ps -q > "${prev_containers_file}"
+        [ -n "$(cat "${prev_containers_file}")" ] && docker stop "$(cat "${prev_containers_file}")"
+        for container in $(jq -r ".containers[]" "${FILES}"/header/meta-data); do
+            docker pull "${container}"
+            docker run -dt "${container}"
         done
         ;;
 
     ArtifactRollback)
-        [[ -f $prev_containers_file ]] || exit 1
-        [[ -n  "$(docker ps -q)" ]] && docker stop $(docker ps -q)
-        [[ -n $(cat $prev_containers_file) ]] && docker start $(cat $prev_containers_file)
+        [ -f "${prev_containers_file}" ] || exit 1
+        [ -n  "$(docker ps -q)" ] && docker stop "$(docker ps -q)"
+        [ -n "$(cat "${prev_containers_file}")" ] && docker start "$(cat "${prev_containers_file}")"
         ;;
 esac
 

--- a/support/modules/rpm
+++ b/support/modules/rpm
@@ -5,9 +5,9 @@ set -e
 STATE="$1"
 FILES="$2"
 
-case "$STATE" in
+case "${STATE}" in
     ArtifactInstall)
-        rpm -U -v --force "$FILES"/files/*.rpm
+        rpm -U -v --force "${FILES}"/files/*.rpm
         ;;
 esac
 exit 0

--- a/support/modules/script
+++ b/support/modules/script
@@ -5,11 +5,11 @@ set -e
 STATE="$1"
 FILES="$2"
 
-case "$STATE" in
+case "${STATE}" in
     ArtifactInstall)
-        for file in "$FILES"/files/*; do
-            chmod u+x "$file"
-            "$file"
+        for file in "${FILES}"/files/*; do
+            chmod u+x "${file}"
+            "${file}"
         done
         ;;
 esac

--- a/support/modules/single-file
+++ b/support/modules/single-file
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 STATE="$1"
 FILES="$2"
 
-tmp_dest_dir="$FILES"/tmp/dest_dir
-dest_dir_file="$FILES"/files/dest_dir
-filename_file="$FILES"/files/filename
-permissions_file="$FILES"/files/permissions
+tmp_dest_dir="${FILES}"/tmp/dest_dir
+dest_dir_file="${FILES}"/files/dest_dir
+filename_file="${FILES}"/files/filename
+permissions_file="${FILES}"/files/permissions
 
-case "$STATE" in
+case "${STATE}" in
 
     NeedsArtifactReboot)
         echo "No"
@@ -21,39 +21,39 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
-        dest_dir=$(cat $dest_dir_file)
-        filename=$(cat $filename_file)
-        test -z "$dest_dir" -o -z "$filename" && \
+        dest_dir=$(cat "${dest_dir_file}")
+        filename=$(cat "${filename_file}")
+        test -z "${dest_dir}" -o -z "${filename}" && \
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
-        mkdir -p $dest_dir
-        mkdir -p $tmp_dest_dir
-        if test -f ${dest_dir}/${filename}
+        mkdir -p "${dest_dir}"
+        mkdir -p "${tmp_dest_dir}"
+        if test -f "${dest_dir}"/"${filename}"
         then
-            if ! cp -a ${dest_dir}/${filename} ${tmp_dest_dir}
+            if ! cp -a "${dest_dir}"/"${filename}" "${tmp_dest_dir}"
             then
                 ret=$?
                 # Make sure there is no half-backup lying around.
-                rm -rf ${tmp_dest_dir}
-                exit $ret
+                rm -rf "${tmp_dest_dir}"
+                exit ${ret}
             fi
         fi
-        cp "$FILES"/files/$filename ${dest_dir}/${filename}
+        cp "$FILES"/files/"${filename}" "${dest_dir}"/"${filename}"
         # Previous revisions of this update module did not use the
         # permissions_file, so it might not exist.
-        if test -f $permissions_file
+        if test -f "${permissions_file}"
         then
-            chmod $(cat $permissions_file) ${dest_dir}/${filename}
+            chmod "$(cat "${permissions_file}")" "${dest_dir}"/"${filename}"
         fi
         ;;
 
     ArtifactRollback)
-        filename=$(cat $filename_file)
-        test -f $tmp_dest_dir/$filename || exit 0
-        dest_dir=$(cat $dest_dir_file)
-        test -z "$dest_dir" -o -z "$filename" && \
+        filename=$(cat "${filename_file}")
+        test -f "${tmp_dest_dir}"/"${filename}" || exit 0
+        dest_dir=$(cat "${dest_dir_file}")
+        test -z "${dest_dir}" -o -z "${filename}" && \
             echo "Fatal error: dest_dir or filename are undefined." && exit 1
-        rm ${dest_dir}/${filename}
-        cp -a $tmp_dest_dir/$filename ${dest_dir}/${filename}
+        rm "${dest_dir}"/"${filename}"
+        cp -a "${tmp_dest_dir}"/"${filename}" "${dest_dir}"/"${filename}"
         ;;
 esac
 


### PR DESCRIPTION
Changes:
  - Remove any bashisms found in the support module scripts.
  - Put double quotes around all varialbes to prevent word splitting.
  - Standardize all variables to use the ${foo} syntax instead of a $foo.