### PR TITLE
Use getter/setter-pattern instead of return pattern to avoid casting.

### DIFF
--- a/app/auth.go
+++ b/app/auth.go
@@ -89,7 +89,7 @@ type AuthManager interface {
 	GetBroadcastMessageChan(name string) <-chan AuthManagerResponse
 	Start()
 	Stop()
-	WithDBus(api dbus.DBusAPI) AuthManager
+	EnableDBus(api dbus.DBusAPI)
 
 	// check if device key is available
 	HasKey() bool
@@ -138,7 +138,7 @@ type AuthManagerConfig struct {
 }
 
 // NewAuthManager returns a new Mender authorization manager instance
-func NewAuthManager(conf AuthManagerConfig) AuthManager {
+func NewAuthManager(conf AuthManagerConfig) *MenderAuthManager {
 	if conf.KeyStore == nil || conf.IdentitySource == nil ||
 		conf.AuthDataStore == nil {
 		return nil
@@ -179,13 +179,11 @@ func NewAuthManager(conf AuthManagerConfig) AuthManager {
 	return mgr
 }
 
-// WithDBus returns a DBus-enabled MenderAuthManager
-func (m *MenderAuthManager) WithDBus(api dbus.DBusAPI) AuthManager {
+func (m *MenderAuthManager) EnableDBus(api dbus.DBusAPI) {
 	if m.hasStarted {
 		panic("Calling WithDBus() after the service has started is a programming mistake.")
 	}
 	m.dbus = api
-	return m
 }
 
 // GetInMessageChan returns the channel to send requests to the auth manager

--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -71,10 +71,6 @@ func TestNewAuthManager(t *testing.T) {
 		KeyStore:       ks,
 	})
 	assert.NotNil(t, am)
-
-	dbus := &mocks.DBusAPI{}
-	am = am.WithDBus(dbus)
-	assert.NotNil(t, am)
 }
 
 func TestAuthManager(t *testing.T) {
@@ -88,7 +84,7 @@ func TestAuthManager(t *testing.T) {
 			Cmdr: cmdr,
 		},
 		KeyStore: store.NewKeystore(ms, "key", "", false),
-	}).(*MenderAuthManager)
+	})
 	assert.NotNil(t, am)
 	assert.IsType(t, &MenderAuthManager{}, am)
 
@@ -117,7 +113,7 @@ func TestAuthManager(t *testing.T) {
 			Cmdr: cmdr,
 		},
 		KeyStore: store.NewKeystore(ms, "key", "", true),
-	}).(*MenderAuthManager)
+	})
 	err = am.GenerateKey()
 	if assert.Error(t, err) {
 		assert.True(t, store.IsStaticKey(err))
@@ -137,7 +133,7 @@ func TestAuthManagerRequest(t *testing.T) {
 		},
 		TenantToken: []byte("tenant"),
 		KeyStore:    store.NewKeystore(ms, "key", "", false),
-	}).(*MenderAuthManager)
+	})
 	assert.NotNil(t, am)
 
 	_, err = am.MakeAuthRequest()
@@ -152,7 +148,7 @@ func TestAuthManagerRequest(t *testing.T) {
 		},
 		KeyStore:    store.NewKeystore(ms, "key", "", false),
 		TenantToken: []byte("tenant"),
-	}).(*MenderAuthManager)
+	})
 	assert.NotNil(t, am)
 	_, err = am.MakeAuthRequest()
 	assert.Error(t, err, "should fail, no device keys are present")
@@ -193,7 +189,7 @@ func TestAuthManagerResponse(t *testing.T) {
 			Cmdr: cmdr,
 		},
 		KeyStore: store.NewKeystore(ms, "key", "", false),
-	}).(*MenderAuthManager)
+	})
 	assert.NotNil(t, am)
 
 	var err error
@@ -235,7 +231,7 @@ func TestForceBootstrap(t *testing.T) {
 	assert.NotEmpty(t, kdataold)
 
 	am.ForceBootstrap()
-	assert.True(t, am.(*MenderAuthManager).needsBootstrap())
+	assert.True(t, am.needsBootstrap())
 
 	merr = am.Bootstrap()
 	assert.NoError(t, merr)
@@ -260,11 +256,10 @@ func TestBootstrap(t *testing.T) {
 	})
 	assert.NotNil(t, am)
 
-	assert.True(t, am.(*MenderAuthManager).needsBootstrap())
+	assert.True(t, am.needsBootstrap())
 	assert.NoError(t, am.Bootstrap())
 
-	mam, _ := am.(*MenderAuthManager)
-	k := store.NewKeystore(mam.store, conf.DefaultKeyFile, "", false)
+	k := store.NewKeystore(am.store, conf.DefaultKeyFile, "", false)
 	assert.NotNil(t, k)
 	assert.NoError(t, k.Load())
 }
@@ -286,9 +281,8 @@ func TestBootstrappedHaveKeys(t *testing.T) {
 		KeyStore: store.NewKeystore(ms, conf.DefaultKeyFile, "", false),
 	})
 	assert.NotNil(t, am)
-	mam, _ := am.(*MenderAuthManager)
-	assert.Equal(t, ms, mam.keyStore.GetStore())
-	assert.NotNil(t, mam.keyStore.Private())
+	assert.Equal(t, ms, am.keyStore.GetStore())
+	assert.NotNil(t, am.keyStore.Private())
 
 	// subsequen bootstrap should not fail
 	assert.NoError(t, am.Bootstrap())
@@ -418,7 +412,8 @@ func TestMenderAuthorize(t *testing.T) {
 		},
 		KeyStore: store.NewKeystore(ms, conf.DefaultKeyFile, "", false),
 		Config:   config,
-	}).WithDBus(dbusAPI).(*MenderAuthManager)
+	})
+	am.EnableDBus(dbusAPI)
 
 	am.Start()
 	defer am.Stop()

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -131,7 +131,7 @@ func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPie
 		if err != nil {
 			return nil, errors.Wrap(err, "DBus API support not available, but DBus is enabled")
 		}
-		authmgr = authmgr.WithDBus(api)
+		authmgr.EnableDBus(api)
 	}
 
 	mp := app.MenderPieces{


### PR DESCRIPTION
This means we can get rid of the returned interface in the function
definition, which again allows us return the type in the constructor,
instead of the interface. Thus we can test this without a lot of
casting.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
