### PR TITLE
tidy: Remove the unneeded export on PUBLISH_LATEST_CLIENT_PACKAGE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ trigger:mender-dist-packages:
     - MENDER_CLIENT_VERSION=$(git tag | egrep -e '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n1)
     # This will only be true in the case that we have a new newest client tag
     - PUBLISH_LATEST_CLIENT_PACKAGE="false"
-    - test "${MENDER_CLIENT_VERSION}" = "${CI_COMMIT_REF_NAME}" && export PUBLISH_LATEST_CLIENT_PACKAGE="true" || true
+    - test "${MENDER_CLIENT_VERSION}" = "${CI_COMMIT_REF_NAME}" && PUBLISH_LATEST_CLIENT_PACKAGE="true" || true
   script:
     - curl -v -f -X POST
       -F token=$MENDER_DIST_PACKAGES_TRIGGER_TOKEN


### PR DESCRIPTION
This caused some confusion for an outsider reading it, so cleaning it up to be
semantically correct.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

