### PR TITLE
MEN-4170: Shutdown the client on SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ func doMain() int {
 		} else if err == installer.ErrorNothingToCommit {
 			log.Warnln(err.Error())
 			return 2
+		} else if err == cli.ErrSIGTERM {
+			return 0
 		} else {
 			log.Errorln(err.Error())
 			return 1

--- a/main.go
+++ b/main.go
@@ -25,14 +25,16 @@ import (
 
 func doMain() int {
 	if err := cli.SetupCLI(os.Args); err != nil {
-		if err == app.ErrorManualRebootRequired {
+		switch err {
+		case cli.ErrSIGTERM:
+			log.Infoln(err.Error())
+			return 0
+		case app.ErrorManualRebootRequired:
 			return 4
-		} else if err == installer.ErrorNothingToCommit {
+		case installer.ErrorNothingToCommit:
 			log.Warnln(err.Error())
 			return 2
-		} else if err == cli.ErrSIGTERM {
-			return 0
-		} else {
+		default:
 			log.Errorln(err.Error())
 			return 1
 		}

--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,17 +1,5 @@
-From ef168e0e7ade9a01cb92027d8b4f2392c25f48d4 Mon Sep 17 00:00:00 2001
-From: Ole Petter <ole.orhagen@northern.tech>
-Date: Mon, 14 Sep 2020 14:49:19 +0200
-Subject: [PATCH] Instrument Mender client for coverage analysis
-
-Changelog: None
-Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
----
- main.go          | 39 ++++++++++++++++++++++++++++++++++++++-
- system/system.go | 13 +------------
- 2 files changed, 39 insertions(+), 13 deletions(-)
-
 diff --git a/main.go b/main.go
-index 479339e..aee8744 100644
+index 56ab5dc..d011399 100644
 --- a/main.go
 +++ b/main.go
 @@ -16,6 +16,8 @@ package main
@@ -44,8 +32,8 @@ index 479339e..aee8744 100644
 +
  func doMain() int {
  	if err := cli.SetupCLI(os.Args); err != nil {
- 		if err == app.ErrorManualRebootRequired {
-@@ -39,5 +56,25 @@ func doMain() int {
+ 		switch err {
+@@ -43,5 +60,25 @@ func doMain() int {
  }
  
  func main() {
@@ -104,6 +92,3 @@ index a96d7d8..b4ceb1a 100644
  }
  
  type Commander interface {
--- 
-2.28.0
-


### PR DESCRIPTION
A signal handler for SIGTERM is added to the daemon run, but this is only able
to interrupt the client on the state-machine changing state. Thus operations
taking a long time, such as writing an update, are never in fact interrupted on
SIGTERM. Also, the Reboot state is stopped, due to this addition.

This can cause long shutdown times on clients in the process of writing an
update, as the client will not terminate until it has either switched state, or
worse, if it is already in the Reboot state, a SIGKILL signal needs to be sent
from the outside in order to shut it down.

This fix simply exits with Exit code 0 upon a received SIGTERM. The client is
already safe from interruptions, so this call is fine.

Changelog: Exit with code 0 on a received SIGTERM signal.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>