### PR TITLE
MEN-3980

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -484,9 +484,9 @@ func TestListSystemCertsFound(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for name, test := range tests {
 		sysCerts, err := nrOfSystemCertsFound(test.certDir)
 		test.assertFunc(t, err)
-		assert.Equal(t, test.certificatesExpected, sysCerts)
+		assert.Equal(t, test.certificatesExpected, sysCerts, name)
 	}
 }

--- a/installer/dual_rootfs_device.go
+++ b/installer/dual_rootfs_device.go
@@ -123,21 +123,49 @@ func (d *dualRootfsDeviceImpl) Rollback() error {
 		return errors.Wrap(err, "Could not determine whether device has an update")
 	} else if !hasUpdate {
 		// Nothing to do.
+		log.Info("No update available, so no rollback needed.")
 		return nil
 	}
 
-	// first get inactive partition
-	inactivePartition, inactivePartitionHex, err := d.getInactivePartition()
+	// If we are still on the active partition, do not switch partitions
+	env, err := d.ReadEnv("mender_boot_part")
 	if err != nil {
 		return err
 	}
-	log.Infof("Setting partition for rollback: %s", inactivePartition)
+	value, ok := env["mender_boot_part"]
+	if !ok {
+		// Oh my
+		return errors.New("The bootloader environment does not have the 'mender_boot_part' set. This is a critical error.")
+	}
+	nextPartition, nextPartitionHex, err := d.getActivePartition()
+	if err != nil {
+		log.Error("Failed to get the active partition.")
+		return err
+	}
+	// If 'mender_boot_part' does not equal the mounted rootfs, and
+	// 'upgrade_available=1' we have not yet rebooted. This means we came
+	// here from ArtifactInstall, and the rollback must switch back the
+	// partition to the current active and running partition.
+	if value != nextPartition {
+		log.Infof("Rolling back to the active partition: (%s).", nextPartition)
+	} else {
+		nextPartition, nextPartitionHex, err = d.getInactivePartition()
+		if err != nil {
+			log.Error("Failed to get the inactive partition.")
+			return err
+		}
+		log.Infof("Rolling back to the inactive partition (%s).", nextPartition)
+	}
 
-	err = d.WriteEnv(BootVars{"mender_boot_part": inactivePartition, "mender_boot_part_hex": inactivePartitionHex, "upgrade_available": "0"})
+	err = d.WriteEnv(BootVars{
+		"mender_boot_part":     nextPartition,
+		"mender_boot_part_hex": nextPartitionHex,
+		"upgrade_available":    "0",
+	})
 	if err != nil {
 		return err
 	}
-	log.Debug("Marking inactive partition as a boot candidate successful.")
+	log.Debugf("Marking %s partition as a boot candidate successful.", nextPartition)
 	return nil
 }
 
@@ -192,13 +220,23 @@ func (d *dualRootfsDeviceImpl) getInactivePartition() (string, string, error) {
 	if err != nil {
 		return "", "", errors.New("Error obtaining inactive partition: " + err.Error())
 	}
+	return d.getPartitionImpl(inactivePartition)
+}
 
-	log.Debugf("Marking inactive partition (%s) as the new boot candidate.", inactivePartition)
+func (d *dualRootfsDeviceImpl) getActivePartition() (string, string, error) {
+	activePartition, err := d.GetActive()
+	if err != nil {
+		return "", "", errors.New("Error obtaining active partition: " + err.Error())
+	}
+	return d.getPartitionImpl(activePartition)
+}
 
-	partitionNumberDecStr := inactivePartition[len(strings.TrimRight(inactivePartition, "0123456789")):]
+func (d *dualRootfsDeviceImpl) getPartitionImpl(partition string) (string, string, error) {
+
+	partitionNumberDecStr := partition[len(strings.TrimRight(partition, "0123456789")):]
 	partitionNumberDec, err := strconv.Atoi(partitionNumberDecStr)
 	if err != nil {
-		return "", "", errors.New("Invalid inactive partition: " + inactivePartition)
+		return "", "", errors.New("Invalid partition: " + partition)
 	}
 
 	partitionNumberHexStr := fmt.Sprintf("%X", partitionNumberDec)
@@ -215,7 +253,13 @@ func (d *dualRootfsDeviceImpl) InstallUpdate() error {
 
 	log.Info("Enabling partition with new image installed to be a boot candidate: ", string(inactivePartition))
 	// For now we are only setting boot variables
-	err = d.WriteEnv(BootVars{"upgrade_available": "1", "mender_boot_part": inactivePartition, "mender_boot_part_hex": inactivePartitionHex, "bootcount": "0"})
+	err = d.WriteEnv(
+		BootVars{
+			"upgrade_available":    "1",
+			"mender_boot_part":     inactivePartition,
+			"mender_boot_part_hex": inactivePartitionHex,
+			"bootcount":            "0",
+		})
 	if err != nil {
 		return err
 	}

--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -16,10 +16,13 @@ package installer
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	stest "github.com/mendersoftware/mender/system/testing"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -192,6 +195,16 @@ func Test_FetchUpdate_existingAndNonExistingUpdateFile(t *testing.T) {
 	}
 }
 
+func testLogContainsMessage(t *testing.T, entries []*log.Entry, msg string) bool {
+	for _, entry := range entries {
+		t.Logf("Log entry: %v", entry)
+		if strings.Contains(entry.Message, msg) {
+			return true
+		}
+	}
+	return false
+}
+
 func Test_Rollback_OK(t *testing.T) {
 	runner := stest.NewTestOSCalls("", 0)
 	fakeEnv := UBootEnv{runner}
@@ -206,6 +219,41 @@ func Test_Rollback_OK(t *testing.T) {
 	if err := testDevice.Rollback(); err != nil {
 		t.FailNow()
 	}
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+	runner = stest.NewTestOSCalls("mender_boot_part=2\nupgrade_available=1", 0)
+	fakeEnv = UBootEnv{runner}
+
+	testPart = partitions{}
+	testPart.active = "part1"
+	testPart.inactive = "part2"
+
+	testDevice = dualRootfsDeviceImpl{}
+	testDevice.partitions = &testPart
+	testDevice.BootEnvReadWriter = &fakeEnv
+
+	err := testDevice.Rollback()
+	assert.NoError(t, err)
+	assert.True(t, testLogContainsMessage(t,
+		hook.AllEntries(), "Rolling back to the active partition: (1)"))
+	hook.Reset()
+
+	runner = stest.NewTestOSCalls("mender_boot_part=1\nupgrade_available=1", 0)
+	fakeEnv = UBootEnv{runner}
+
+	testPart = partitions{}
+	testPart.active = "part1"
+	testPart.inactive = "part2"
+
+	testDevice = dualRootfsDeviceImpl{}
+	testDevice.partitions = &testPart
+	testDevice.BootEnvReadWriter = &fakeEnv
+
+	err = testDevice.Rollback()
+	assert.NoError(t, err)
+	assert.True(t, testLogContainsMessage(t,
+		hook.AllEntries(), "Rolling back to the inactive partition (2)."))
 }
 
 func TestDeviceVerifyReboot(t *testing.T) {

--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -75,7 +75,7 @@ func Test_commitUpdate(t *testing.T) {
 	}
 }
 
-func Test_enableUpdatedPartition_wrongPartitinNumber_fails(t *testing.T) {
+func Test_enableUpdatedPartition_wrongPartitionNumber_fails(t *testing.T) {
 	runner := stest.NewTestOSCalls("", 0)
 	fakeEnv := UBootEnv{runner}
 
@@ -91,7 +91,7 @@ func Test_enableUpdatedPartition_wrongPartitinNumber_fails(t *testing.T) {
 	}
 }
 
-func Test_enableUpdatedPartition_correctPartitinNumber(t *testing.T) {
+func Test_enableUpdatedPartition_correctPartitionNumber(t *testing.T) {
 	runner := stest.NewTestOSCalls("", 0)
 	fakeEnv := UBootEnv{runner}
 


### PR DESCRIPTION
Currently the client has some issues with rollback on a current running
partition. Hence, any error which takes the client to the rollback state,
without the client having rebooted, will actually make the client 'roll
forward', meaning that it flips the partition, when it is not meant to. This
leads a client to reboot into the inactive partition.

This fix checks to see if the mounted partition and the next bootable partition
matches. If it does not, then a reboot is not needed, since the client came to
the rollback state without having rebooted, which can only happen on the active
partition after an install error during the initial update process.

In all other cases, the partition will be flipped.
