### PR TITLE
Remove bashisms in the update module scripts

### DIFF
--- a/support/modules/docker
+++ b/support/modules/docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -19,7 +19,7 @@ case "$STATE" in
 
     ArtifactInstall)
         docker ps -q > $prev_containers_file
-        [[ -n $(cat $prev_containers_file) ]] && docker stop $(cat $prev_containers_file)
+        [ -n "$(cat $prev_containers_file)" ] && docker stop $(cat $prev_containers_file)
         for container in $(jq -r ".containers[]" "$FILES"/header/meta-data); do
             docker pull $container
             docker run -dt $container
@@ -27,9 +27,9 @@ case "$STATE" in
         ;;
 
     ArtifactRollback)
-        [[ -f $prev_containers_file ]] || exit 1
-        [[ -n  "$(docker ps -q)" ]] && docker stop $(docker ps -q)
-        [[ -n $(cat $prev_containers_file) ]] && docker start $(cat $prev_containers_file)
+        [ -f $prev_containers_file ] || exit 1
+        [ -n  "$(docker ps -q)" ] && docker stop $(docker ps -q)
+        [ -n "$(cat $prev_containers_file)" ] && docker start $(cat $prev_containers_file)
         ;;
 esac
 

--- a/support/modules/single-file
+++ b/support/modules/single-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
The only update module to actually have any bashisms was the docker module,
and the bashisms were trivial to remove.

Changes to docker:
  - Change any [[ ]] call to [ ]
  - Quote any shell calls in [ -n ]
  - Change the shebang from #!/bin/bash to #!/bin/sh

Changes to single-file:
  - Change the shebang from #!/bin/bash to #!/bin/sh
  - No other bashisms are currently present in the file.

Changelog: None

Signed-off-by: Adam Duskett <Aduskett@gmail.com>