### PR TITLE
Test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,10 @@
 
 comment:
-  after_n_builds: 8
+  after_n_builds: 5
 
 codecov:
   notify:
-    after_n_builds: 8
+    after_n_builds: 5
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
+
+comment:
+  after_n_builds: 8
+
+codecov:
+  notify:
+    after_n_builds: 8
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Where (n) = number of jobs in pipeline step.

The number 10 is taken from:

setup (1) + build (4) + test_acceptance_qemu (1) + test_backend_integration (1)
+ test_full_integration (1) + two_random_acceptance_tests (2)

= 10

Where the 'test_acceptance_qemu' test is required, since it is sort of a sham
test. It also requires the backend, and full integration tests, at minimum.

Thus, the formula is supposed to force at least two acceptance to finish before
reporting the project coverage.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

Only comment coverage on a PR until it is valid

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

Publish test unit coverage after one upload

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

Seperate coverage for unit and acceptance

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

Experiment

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

Six

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>