### PR TITLE
MEN-3970: Add backwards compatibility to write to old U-Boot envs

### DIFF
--- a/installer/bootenv_test.go
+++ b/installer/bootenv_test.go
@@ -168,3 +168,19 @@ func Test_PermissionDenied(t *testing.T) {
 	err = env.WriteEnv(nil)
 	assert.Error(t, err)
 }
+
+func Test_ProbeSeparator(t *testing.T) {
+	// Environment supporting the '=' separator
+	runner := stest.NewTestOSCalls("", 0)
+	fakeEnv := NewEnvironment(runner)
+	separator, err := fakeEnv.probeSeparator()
+	assert.NoError(t, err)
+	assert.Equal(t, uBootEnvStandardSeparator, separator)
+
+	// Environment supporting whitespace as a separator
+	runner = stest.NewTestOSCalls("mender_uboot_separator=1", 0)
+	fakeEnv = NewEnvironment(runner)
+	separator, err = fakeEnv.probeSeparator()
+	assert.NoError(t, err)
+	assert.Equal(t, uBootEnvLegacySeparator, separator)
+}


### PR DESCRIPTION
This change is needed to support older U-Boot versions, where the firmware tools
only support the 'key value', syntax, whereas the newer tools, and libubootenv
especially only support the '=' separator, giving 'key=value' as the only option.

This is solved through first writing to the environment using the legacy whitespace separator syntax, and then reading the variable back, to see if the operation applied a change to the environment. If it did, assume the separator to use is the legacy space separator.

Changelog: Title
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
