### PR TITLE
Fix dangling code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the `make` commands in the instructions below for:
 
 ```
 make TAGS=nodbus
-
+```
 ### Steps
 
 To install Mender on a device from source, first clone the repository in the correct folder


### PR DESCRIPTION
The README code blocks are inverted after the `make TAGS=nodbus` line due to the codeblock markdown not being closed.