### PR TITLE
Fixed wrong error produced by rootfs-image commit

### DIFF
--- a/installer/dual_rootfs_device.go
+++ b/installer/dual_rootfs_device.go
@@ -236,7 +236,7 @@ func (d *dualRootfsDeviceImpl) CommitUpdate() error {
 		// For now set only appropriate boot flags
 		return d.WriteEnv(BootVars{"upgrade_available": "0"})
 	}
-	return ErrorNothingToCommit
+	return errors.New(verifyRebootError)
 }
 
 func (d *dualRootfsDeviceImpl) HasUpdate() (bool, error) {

--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -59,7 +59,7 @@ func Test_commitUpdate(t *testing.T) {
 		},
 	}
 
-	if err := dualRootfsDevice.CommitUpdate(); err != ErrorNothingToCommit {
+	if err := dualRootfsDevice.CommitUpdate(); !assert.EqualError(t, err, verifyRebootError) {
 		t.FailNow()
 	}
 


### PR DESCRIPTION
After a rootfs update is attempted in standalone mode and
reverted by the bootloader, a manual "commit" attempt
would report the wrong error (nothing to commit).
Now it reports the same error as the VerifyReboot state, so
the behavior is now similar in managed and standalone modes.

Changelog: Title
Signed-off-by: Pascal Hache <hacpa@touchtunes.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
