### PR TITLE
QA-214: Publish the 'latest' debian client package on new tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,11 +89,16 @@ trigger:mender-dist-packages:
   stage: trigger
   before_script:
     - apk add --no-cache curl
+    - MENDER_CLIENT_VERSION=$(git tag | egrep -e '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n1)
+    # This will only be true in the case that we have a new newest client tag
+    - PUBLISH_LATEST_CLIENT_PACKAGE="false"
+    - test "${MENDER_CLIENT_VERSION}" = "${CI_COMMIT_REF_NAME}" && export PUBLISH_LATEST_CLIENT_PACKAGE="true" || true
   script:
     - curl -v -f -X POST
       -F token=$MENDER_DIST_PACKAGES_TRIGGER_TOKEN
       -F ref=master
       -F variables[MENDER_VERSION]=$CI_COMMIT_REF_NAME
+      -F variables[PUBLISH_LATEST_CLIENT_PACKAGE]=$PUBLISH_LATEST_CLIENT_PACKAGE
       https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
   only:
     - tags


### PR DESCRIPTION
This is done through comparing the latest MENDER_CLIENT_VERSION from the
mender-client source, and then comparing it to the CI_COMMIT_TAG gitlab
variable, which is set to the tag of the current build.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

