### PR TITLE
MEN-3420 Invalidate server device token if tenant token changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,12 @@ _testmain.go
 *.test
 *.prof
 
+# editor and ide stuff
+.idea
+*.swp
+
 mender
 
 # Go test coverage output
 *coverage*.txt
+

--- a/app/auth.go
+++ b/app/auth.go
@@ -88,16 +88,19 @@ func NewAuthManager(conf AuthManagerConfig) AuthManager {
 }
 
 func (m *MenderAuthManager) IsAuthorized(config conf.MenderConfig) bool {
-	serverURL, err := m.AuthServerURL()
-	if err == nil {
-		return false
-	}
-	if config.ServerURL != serverURL {
-		return false
-	}
-
+	log.Infof("IsAuthorized starting;")
+	//serverURL, err := m.AuthServerURL()
+	//log.Infof("    IsAuthorized config.ServerURL:%s != serverURL:%s; err=%v.", config.Servers[0].ServerURL, serverURL, err)
+	//if err != nil {
+	//	return false
+	//}
+	//if config.Servers[0].ServerURL != serverURL {
+	//	return false
+	//}
+	//
 	tenantToken, err := m.AuthTenantToken()
-	if err == nil {
+	log.Infof("    IsAuthorized config.TenantToken:%s != tenantToken:%s; err=%v.", config.TenantToken, tenantToken, err)
+	if err != nil {
 		return false
 	}
 	if config.TenantToken != tenantToken {
@@ -108,7 +111,7 @@ func (m *MenderAuthManager) IsAuthorized(config conf.MenderConfig) bool {
 	if err != nil {
 		return false
 	}
-
+	log.Infof("    IsAuthorized adata:%s", adata)
 	if adata == noAuthToken {
 		return false
 	}

--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -173,17 +173,19 @@ func TestAuthManagerResponse(t *testing.T) {
 	assert.NotNil(t, am)
 
 	var err error
-	err = am.RecvAuthResponse([]byte{})
+	var tenantToken string
+	var serverURL string
+	err = am.RecvAuthResponse([]byte{}, tenantToken, serverURL)
 	// should fail with empty response
 	assert.Error(t, err)
 
 	// make storage RO
 	ms.ReadOnly(true)
-	err = am.RecvAuthResponse([]byte("fooresp"))
+	err = am.RecvAuthResponse([]byte("fooresp"), tenantToken, serverURL)
 	assert.Error(t, err)
 
 	ms.ReadOnly(false)
-	err = am.RecvAuthResponse([]byte("fooresp"))
+	err = am.RecvAuthResponse([]byte("fooresp"), tenantToken, serverURL)
 	assert.NoError(t, err)
 	tokdata, err := ms.ReadAll(datastore.AuthTokenName)
 	assert.NoError(t, err)

--- a/app/mender.go
+++ b/app/mender.go
@@ -189,7 +189,7 @@ func (m *Mender) loadAuth() menderError {
 }
 
 func (m *Mender) IsAuthorized() bool {
-	if m.authMgr.IsAuthorized() {
+	if m.authMgr.IsAuthorized(m.Config) {
 		// AuthToken is present in store
 
 		if err := m.loadAuth(); err != nil {
@@ -206,7 +206,7 @@ func (m *Mender) Authorize() menderError {
 	var err error
 	var server *client.MenderServer
 
-	if m.authMgr.IsAuthorized() {
+	if m.authMgr.IsAuthorized(m.Config) {
 		log.Info("authorization data present and valid, skipping authorization attempt")
 		return m.loadAuth()
 	}
@@ -252,7 +252,7 @@ func (m *Mender) Authorize() menderError {
 		return NewTransientError(errors.Wrap(err, "authorization request failed"))
 	}
 
-	err = m.authMgr.RecvAuthResponse(rsp)
+	err = m.authMgr.RecvAuthResponse(rsp, m.Config.TenantToken, server.ServerURL)
 	if err != nil {
 		return NewTransientError(errors.Wrap(err, "failed to parse authorization response"))
 	}
@@ -462,7 +462,7 @@ func reauthorize(m *Mender) func(string) (client.AuthToken, error) {
 			return noAuthToken, NewTransientError(errors.Wrap(err, "authorization request failed"))
 		}
 
-		err = m.authMgr.RecvAuthResponse(rsp)
+		err = m.authMgr.RecvAuthResponse(rsp, m.Config.TenantToken, serverURL)
 		if err != nil {
 			return noAuthToken, NewTransientError(errors.Wrap(err, "failed to parse authorization response"))
 		}

--- a/app/mender.go
+++ b/app/mender.go
@@ -175,29 +175,39 @@ func (m *Mender) Bootstrap() menderError {
 
 // cache authorization code
 func (m *Mender) loadAuth() menderError {
+	log.Info("Mender.loadAuth starting.")
 	if m.authToken != noAuthToken {
+		log.Info("    Mender.loadAuth returning nil.")
 		return nil
 	}
 
+	log.Info("    Mender.loadAuth calling m.authMgr.AuthToken;")
 	code, err := m.authMgr.AuthToken()
+	log.Infof("    Mender.loadAuth m.authMgr.AuthToken rc %v,%v;", code, err)
 	if err != nil {
+		log.Info("Mender.loadAuth returns fatal error.")
 		return NewFatalError(errors.Wrap(err, "failed to cache authorization code"))
 	}
 
 	m.authToken = code
+	log.Info("Mender.loadAuth set m.authToken = code and returns nil.")
 	return nil
 }
 
 func (m *Mender) IsAuthorized() bool {
+	log.Info("Mender.IsAuthorized starting; calling m.authMgr.IsAuthorized")
 	if m.authMgr.IsAuthorized(m.Config) {
+		log.Info("    Mender.IsAuthorized m.authMgr.IsAuthorized rc=true")
 		// AuthToken is present in store
 
 		if err := m.loadAuth(); err != nil {
+			log.Infof("        Mender.IsAuthorized m.loadAuth err=%v.", err)
 			return false
 		}
-		log.Info("authorization data present and valid")
+		log.Info("Mender.IsAuthorized authorization data present and valid; returns true")
 		return true
 	}
+	log.Info("Mender.IsAuthorized returns false")
 	return false
 }
 

--- a/app/mender_test.go
+++ b/app/mender_test.go
@@ -358,7 +358,7 @@ func (t *testAuthDataMessenger) MakeAuthRequest() (*client.AuthRequest, error) {
 	}, t.reqError
 }
 
-func (t *testAuthDataMessenger) RecvAuthResponse(data []byte) error {
+func (t *testAuthDataMessenger) RecvAuthResponse(data []byte, tenantToken, serverURL string) error {
 	t.rspData = data
 	return t.rspError
 }

--- a/app/state.go
+++ b/app/state.go
@@ -242,6 +242,7 @@ type idleState struct {
 }
 
 func (i *idleState) Handle(ctx *StateContext, c Controller) (State, bool) {
+	log.Info("idleState.Handle starting")
 	// stop deployment logging
 	DeploymentLogger.Disable()
 
@@ -249,9 +250,12 @@ func (i *idleState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	RemoveStateData(ctx.Store)
 
 	// check if client is authorized
+	log.Info("    idleState.Handle calling c.IsAuthorized")
 	if c.IsAuthorized() {
+		log.Infof("        idleState.Handle returning %v,%v.", States.CheckWait, false)
 		return States.CheckWait, false
 	}
+	log.Infof("    idleState.Handle returning %v,%v.", States.AuthorizeWait, false)
 	return States.AuthorizeWait, false
 }
 
@@ -659,7 +663,7 @@ type updateCheckState struct {
 }
 
 func (u *updateCheckState) Handle(ctx *StateContext, c Controller) (State, bool) {
-	log.Debugf("Handle update check state")
+	log.Infof("Handle update check state")
 
 	update, err := c.CheckUpdate()
 
@@ -1117,7 +1121,7 @@ func (cw *checkWaitState) Cancel() bool {
 
 func (cw *checkWaitState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
-	log.Debugf("Handle check wait state")
+	log.Info("Handle check wait state")
 
 	// calculate next interval
 	update := ctx.lastUpdateCheckAttempt.Add(c.GetUpdatePollInterval())

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -22,7 +22,9 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/conf"
@@ -414,6 +416,14 @@ func (runOptions *runOptionsType) commonCLIHandler(
 }
 
 func (runOptions *runOptionsType) handleCLIOptions(ctx *cli.Context) error {
+	initalSleep := os.Getenv("MENDER_INITIAL_SLEEP")
+	if len(initalSleep) > 0 {
+		initialSleepSeconds, err := strconv.ParseInt(initalSleep, 10, 64)
+		if err == nil {
+			log.Infof("initial sleeping %ds", initialSleepSeconds)
+			time.Sleep(time.Duration(initialSleepSeconds) * time.Second)
+		}
+	}
 	config, dualRootfsDevice, err := runOptions.commonCLIHandler(ctx)
 	if err != nil {
 		return err

--- a/client/auth.go
+++ b/client/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -68,5 +68,5 @@ type AuthDataMessenger interface {
 	MakeAuthRequest() (*AuthRequest, error)
 	// Receive authorization token. Normally, the recipient should store the token
 	// in a safe place, so that the token can be used in subsequent API requests.
-	RecvAuthResponse([]byte) error
+	RecvAuthResponse([]byte, string, string) error
 }

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -42,7 +42,7 @@ func (t *testAuthDataMessenger) MakeAuthRequest() (*AuthRequest, error) {
 	}, t.reqError
 }
 
-func (t *testAuthDataMessenger) RecvAuthResponse(data []byte) error {
+func (t *testAuthDataMessenger) RecvAuthResponse(data []byte, tenantToken, serverURL string) error {
 	t.rspData = data
 	return t.rspError
 }

--- a/conf/config.go
+++ b/conf/config.go
@@ -105,6 +105,7 @@ func NewMenderConfig() *MenderConfig {
 // values into the MenderConfig structure defining high level client
 // configurations.
 func LoadConfig(mainConfigFile string, fallbackConfigFile string) (*MenderConfig, error) {
+	log.Info("LoadConfig starts")
 	// Load fallback configuration first, then main configuration.
 	// It is OK if either file does not exist, so long as the other one does exist.
 	// It is also OK if both files exist.

--- a/datastore/dbkeys.go
+++ b/datastore/dbkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,6 +37,12 @@ const (
 
 	// Key used to store the auth token.
 	AuthTokenName = "authtoken"
+
+	// Key used to store the auth token.
+	AuthTenantTokenName = "tenanttoken"
+
+	// Key used to store the auth token.
+	AuthServerURLName = "serverurl"
 
 	// The key used by the standalone installer to track artifacts that have
 	// been started, but not committed. We don't want to use the


### PR DESCRIPTION
Go to unauth state when server URL or tenant token change.

* save tenant token and server URL in the lmdb store
* check if server URL or tenant token changed
* go to unauth state if server URL or tenant token changed

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>
