### PR TITLE
Add --reboot-exit-code parameter to "install" command.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -24,13 +24,14 @@ import (
 	"runtime"
 	"strings"
 
+	"log/syslog"
+
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/installer"
 	mender_syslog "github.com/mendersoftware/mender/log/syslog"
 	"github.com/mendersoftware/mender/system"
 	log "github.com/sirupsen/logrus"
-	"log/syslog"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -171,6 +172,14 @@ func SetupCLI(args []string) error {
 					cli.ShowAppHelpAndExit(ctx, 1)
 				}
 				return runOptions.handleCLIOptions(ctx)
+			},
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:        "reboot-exit-code",
+					Destination: &runOptions.rebootExitCode,
+					Usage: "Return exit code 4 if a manual reboot " +
+						"is required after the Artifact installation.",
+				},
 			},
 		},
 		{

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -48,8 +48,9 @@ type runOptionsType struct {
 	imageFile      string
 	bootstrapForce bool
 	client.Config
-	logOptions   logOptionsType
-	setupOptions setupOptionsType // Options for setup subcommand
+	logOptions     logOptionsType
+	setupOptions   setupOptionsType // Options for setup subcommand
+	rebootExitCode bool
 }
 
 func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPieces, error) {
@@ -169,7 +170,7 @@ func handleArtifactOperations(ctx *cli.Context, runOptions runOptionsType,
 	case "install":
 		vKey := config.GetVerificationKey()
 		return app.DoStandaloneInstall(deviceManager, runOptions.imageFile,
-			runOptions.Config, vKey, stateExec)
+			runOptions.Config, vKey, stateExec, runOptions.rebootExitCode)
 
 	case "commit":
 		return app.DoStandaloneCommit(deviceManager, stateExec)

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 
+	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/cli"
 	"github.com/mendersoftware/mender/installer"
 	log "github.com/sirupsen/logrus"
@@ -24,7 +25,9 @@ import (
 
 func doMain() int {
 	if err := cli.SetupCLI(os.Args); err != nil {
-		if err == installer.ErrorNothingToCommit {
+		if err == app.ErrorManualRebootRequired {
+			return 4
+		} else if err == installer.ErrorNothingToCommit {
 			log.Warnln(err.Error())
 			return 2
 		} else {


### PR DESCRIPTION
This parameter will cause the "mender install" command to return an
exit code of 4 if a manual reboot is required after installation.

Changelog: Title
Signed-off-by: Pascal Hache <hacpa@touchtunes.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
