### PR TITLE
Make Codecov only update coverage after all reports are uploaded

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,13 @@
+
+comment:
+  # Only comment after 7 reports uploaded
+  after_n_builds: 7
+
+codecov:
+  notify:
+    # Only notify after 7 reports uploaded
+    after_n_builds: 7
+
 coverage:
   status:
     project:


### PR DESCRIPTION

This fixes one issue with codecoverage, wherein the required project coverage
would be posted after 2 finished CI-jobs. And since, our coverage is dependent
upon both unit and coverage tests, posting the coverage too early actually means
that Codecov marks the required check as failed.

This sets the number of required builds to 7. This is not a random number, but
is taken from our CI-setup for Mender. The Pipeline right now looks similar to:

1 unit-test + 6 acceptance-tests = 7

Thus Codecov will not comment, or update the coverage status until all the
coverage reports are uploaded, which will then provide a consistent coverage
report, as opposed to the premature coverage which is not posted.
