### PR TITLE
[Makefile]: Add a separate install target for network scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,10 @@ INVENTORY_SCRIPTS = \
 	support/mender-inventory-os \
 	support/mender-inventory-provides \
 	support/mender-inventory-rootfs-type \
-	support/mender-inventory-geo \
 	support/mender-inventory-update-modules
+
+INVENTORY_NETWORK_SCRIPTS = \
+	support/mender-inventory-geo
 
 MODULES = \
 	support/modules/deb \
@@ -105,9 +107,15 @@ install-identity-scripts: install-datadir
 	install -m 755 -d $(prefix)$(datadir)/mender/identity
 	install -m 755 $(IDENTITY_SCRIPTS) $(prefix)$(datadir)/mender/identity/
 
-install-inventory-scripts: install-datadir
+install-inventory-scripts: install-inventory-local-scripts install-inventory-network-scripts
+
+install-inventory-local-scripts: install-datadir
 	install -m 755 -d $(prefix)$(datadir)/mender/inventory
 	install -m 755 $(INVENTORY_SCRIPTS) $(prefix)$(datadir)/mender/inventory/
+
+install-inventory-network-scripts: install-datadir
+	install -m 755 -d $(prefix)$(datadir)/mender/inventory
+	install -m 755 $(INVENTORY_NETWORK_SCRIPTS) $(prefix)$(datadir)/mender/inventory/
 
 install-modules:
 	install -m 755 -d $(prefix)$(datadir)/mender/modules/v3
@@ -153,8 +161,17 @@ uninstall-identity-scripts:
 	done
 	-rmdir -p $(prefix)$(datadir)/mender/identity
 
-uninstall-inventory-scripts:
+uninstall-inventory-scripts: uninstall-inventory-local-scripts uninstall-inventory-network-scripts
+	-rmdir -p $(prefix)$(datadir)/mender/inventory
+
+uninstall-inventory-local-scripts:
 	for script in $(INVENTORY_SCRIPTS); do \
+		rm -f $(prefix)$(datadir)/mender/inventory/$$(basename $$script); \
+	done
+	-rmdir -p $(prefix)$(datadir)/mender/inventory
+
+uninstall-inventory-network-scripts:
+	for script in $(INVENTORY_NETWORK_SCRIPTS); do \
 		rm -f $(prefix)$(datadir)/mender/inventory/$$(basename $$script); \
 	done
 	-rmdir -p $(prefix)$(datadir)/mender/inventory
@@ -259,6 +276,8 @@ instrument-binary:
 .PHONY: install-dbus
 .PHONY: install-identity-scripts
 .PHONY: install-inventory-scripts
+.PHONY: install-inventory-local-scripts
+.PHONY: install-inventory-network-scripts
 .PHONY: install-modules
 .PHONY: install-modules-gen
 .PHONY: install-systemd
@@ -269,6 +288,8 @@ instrument-binary:
 .PHONY: uninstall-dbus
 .PHONY: uninstall-identity-scripts
 .PHONY: uninstall-inventory-scripts
+.PHONY: uninstall-inventory-local-scripts
+.PHONY: uninstall-inventory-network-scripts
 .PHONY: uninstall-modules
 .PHONY: uninstall-modules-gen
 .PHONY: uninstall-systemd


### PR DESCRIPTION
This way, it can later on be made optional, whether or not to include the
'inventory-geo-script', and other network scripts if we decide to add them.

This is followed by a separate target in meta-mender, called:
mender-inventory-network-scripts, which can be removed ad-hoc by a superuser which
whishes full control over his install.

This follows from the situation where we have had some issues with the
third-party provider we rely on for the geolocation data.

The script is still a part of the standard install target.

Changelog: The 'inventory-geo-script' now has a separate install target:
'install-inventory-network-scripts'. Note however that it is still installed by
the default 'install-inventory-scripts' target.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
