### PR TITLE
MEN-3316: Log state-script stderr as info, not error

### DIFF
--- a/statescript/executor.go
+++ b/statescript/executor.go
@@ -243,9 +243,9 @@ func execute(name string, timeout time.Duration) error {
 
 	if len(bts) > 0 {
 		if len(bts) > 10*1024 {
-			log.Errorf("stderr collected while running script %s [%s] (Truncated to 10KB)", name, bts[:10*1024])
+			log.Infof("Collected output (stderr) while running script %s (Truncated to 10KB)\n%s\n---------- end of script output", name, bts[:10*1024])
 		} else {
-			log.Errorf("stderr collected while running script %s [%s]", name, string(bts))
+			log.Infof("Collected output (stderr) while running script %s\n%s\n---------- end of script output", name, string(bts))
 		}
 	}
 


### PR DESCRIPTION
Script error prints might as well be diagnostics, and not necessarily errors.
Therefore, in order not to confuse the end user, log it as info.

Changelog: Title

Signed-off-by: Christian Müller <christian.muller@wifx.net>

Cherry of PR: https://github.com/mendersoftware/mender/pull/521.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

(cherry picked from commit d3be6dcf2e458fcfb5bc9efe6ef30856222beaba)