### PR TITLE
test: Only include mendersoftware/mender files in coverage 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ htmlcover: coverage
 
 coverage:
 	rm -f coverage.txt
-	$(GO) test -coverprofile=coverage-tmp.txt -coverpkg=github.com/mendersoftware/... ./...
+	$(GO) test -coverprofile=coverage-tmp.txt -coverpkg=./... ./...
 	if [ -f coverage-missing-subtests.txt ]; then \
 		echo 'mode: set' > coverage.txt; \
 		cat coverage-tmp.txt coverage-missing-subtests.txt | grep -v 'mode: set' >> coverage.txt; \


### PR DESCRIPTION
Previously all packages matching the prefix mendersoftware/mender would be
included in the coverage report. This meant that 'mender-artifact' would be
included in the test coverage reports, which is unnecessary, considering it is a
package of its own.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
