### PR TITLE
2.2.x: MEN-3684: Switch to fw_setenv script syntax which libubootenv supports. 

### DIFF
--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -113,7 +113,7 @@ func (e *UBootEnv) WriteEnv(vars BootVars) error {
 		return err
 	}
 	for k, v := range vars {
-		_, err = fmt.Fprintf(pipe, "%s %s\n", k, v)
+		_, err = fmt.Fprintf(pipe, "%s=%s\n", k, v)
 		if err != nil {
 			log.Error("Error while setting U-Boot variable: ", err)
 			pipe.Close()


### PR DESCRIPTION
Specifically, it means using:

```
bootcount=0
```

instead of:

```
bootcount 0
```

Luckily, this is a backwards compatible change, as both the original
fw-utils based on U-Boot, as well as fw_setenv from
grub-mender-grubenv already support this syntax.

Changelog: Add support for libubootenv as boot loader user space tools
provider.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit b2507398889da5de4d859a97cf9fd8d0daf1449c)
