### PR TITLE
Reduce some logging to Debug level.

### DIFF
--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -103,7 +103,7 @@ func (e *UBootEnv) ReadEnv(names ...string) (BootVars, error) {
 // means that we are on a legacy U-Boot implementation, which supports the
 // 'key<whitespace>value' syntax. If not, then use the new '=' separator.
 func (e *UBootEnv) probeSeparator() (string, error) {
-	log.Info("Probing the Bootloader environment for which separator to use")
+	log.Debug("Probing the Bootloader environment for which separator to use")
 	// Try writing using the old separator syntax
 	err := e.writeEnvImpl(BootVars{
 		menderUBootSeparatorProbe: "1",
@@ -145,7 +145,7 @@ func (e *UBootEnv) WriteEnv(vars BootVars) error {
 
 func (e *UBootEnv) writeEnvImpl(vars BootVars, separator string) error {
 
-	log.Infof("Writing %v to the U-Boot environment, using separator: %s",
+	log.Debugf("Writing %v to the U-Boot environment, using separator: %s",
 		vars, separator)
 
 	// Make environment update atomic by using fw_setenv "-s" option.


### PR DESCRIPTION
These messages are just too verbose for a standard run. Take this
example, just committing an artifact:

```
INFO[0000] Loaded configuration file: /var/lib/mender/mender.conf
INFO[0000] Loaded configuration file: /etc/mender/mender.conf
INFO[0000] Mender running on partition: /dev/mmcblk0p3
Committing Artifact...
INFO[0001] Committing update
INFO[0001] Probing the Bootloader environment for which separator to use ...
INFO[0001] Writing map[mender_uboot_separator:1] to the U-Boot environment ...
INFO[0003] Writing map[mender_uboot_separator:] to the U-Boot environment ...
INFO[0004] Writing map[upgrade_available:0] to the U-Boot environment ...
```

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
