### PR TITLE
Fix TestIgnoreServerConfigVerification

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -479,6 +479,7 @@ func TestIgnoreServerConfigVerification(t *testing.T) {
 	// Run mender setup command (non-interactive)
 	menderSetupNonInteractive := []string{
 		"mender",
+		"-no-syslog",
 		"setup",
 		"--device-type",
 		"fancy-stuff",


### PR DESCRIPTION
This test started failing in CI after the syslog fixes due to a warning
saying when unable to connect to syslog daemon. It passes locally
because it connects to syslog with no problem.