### PR TITLE
Use new command syntax on the service ExecStart

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -7,7 +7,7 @@ After=systemd-resolved.service network-online.target
 Type=idle
 User=root
 Group=root
-ExecStart=/usr/bin/mender -daemon
+ExecStart=/usr/bin/mender daemon
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
At the moment both syntax are supported, but we will remove the -command
one on Mender 3.0, so better to start spreading the word ;)

Changelog: None