### PR TITLE
MEN-3652: Remove Server config warn on mender setup command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -392,6 +392,15 @@ func (runOptions *runOptionsType) commonCLIHandler(
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Skip verify for setup, as the configuration will be overridden
+	if ctx.Command.Name != "setup" {
+		err := config.Validate()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	if runOptions.Config.NoVerify {
 		config.HttpsClient.SkipVerify = true
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -459,6 +459,49 @@ func TestInvalidServerCertificateBoot(t *testing.T) {
 	assert.True(t, testLogContainsMessage(hook.AllEntries(), "IGNORING ERROR"))
 }
 
+func TestIgnoreServerConfigVerification(t *testing.T) {
+	// Config with invalid Server fields
+	config := conf.NewMenderConfig()
+	config.ServerURL = ""
+	config.Servers = nil
+
+	// Save to tempdir for the test to load
+	tdir, err := ioutil.TempDir("", "mendertest")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tdir)
+	cpath := path.Join(tdir, "invalid-servers.conf")
+	writeConfig(t, cpath, *config)
+	conf.DefaultConfFile = cpath
+
+	// Capture warnings
+	var hook = logtest.NewGlobal()
+	defer hook.Reset()
+	log.SetLevel(log.WarnLevel)
+
+	// Run mender setup command (non-interactive)
+	menderSetupNonInteractive := []string{
+		"mender",
+		"setup",
+		"--device-type",
+		"fancy-stuff",
+		"--demo=false",
+		"--hosted-mender",
+		"--tenant-token",
+		"Paste your Hosted Mender token here",
+		"--update-poll",
+		"1800",
+		"--inventory-poll",
+		"28800",
+		"--retry-poll",
+		"30",
+	}
+	err = SetupCLI(menderSetupNonInteractive)
+
+	// Shall succeed with no warnings
+	assert.NoError(t, err)
+	assert.Empty(t, hook.AllEntries())
+}
+
 func TestCliHelpText(t *testing.T) {
 	oldstdout := os.Stdout
 	defer func() {

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -124,11 +124,15 @@ func Test_LoadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 	config, err := LoadConfig("mender.config", "does-not-exist.config")
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
+	err = config.Validate()
+	assert.NoError(t, err)
 	validateConfiguration(t, config)
 
 	config2, err2 := LoadConfig("does-not-exist.config", "mender.config")
 	assert.NoError(t, err2)
 	assert.NotNil(t, config2)
+	err = config2.Validate()
+	assert.NoError(t, err)
 	validateConfiguration(t, config2)
 }
 
@@ -140,14 +144,17 @@ func TestServerURLConfig(t *testing.T) {
 
 	config, err := LoadConfig("mender.config", "does-not-exist.config")
 	assert.NoError(t, err)
+	err = config.Validate()
+	assert.NoError(t, err)
 	assert.Equal(t, "https://mender.io", config.Servers[0].ServerURL)
 
 	// Not allowed to specify server(s) both as a list and string entry.
 	configFile.Seek(0, io.SeekStart)
 	configFile.WriteString(testTooManyServerDefsConfig)
 	config, err = LoadConfig("mender.config", "does-not-exist.config")
+	assert.NoError(t, err)
+	err = config.Validate()
 	assert.Error(t, err)
-	assert.Nil(t, config)
 }
 
 // TestMultipleServersConfig attempts to add multiple servers to config-
@@ -165,6 +172,8 @@ func TestMultipleServersConfig(t *testing.T) {
 	// load config and assert expected values i.e. check that all entries
 	// are present and URL's trailing forward slash is trimmed off.
 	conf, err := LoadConfig(confPath, "does-not-exist.config")
+	assert.NoError(t, err)
+	conf.Validate()
 	assert.NoError(t, err)
 	assert.Equal(t, "https://server.one", conf.Servers[0].ServerURL)
 	assert.Equal(t, "https://server.two", conf.Servers[1].ServerURL)


### PR DESCRIPTION
Skip the Server configuration verification for mender setup. This
command will override these fields so it is not important to validate
contents of the current config beforehand.

This validation was printing warnings on first time setup for
on-boarding Rasperry Pi install.

Changelog: Title