### PR TITLE
MEN-3684: Switch to fw_setenv script syntax which libubootenv supports.

### DIFF
--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -113,7 +113,7 @@ func (e *UBootEnv) WriteEnv(vars BootVars) error {
 		return err
 	}
 	for k, v := range vars {
-		_, err = fmt.Fprintf(pipe, "%s %s\n", k, v)
+		_, err = fmt.Fprintf(pipe, "%s=%s\n", k, v)
 		if err != nil {
 			log.Error("Error while setting U-Boot variable: ", err)
 			pipe.Close()


### PR DESCRIPTION
Specifically, it means using:

```
bootcount=0
```

instead of:

```
bootcount 0
```

Luckily, this is a backwards compatible change, as both the original
fw-utils based on U-Boot, as well as fw_setenv from
grub-mender-grubenv already support this syntax.

Changelog: Add support for libubootenv as boot loader user space tools
provider.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
