### PR TITLE
mender-inventory-geo: Fixing the syntax error appearing on rpi4.

### DIFF
--- a/support/mender-inventory-geo
+++ b/support/mender-inventory-geo
@@ -23,7 +23,7 @@
 # but in the following we assume busybox version of the utilities.
 # see below for the configuration of the attributes names
 
-function err() {
+err() {
  local rc=$1
 
  shift


### PR DESCRIPTION
This one fixes:

root@raspberrypi:~# /usr/share/mender/inventory/mender-inventory-geo
/usr/share/mender/inventory/mender-inventory-geo: 26: /usr/share/mender/inventory/mender-inventory-geo: Syntax error: "(" unexpected

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
