### PR TITLE
fix: Do not close the response body before reading error message

### DIFF
--- a/client/client_update.go
+++ b/client/client_update.go
@@ -146,9 +146,10 @@ func (u *UpdateClient) FetchUpdate(api ApiRequester, url string, maxWait time.Du
 	log.Debugf("Received fetch update response %v+", r)
 
 	if r.StatusCode != http.StatusOK {
+		err = NewAPIError(errors.New("error receiving scheduled update information"), r)
 		r.Body.Close()
 		log.Errorf("Error fetching scheduled update info: code (%d)", r.StatusCode)
-		return nil, -1, NewAPIError(errors.New("error receiving scheduled update information"), r)
+		return nil, -1, err
 	}
 
 	if r.ContentLength < 0 {


### PR DESCRIPTION
This shows up in the client logs as:

2020-10-22 12:14:24 +0000 UTC error: Update fetch failed: (request_id: ): error receiving scheduled update information server error message: failed to parse server response: http: read on closed response body

Due to the prematurely closed response body.

The fix is to simply extract the error message before closing the response body.

Changelog: Correctly log the error message from the server on failed update
download attempts.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

