### PR TITLE
Fix: Ignore the coverage files in the vendor folder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,6 @@ coverage:
       unit:
         flags:
           - unit
+
+ignore:
+  - "vendor/"


### PR DESCRIPTION
Currently coverage is collected from the vendor folder. This coverage is quite
low, for some projects, as low as 40%. Since the vendor folder should not have
any effects on the general coverage of the project, ignore it.

This should make general coverage more reflective of what our actual coverage is.

See: https://docs.codecov.io/docs/ignoring-paths for more information.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
