### PR TITLE
MEN-4032: Add Glib's GIO dependency and demo integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ test:
     - mkdir -p /go/src/$(dirname $REPO_NAME)/mender /go/src/_/builds
     - cp -r $CI_PROJECT_DIR /go/src/$(dirname $REPO_NAME)
     - cd $GOPATH/src/$REPO_NAME
-    - apt-get update && apt-get install -yyq liblzma-dev libssl-dev
+    - apt-get update && apt-get install -yyq liblzma-dev libssl-dev libglib2.0-dev
     - make get-tools
   script:
     - make extracheck

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ issue. We thank you in advance for your cooperation.
 
 * C compiler
 * [Go compiler](https://golang.org/dl/)
-* liblzma-dev and libssl-dev packages
+* liblzma-dev, libssl-dev and libglib2.0-dev packages
 
 #### LZMA support opt-out
 
@@ -81,6 +81,14 @@ dependency and substitute the `make` commands in the instructions below for:
 ```
 make TAGS=nolzma
 ```
+
+#### D-Bus support opt-out
+
+If no D-Bus support if desired, you can ignore the `libglib2.0-dev` package dependency and substitute
+the `make` commands in the instructions below for:
+
+```
+make TAGS=nodbus
 
 ### Steps
 

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package dbus
+
+import "github.com/pkg/errors"
+
+var dbusAPI DBusAPI = nil
+
+type DBusAPI interface {
+	GenerateGUID() string
+	IsGUID(string) bool
+}
+
+func GetDBusAPI() (DBusAPI, error) {
+	if dbusAPI != nil {
+		return dbusAPI, nil
+	}
+	return nil, errors.New("no D-Bus interface available")
+}

--- a/dbus/dbus_libgio.go
+++ b/dbus/dbus_libgio.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// +build !nodbus,cgo
+
+package dbus
+
+// #cgo pkg-config: gio-2.0
+// #include <gio/gio.h>
+import "C"
+
+type dbusAPILibGio struct{}
+
+// GenerateGUID generates a D-Bus GUID that can be used with e.g. g_dbus_connection_new().
+// https://developer.gnome.org/gio/stable/gio-D-Bus-Utilities.html#g-dbus-generate-guid
+func (d *dbusAPILibGio) GenerateGUID() string {
+	guid := C.g_dbus_generate_guid()
+	defer C.g_free(C.gpointer(guid))
+	return goString(guid)
+}
+
+// IsGUID Checks if string is a D-Bus GUID.
+// https://developer.gnome.org/gio/stable/gio-D-Bus-Utilities.html#g-dbus-is-guid
+func (d *dbusAPILibGio) IsGUID(str string) bool {
+	cstr := C.CString(str)
+	return goBool(C.g_dbus_is_guid(cstr))
+}
+
+func init() {
+	dbusAPI = &dbusAPILibGio{}
+}

--- a/dbus/dbus_libgio_helpers.go
+++ b/dbus/dbus_libgio_helpers.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// +build !nolibgio,cgo
+
+// Based on: https://github.com/gotk3/gotk3/blob/v0.5.0/gio/utils.go
+
+package dbus
+
+// #include <glib.h>
+import "C"
+
+func goString(cstr *C.gchar) string {
+	return C.GoString((*C.char)(cstr))
+}
+
+func goBool(b C.gboolean) bool {
+	return b != C.FALSE
+}

--- a/dbus/dbus_libgio_test.go
+++ b/dbus/dbus_libgio_test.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package dbus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var libgio dbusAPILibGio
+
+func TestGenerateGUID(t *testing.T) {
+	guid := libgio.GenerateGUID()
+	assert.NotEmpty(t, guid)
+}
+
+func TestIsGUID(t *testing.T) {
+	// Dummy GUID
+	assert.False(t, libgio.IsGUID("fake-guid"))
+
+	// Get and check a valid GUID
+	guid := libgio.GenerateGUID()
+	assert.True(t, libgio.IsGUID(guid))
+}

--- a/dbus/dbus_test.go
+++ b/dbus/dbus_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package dbus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDBusAPI(t *testing.T) {
+	api, err := GetDBusAPI()
+	assert.NoError(t, err)
+	assert.NotNil(t, api)
+}


### PR DESCRIPTION
Added a new package `dbus` in the source code defining an interface and
a default implementation for it (using C bindings for libgio).

Implement wrappers for the two easiest calls and add unit tests for
them.

Changelog: Add Glib's GIO dependency for D-Bus interface. It can be
opt-out using `nodbus` at compile time.