### PR TITLE
(cherry) testfix: Set the default config directory to a temporary directory

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -494,6 +494,7 @@ func TestIgnoreServerConfigVerification(t *testing.T) {
 		"--retry-poll",
 		"30",
 	}
+	conf.DefaultDataStore = tdir
 	err = SetupCLI(menderSetupNonInteractive)
 
 	// Shall succeed with no warnings


### PR DESCRIPTION
This fixes the test issue where this will fail locally if your permissions are
set to exclude access by the test runner.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 696d59dc17439eed0cb112a4c8e4396164b52ccc)

