### PR TITLE
Fix incorrect use of AuthManager leading to race condition.

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -165,7 +165,7 @@ func doBootstrapAuthorize(config *conf.MenderConfig, opts *runOptionsType) error
 		return merr.Cause()
 	}
 
-	go authManager.Start()
+	authManager.Start()
 	defer authManager.Stop()
 
 	if merr := controller.Authorize(); merr != nil {


### PR DESCRIPTION
This was missed in 0e1608916bf4c. The auth service is not supposed to
be started in a go routine anymore, since this is managed internally
in the implementation now.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
