### PR TITLE
Added unit tests for ED25519 signatures

### DIFF
--- a/store/keystore.go
+++ b/store/keystore.go
@@ -140,7 +140,11 @@ func (k *Keystore) PublicPEM() (string, error) {
 }
 
 func (k *Keystore) Sign(data []byte) ([]byte, error) {
-	return k.private.SignPKCS1v15(openssl.SHA256_Method, data)
+	method := openssl.SHA256_Method
+	if k.private.KeyType() == openssl.KeyTypeED25519 {
+		method = nil
+	}
+	return k.private.SignPKCS1v15(method, data)
 }
 
 func IsNoKeys(e error) bool {


### PR DESCRIPTION
This simply adds a unit test for the `ed25519` signature added in #572 