### PR TITLE
MEN-3871 Load private key from engine.

### DIFF
--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -31,7 +31,7 @@ func TestNewAuthManager(t *testing.T) {
 	idrunner := &dev.IdentityDataRunner{
 		Cmdr: cmdr,
 	}
-	ks := store.NewKeystore(ms, "key", false)
+	ks := store.NewKeystore(ms, "key", "", false)
 
 	am := NewAuthManager(AuthManagerConfig{
 		AuthDataStore:  nil,
@@ -72,7 +72,7 @@ func TestAuthManager(t *testing.T) {
 		IdentitySource: &dev.IdentityDataRunner{
 			Cmdr: cmdr,
 		},
-		KeyStore: store.NewKeystore(ms, "key", false),
+		KeyStore: store.NewKeystore(ms, "key", "", false),
 	})
 	assert.NotNil(t, am)
 	assert.IsType(t, &MenderAuthManager{}, am)
@@ -103,7 +103,7 @@ func TestAuthManager(t *testing.T) {
 		IdentitySource: &dev.IdentityDataRunner{
 			Cmdr: cmdr,
 		},
-		KeyStore: store.NewKeystore(ms, "key", true),
+		KeyStore: store.NewKeystore(ms, "key", "", true),
 	})
 	err = am.GenerateKey()
 	if assert.Error(t, err) {
@@ -123,7 +123,7 @@ func TestAuthManagerRequest(t *testing.T) {
 			Cmdr: badCmdr,
 		},
 		TenantToken: []byte("tenant"),
-		KeyStore:    store.NewKeystore(ms, "key", false),
+		KeyStore:    store.NewKeystore(ms, "key", "", false),
 	})
 	assert.NotNil(t, am)
 
@@ -137,7 +137,7 @@ func TestAuthManagerRequest(t *testing.T) {
 		IdentitySource: dev.IdentityDataRunner{
 			Cmdr: cmdr,
 		},
-		KeyStore:    store.NewKeystore(ms, "key", false),
+		KeyStore:    store.NewKeystore(ms, "key", "", false),
 		TenantToken: []byte("tenant"),
 	})
 	assert.NotNil(t, am)
@@ -180,7 +180,7 @@ func TestAuthManagerResponse(t *testing.T) {
 		IdentitySource: dev.IdentityDataRunner{
 			Cmdr: cmdr,
 		},
-		KeyStore: store.NewKeystore(ms, "key", false),
+		KeyStore: store.NewKeystore(ms, "key", "", false),
 	})
 	assert.NotNil(t, am)
 

--- a/app/mender_test.go
+++ b/app/mender_test.go
@@ -111,7 +111,7 @@ func newTestMender(_ *stest.TestOSCalls, config conf.MenderConfig,
 
 	if pieces.AuthMgr == nil {
 
-		ks := store.NewKeystore(pieces.Store, conf.DefaultKeyFile, false)
+		ks := store.NewKeystore(pieces.Store, conf.DefaultKeyFile, "", false)
 
 		cmdr := stest.NewTestOSCalls("mac=foobar", 0)
 		pieces.AuthMgr = NewAuthManager(AuthManagerConfig{
@@ -182,7 +182,7 @@ func Test_Bootstrap(t *testing.T) {
 	assert.NoError(t, mender.Bootstrap())
 
 	mam, _ := mender.authMgr.(*MenderAuthManager)
-	k := store.NewKeystore(mam.store, conf.DefaultKeyFile, false)
+	k := store.NewKeystore(mam.store, conf.DefaultKeyFile, "", false)
 	assert.NotNil(t, k)
 	assert.NoError(t, k.Load())
 }
@@ -191,7 +191,7 @@ func Test_BootstrappedHaveKeys(t *testing.T) {
 
 	// generate valid keys
 	ms := store.NewMemStore()
-	k := store.NewKeystore(ms, conf.DefaultKeyFile, false)
+	k := store.NewKeystore(ms, conf.DefaultKeyFile, "", false)
 	assert.NotNil(t, k)
 	assert.NoError(t, k.Generate())
 	assert.NoError(t, k.Save())

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -110,7 +110,7 @@ func TestRunDaemon(t *testing.T) {
 
 	pieces.AuthMgr = app.NewAuthManager(app.AuthManagerConfig{
 		AuthDataStore: pieces.Store,
-		KeyStore:      store.NewKeystore(pieces.Store, conf.DefaultKeyFile, false),
+		KeyStore:      store.NewKeystore(pieces.Store, conf.DefaultKeyFile, "", false),
 		IdentitySource: &dev.IdentityDataRunner{
 			Cmdr: stest.NewTestOSCalls("mac=foobar", 0),
 		},

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -75,9 +75,9 @@ func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPie
 	)
 	dirstore = store.NewDirStore(opts.dataStore)
 	if config.HttpsClient.Key != "" {
-		ks = store.NewKeystore(dirstore, config.HttpsClient.Key, true)
+		ks = store.NewKeystore(dirstore, config.HttpsClient.Key, config.HttpsClient.SSLEngine, true)
 	} else {
-		ks = store.NewKeystore(dirstore, conf.DefaultKeyFile, false)
+		ks = store.NewKeystore(dirstore, conf.DefaultKeyFile, config.HttpsClient.SSLEngine, false)
 	}
 	if ks == nil {
 		return nil, errors.New("failed to setup key storage")

--- a/client/client.go
+++ b/client/client.go
@@ -364,6 +364,7 @@ func loadPrivateKey(keyFile string, engineId string) (key openssl.PrivateKey, er
 				engineId, err.Error())
 			return nil, err
 		}
+		log.Infof("laoded private key: '%v' from '%s'.", key, engineId)
 	} else {
 		keyBytes, err := ioutil.ReadFile(keyFile)
 		if err != nil {

--- a/store/keystore_test.go
+++ b/store/keystore_test.go
@@ -74,12 +74,12 @@ AuMObwrNlzbL4utcxhadX27MmpV9z4GGIJGYkNo4gFE9hNWGmG4=
 func TestKeystore(t *testing.T) {
 	ms := NewMemStore()
 
-	k := NewKeystore(nil, "", false)
+	k := NewKeystore(nil, "", "", false)
 	assert.Nil(t, k)
 
 	var err error
 
-	k = NewKeystore(ms, "foo", false)
+	k = NewKeystore(ms, "foo", "", false)
 
 	// keystore has no keys, save should fail
 	err = k.Save()


### PR DESCRIPTION
Ability to load a private key from a given engine.

* if `HttpsClient.Key` contains "pkcs11:" prefix treat it as PCKS#11 URI
* new configuration directive: `HttpsClient.SSLEngine`
* tests
  * done in: https://github.com/mendersoftware/openssl/pull/17
  * integration test coming with [MEN-3905](https://tracker.mender.io/browse/MEN-3905)

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit b805a45e2d8d64309d370ce75e7cc98c2378aea1)
