### PR TITLE
QA-193: Add separate code coverage for unit and acceptance tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ publish:tests:
     - test
   script:
     - tar -xvf unit-coverage.tar
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -s ./tests/unit-coverage"
+    - bash -c "bash <(curl -s https://codecov.io/bash) -F unit -Z -s ./tests/unit-coverage"
 
 trigger:mender-qa:
   image: alpine

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -200,7 +200,7 @@ func TestCaLoading(t *testing.T) {
 	var systemOK, oursOK bool
 	subj := certs.Subjects()
 	for i := 0; i < len(subj); i++ {
-		if strings.Contains(string(subj[i]), "thawte Primary Root CA") {
+		if strings.Contains(string(subj[i]), "VeriSign, Inc.") {
 			systemOK = true
 		}
 		// "Acme Co", just a dummy certificate in this repo.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      acceptance:
+        flags:
+          - acceptance
+      unit:
+        flags:
+          - unit


### PR DESCRIPTION
The acceptance tests are covered in mender-qa, so they are not visible
in this repo.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>