### PR TITLE
Add: inventory-script for reporting installed update-modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ INVENTORY_SCRIPTS = \
 	support/mender-inventory-network \
 	support/mender-inventory-os \
 	support/mender-inventory-rootfs-type \
-	support/mender-inventory-geo
+	support/mender-inventory-geo \
+	support/mender-inventory-update-modules
 
 MODULES = \
 	support/modules/deb \

--- a/support/mender-inventory-update-modules
+++ b/support/mender-inventory-update-modules
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Returns the update-modules currently installed on the system
+# For more information on update-modules see:
+# https://hub.mender.io/c/update-modules/13
+#
+
+set -e
+
+RESET_INVENTORY="true"
+
+if [ ! -d /usr/share/mender/modules/ ]; then
+    echo update_modules=""
+    exit 0
+fi
+
+for file in /usr/share/mender/modules/*/*; do
+    if [ ! -x "${file}" ]; then
+      continue
+    fi
+    echo update_modules=$(basename "${file}")
+    RESET_INVENTORY="false"
+done
+
+if [ "${RESET_INVENTORY}" = "true" ]; then
+    echo update_modules=""
+fi


### PR DESCRIPTION
This simple scripts lists all the executable files found in the inventory-script
path:

/usr/share/mender/modules/*/*

Changelog: Add an inventory script for reporting the update-modules currently
installed on a device.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

