### PR TITLE
[2.3.x] MEN-3676: Fix broken logging to syslogger.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -582,8 +582,7 @@ func (runOptions *runOptionsType) handleLogFlags(ctx *cli.Context) error {
 		}
 		log.SetOutput(fd)
 	}
-	if ctx.IsSet("no-syslog") &&
-		!runOptions.logOptions.noSyslog {
+	if !runOptions.logOptions.noSyslog {
 		hook, err := mender_syslog.NewSyslogHook(
 			"", "", syslog.LOG_DEBUG|syslog.LOG_USER, "mender", level)
 		if err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -190,8 +190,6 @@ func TestLoggingOptions(t *testing.T) {
 	err = SetupCLI([]string{"mender", "-no-syslog"})
 	// Just check that the flag can be specified.
 	assert.True(t, err == nil)
-	assert.False(t, testLogContainsMessage(hook.AllEntries(), "syslog"),
-		"log does contain 'syslog', with the '-no-syslog' flag")
 }
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
The test being removed is wrong, whether or not you specify -no-syslog
has no effect on hooks, it only affects the specific hook which is the
syslog hook. This part is tested in meta-mender on an actual device.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit ec05929c10788016e254c5f057f6eea1d0bbc20d)
