### PR TITLE
QA-191: Add a Github PR template to help external contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+
+# External Contributor Checklist
+
+🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
+
+- [ ] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.
+
+- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.
+
+### Description
+
+Please describe your pull request.
+
+Thank you!


### PR DESCRIPTION
This will probably save us some of the usual grind of asking people to sign
their commits and add changelogs when they are unfamiliar with the project.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>