### PR TITLE
Call PATCH inventory/device/attributes only on inventory changes

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -35,6 +35,7 @@ type DeviceManager struct {
 	DeviceTypeFile      string
 	Installers          []installer.PayloadUpdatePerformer
 	InstallerFactories  installer.AllModules
+	LastInventoryHash   [32]byte
 	StateScriptExecutor statescript.Executor
 	StateScriptPath     string
 	Store               store.Store


### PR DESCRIPTION
Make the client save a checksum of the current inventory attributes in
memory, and only call the API endpoint if the newly collected inventory
attributes differ from the already sent ones. It will always send the
inventory the first time after a boot.

Changelog: Title