### PR TITLE
Fix regression: Cause of error not reported when authorization fails.

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -213,7 +213,7 @@ func (m *Mender) authorize() menderError {
 	// wait for the broadcast notification
 	resp, ok := <-broadcastChan
 	if !ok || resp.Error != nil {
-		return NewTransientError(errors.New("authorization request failed"))
+		return NewTransientError(errors.Wrap(resp.Error, "authorization request failed"))
 	}
 
 	// get the authentication token using loadAuth


### PR DESCRIPTION
This was causing some integration tests which look for the error to
fail.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
