### PR TITLE
mender.service: update to run after network-online.target

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mender OTA update service
-After=systemd-resolved.service
+Wants=network-online.target
+After=systemd-resolved.service network-online.target
 
 [Service]
 Type=idle


### PR DESCRIPTION
Mender client startup may happen before the network is ready, so
it can't actually reach the server. It will wait its normal polling
interval to try again, but that's usually on the order of many minutes.

This change adds a weak dependency on the network-online.target and
orders itself after this target. This way, the system's regular checks
for network online will be run before the mender client starts.

Changelog: Title

Signed-off-by: Matt Madison <matt@madison.systems>
Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>