### PR TITLE
MEN-4191: generic D-Bus JwtTokenStateChange signal

### DIFF
--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -377,7 +377,8 @@ func TestMenderAuthorize(t *testing.T) {
 		"",
 		AuthManagerDBusPath,
 		AuthManagerDBusInterfaceName,
-		AuthManagerDBusSignalValidJwtTokenAvailable,
+		AuthManagerDBusSignalJwtTokenStateChange,
+		mock.AnythingOfType("string"),
 	).Return(nil)
 
 	dbusAPI.On("MainLoopQuit", dbusLoop)
@@ -462,7 +463,7 @@ func TestMenderAuthorize(t *testing.T) {
 	// - broadcast
 	message = <-broadcastChan
 	assert.NoError(t, message.Error)
-	assert.Equal(t, EventAuthTokenAvailable, message.Event)
+	assert.Equal(t, EventAuthTokenStateChange, message.Event)
 
 	// - get the token
 	inChan <- AuthManagerRequest{
@@ -494,7 +495,7 @@ func TestMenderAuthorize(t *testing.T) {
 	// - broadcast
 	message = <-broadcastChan
 	assert.NoError(t, message.Error)
-	assert.Equal(t, EventAuthTokenAvailable, message.Event)
+	assert.Equal(t, EventAuthTokenStateChange, message.Event)
 
 	// - get the token
 	inChan <- AuthManagerRequest{
@@ -524,6 +525,11 @@ func TestMenderAuthorize(t *testing.T) {
 	message = <-respChan
 	assert.NoError(t, message.Error)
 	assert.Equal(t, EventFetchAuthToken, message.Event)
+
+	// - broadcast, auth token state changed
+	message = <-broadcastChan
+	assert.Equal(t, EventAuthTokenStateChange, message.Event)
+	assert.Equal(t, noAuthToken, message.AuthToken)
 
 	// - broadcast, error message received
 	message = <-broadcastChan
@@ -577,7 +583,7 @@ func TestMenderAuthorize(t *testing.T) {
 	// - broadcast
 	message = <-broadcastChan
 	assert.NoError(t, message.Error)
-	assert.Equal(t, EventAuthTokenAvailable, message.Event)
+	assert.Equal(t, EventAuthTokenStateChange, message.Event)
 
 	// - get the token
 	inChan <- AuthManagerRequest{

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -53,7 +53,7 @@ type DBusAPI interface {
 	// MainLoopQuit stops a main loop from running
 	MainLoopQuit(MainLoop)
 	// EmitSignal emits a signal
-	EmitSignal(Handle, string, string, string, string) error
+	EmitSignal(Handle, string, string, string, string, interface{}) error
 }
 
 // MethodCallCallback represents a method_call callback

--- a/dbus/dbus_libgio_test.go
+++ b/dbus/dbus_libgio_test.go
@@ -276,7 +276,9 @@ func TestEmitSignal(t *testing.T) {
 
 	xml := `<node>
 	<interface name="io.mender.Authentication1">
-		<signal name="ValidJwtTokenAvailable"></signal>
+		<signal name="JwtTokenStateChange">
+			<arg type="s" name="token"/>
+		</signal>
 	</interface>
 </node>`
 
@@ -291,13 +293,13 @@ func TestEmitSignal(t *testing.T) {
 			objectName:    objectName,
 			objectPath:    "/io/mender/AuthenticationManager/TestEmitSignal1",
 			interfaceName: "io.mender.Authentication1",
-			signalName:    "ValidJwtTokenAvailable",
+			signalName:    "JwtTokenStateChange",
 		},
 		"ok, broadcast": {
 			objectName:    "",
 			objectPath:    "/io/mender/AuthenticationManager/TestEmitSignal2",
 			interfaceName: "io.mender.Authentication1",
-			signalName:    "ValidJwtTokenAvailable",
+			signalName:    "JwtTokenStateChange",
 		},
 	}
 	for name, tc := range testCases {
@@ -311,7 +313,7 @@ func TestEmitSignal(t *testing.T) {
 			go libgio.MainLoopRun(loop)
 			defer libgio.MainLoopQuit(loop)
 
-			err = libgio.EmitSignal(conn, tc.objectName, tc.objectPath, tc.interfaceName, tc.signalName)
+			err = libgio.EmitSignal(conn, tc.objectName, tc.objectPath, tc.interfaceName, tc.signalName, "token")
 			if tc.err != nil {
 				assert.Error(t, err)
 			} else {

--- a/dbus/mocks/DBusAPI.go
+++ b/dbus/mocks/DBusAPI.go
@@ -108,13 +108,13 @@ func (_m *DBusAPI) BusUnregisterInterface(_a0 dbus.Handle, _a1 uint) bool {
 	return r0
 }
 
-// EmitSignal provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
-func (_m *DBusAPI) EmitSignal(_a0 dbus.Handle, _a1 string, _a2 string, _a3 string, _a4 string) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
+// EmitSignal provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
+func (_m *DBusAPI) EmitSignal(_a0 dbus.Handle, _a1 string, _a2 string, _a3 string, _a4 string, _a5 interface{}) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(dbus.Handle, string, string, string, string) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4)
+	if rf, ok := ret.Get(0).(func(dbus.Handle, string, string, string, string, interface{}) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Update the D-Bus API replacing ValidJwtTokenAvailable Dbus signal with
a generic JwtTokenStateChange signal which carries the JWT token as a
string parameter.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>