### PR TITLE
MEN-4177: Implement fallback to PATCH endpoint for inventory updates.

### DIFF
--- a/client/client_inventory.go
+++ b/client/client_inventory.go
@@ -35,29 +35,43 @@ func NewInventory() InventorySubmitter {
 
 // Submit reports status information to the backend
 func (i *InventoryClient) Submit(api ApiRequester, url string, data interface{}) error {
-	req, err := makeInventorySubmitRequest(url, data)
+	// PATCH used to be the only method available in Mender Product 2.5, so
+	// fall back to that if PUT fails.
+	r, err := doSubmitInventory(api, http.MethodPut, url, data)
+	if r != nil && r.StatusCode == http.StatusMethodNotAllowed {
+		r, err = doSubmitInventory(api, http.MethodPatch, url, data)
+	}
+
+	log.Debugf("Inventory update sent, response %v", r)
+
 	if err != nil {
-		return errors.Wrapf(err, "failed to prepare inventory submit request")
+		log.Error(err.Error())
+	}
+
+	return err
+}
+
+func doSubmitInventory(api ApiRequester, method, url string, data interface{}) (*http.Response, error) {
+	req, err := makeInventorySubmitRequest(method, url, data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to prepare inventory submit request")
 	}
 
 	r, err := api.Do(req)
 	if err != nil {
 		log.Error("Failed to submit inventory data: ", err)
-		return errors.Wrapf(err, "inventory submit failed")
+		return r, errors.Wrapf(err, "inventory submit failed")
 	}
 
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		log.Errorf("Got unexpected HTTP status when submitting to inventory: %v", r.StatusCode)
-		return NewAPIError(errors.Errorf("inventory submit failed, bad status %v", r.StatusCode), r)
+		return r, NewAPIError(errors.Errorf("Got unexpected HTTP status when submitting to inventory %d", r.StatusCode), r)
 	}
-	log.Debugf("Inventory update sent, response %v", r)
-
-	return nil
+	return r, nil
 }
 
-func makeInventorySubmitRequest(server string, data interface{}) (*http.Request, error) {
+func makeInventorySubmitRequest(method, server string, data interface{}) (*http.Request, error) {
 	url := buildApiURL(server, "/inventory/device/attributes")
 
 	out := &bytes.Buffer{}
@@ -67,7 +81,7 @@ func makeInventorySubmitRequest(server string, data interface{}) (*http.Request,
 		return nil, errors.Wrapf(err, "failed to encode inventory request data")
 	}
 
-	hreq, err := http.NewRequest(http.MethodPut, url, out)
+	hreq, err := http.NewRequest(method, url, out)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create inventory HTTP request")
 	}


### PR DESCRIPTION
Otherwise a new client cannot submit inventory to an old server.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
