### PR TITLE
mender-device-identity: skip dummyX interfaces

### DIFF
--- a/support/mender-device-identity
+++ b/support/mender-device-identity
@@ -39,6 +39,11 @@ for dev in $SCN/*; do
         continue
     fi
 
+    # Skip dummy interfaces
+    if echo "$dev" | grep -q "$SCN/dummy" 2>/dev/null; then
+	continue
+    fi
+
     idx=$(cat $dev/ifindex)
     if [ $idx -lt $min ]; then
         min=$idx


### PR DESCRIPTION
This fixes an issue where driver initialization happened to order
the interfaces such that dummy0 showed up before a real network
interface, resulting in an invalid identity.

These are virtual interfaces, not suitable for device identity.
It may be unusual for an embedded system (or any system, for that
matter) to include CONFIG_DUMMY in their kernel configuration, but
if it does, its MAC address shouldn't be used as a device identifier.

Changelog: Title

Signed-off-by: Matt Madison <matt@madison.systems>
Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>