### PR TITLE
MEN-3924 Allow to load private key from the Security configuration section

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -83,11 +83,26 @@ func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPie
 		dirstore *store.DirStore
 	)
 	dirstore = store.NewDirStore(opts.dataStore)
+	var privateKey string
+	var sslEngine string
+	var static bool
+
 	if config.HttpsClient.Key != "" {
-		ks = store.NewKeystore(dirstore, config.HttpsClient.Key, config.HttpsClient.SSLEngine, true)
-	} else {
-		ks = store.NewKeystore(dirstore, conf.DefaultKeyFile, config.HttpsClient.SSLEngine, false)
+		privateKey = config.HttpsClient.Key
+		sslEngine = config.HttpsClient.SSLEngine
+		static = true
 	}
+	if config.Security.AuthPrivateKey != "" {
+		privateKey = config.Security.AuthPrivateKey
+		sslEngine = config.Security.SSLEngine
+		static = true
+	}
+	if config.HttpsClient.Key == "" && config.Security.AuthPrivateKey == "" {
+		privateKey = conf.DefaultKeyFile
+		sslEngine = config.HttpsClient.SSLEngine
+		static = false
+	}
+	ks = store.NewKeystore(dirstore, privateKey, sslEngine, static)
 	if ks == nil {
 		return nil, errors.New("failed to setup key storage")
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -514,6 +514,16 @@ type HttpsClient struct {
 	SSLEngine   string
 }
 
+// Security structure holds the configuration for the client
+// Added for MEN-3924 in order to provide a way to specify PKI params
+// outside HttpsClient.
+// NOTE: Careful when changing this, the struct is exposed directly in the
+// 'mender.conf' file.
+type Security struct {
+	AuthPrivateKey string
+	SSLEngine      string
+}
+
 func (h *HttpsClient) Validate() {
 	if h == nil {
 		return

--- a/conf/config.go
+++ b/conf/config.go
@@ -32,6 +32,8 @@ type MenderConfigFromFile struct {
 	ArtifactVerifyKey string
 	// HTTPS client parameters
 	HttpsClient client.HttpsClient
+	// Security parameters
+	Security client.Security
 	// Rootfs device path
 	RootfsPartA string
 	RootfsPartB string
@@ -162,6 +164,12 @@ func (c *MenderConfig) Validate() error {
 	}
 
 	c.HttpsClient.Validate()
+
+	if c.HttpsClient.Key != "" && c.Security.AuthPrivateKey != "" {
+		log.Warn("both config.HttpsClient.Key and config.Security.AuthPrivateKey" +
+			" specified; config.Security.AuthPrivateKey will take precedence over" +
+			" the former for the signing of auth requests.")
+	}
 
 	log.Debugf("Verified configuration = %#v", c)
 


### PR DESCRIPTION
Allow to provide the key outside HttpsClient configuration section.

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>
