### PR TITLE
Check if root mount candidate match rootfsPartA/B

### DIFF
--- a/installer/partitions.go
+++ b/installer/partitions.go
@@ -181,6 +181,16 @@ func (p *partitions) getAndCacheActivePartition(rootChecker func(system.StatComm
 			log.Debug("Setting active partition: ", mountCandidate)
 			return p.active, nil
 		}
+		if mountCandidate == p.rootfsPartA {
+			p.active = p.rootfsPartA
+			log.Debugf("Setting active partition from configuration and mount candidate: %s", p.active)
+			return p.active, nil
+		}
+		if mountCandidate == p.rootfsPartB {
+			p.active = p.rootfsPartB
+			log.Debugf("Setting active partition from configuration and mount candidate: %s", p.active)
+			return p.active, nil
+		}
 		// If not see if we are lucky somewhere else
 	}
 


### PR DESCRIPTION
When using device-less mounts for ubi rootfs (e.g. root=ubi0:rootfsa), mender
won't find which device is the active device unless I specify them as ubi0_0/1
in mender.conf.

This patch tries to match the root mount candidate, as reported by 'mount',
with what is written in mender.conf.

Example output of `mount`:

        / # mount
        ubi0:rootfsa on / type ubifs (rw,relatime)
        devtmpfs on /dev type devtmpfs (rw,relatime,size=251372k,nr_inodes=62843,mode=755)
        proc on /proc type proc (rw,relatime)
        devpts on /dev/pts type devpts (rw,relatime,gid=5,mode=620)
        tmpfs on /dev/shm type tmpfs (rw,relatime,mode=777)
        tmpfs on /tmp type tmpfs (rw,relatime)
        tmpfs on /run type tmpfs (rw,nosuid,nodev,relatime,mode=755)
        sysfs on /sys type sysfs (rw,relatime)
        ubi0:data on /data type ubifs (rw,relatime)

Example _mender.conf_ file:

        # cat /etc/mender/mender.conf
        {
          "InventoryPollIntervalSeconds": 1800,
          "UpdatePollIntervalSeconds": 1800,
          "RetryPollIntervalSeconds": 300,
          "RootfsPartA": "ubi0:rootfsa",
          "RootfsPartB": "ubi0:rootfsb",
          "ServerCertificate": "/etc/mender/server.crt",
          "ServerURL": "https://REDACTED",
          "TenantToken": "dummy"
        }

Changelog: Title
Signed-off-by: Patrik Dahlström <risca@dalakolonin.se>