### PR TITLE
MEN-4245: Fix error parsing response for getting tenant token on setup

### DIFF
--- a/cli/setup.go
+++ b/cli/setup.go
@@ -484,6 +484,10 @@ func (opts *setupOptionsType) askServerCert(ctx *cli.Context,
 
 func (opts *setupOptionsType) getTenantToken(
 	client *http.Client, userToken []byte) error {
+	type tenantTokenResponse struct {
+		Token string `json:"tenant_token"`
+	}
+
 	tokReq, err := http.NewRequest(
 		"GET",
 		hostedMenderURL+
@@ -509,13 +513,13 @@ func (opts *setupOptionsType) getTenantToken(
 		return errors.Wrap(err,
 			"Reading tenant token FAILED.")
 	}
-	dataJson := make(map[string]string)
-	err = json.Unmarshal(data, &dataJson)
+	tokRsp := new(tenantTokenResponse)
+	err = json.Unmarshal(data, tokRsp)
 	if err != nil {
 		return errors.Wrap(err,
 			"Error parsing JSON response.")
 	}
-	opts.tenantToken = dataJson["tenant_token"]
+	opts.tenantToken = tokRsp.Token
 	log.Info("Successfully requested tenant token.")
 
 	return nil


### PR DESCRIPTION
The problem is that the endpoint now returns an embedded JSON object
with info about the api limits, which fails to unmarshal into an object of type
map[string]string.