### PR TITLE
Fix rootfs-image-v2 commit in standalone mode when upgrade fails

### DIFF
--- a/tests/rootfs-image-v2
+++ b/tests/rootfs-image-v2
@@ -63,7 +63,14 @@ EOF
         ;;
 
     ArtifactCommit)
-        fw_setenv upgrade_available 0
+        if test "$(fw_printenv upgrade_available)" = "upgrade_available=1"; then
+            fw_setenv upgrade_available 0
+        else
+            # If we get here, an upgrade in standalone mode failed to boot and the user is trying to commit from the old OS.
+            # This communicates to the user that the upgrade failed.
+            echo "Upgrade failed and was reverted: refusing to commit!"
+            exit 1
+        fi
         ;;
 
     ArtifactRollback)


### PR DESCRIPTION
This changes the behavior of the ArtifactCommit function. Now, the variable
"upgrade_available" is verified, just like the built-in "rootfs-image",
and the commit fails if no upgrade is in progress. So, if an upgrade fails and
the user tries to commit after returning to the old OS, the commit will fail
and an appropriate message will be printed.

Changelog: Title

Signed-off-by: Pascal Hache <hacpa@touchtunes.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
