### PR TITLE
Fix DBus race condition between mender-client and mender-shell.

### DIFF
--- a/app/auth.go
+++ b/app/auth.go
@@ -301,6 +301,17 @@ func (m *menderAuthManagerService) run() {
 	}
 
 mainloop:
+	// Broadcast the TokenStateChange signal once on startup, if we have a
+	// valid token. The reason this is important is that clients that use
+	// the auth DBus API may already have tried calling GetJwtToken
+	// unsuccessfully, and are now waiting for a signal. If we don't
+	// broadcast it on startup, these clients may be left without a token
+	// until it expires and we get a new one, which can take several days.
+	token, err := m.authToken()
+	if err == nil && token != "" {
+		m.broadcastAuthTokenStateChange()
+	}
+
 	// run the auth manager main loop
 	running := true
 	for running {


### PR DESCRIPTION
Since we do not have DBus activation enabled in the
`mender-client.service` file, there is no guarantee that mender-client
will grab the DBus interface first. If mender-shell happens to grab it
first, it will not get a reply to GetJwtToken, but will instead start
waiting for a state change. But unless the token has actually changed,
it will not get one if mender-client doesn't post it on startup.

Adding DBus activation in the systemd service file would also solve
the problem, but this comes with some extra complexities because the
client can also be compiled without DBus support. Rather than deal
with that, this short fix seems to solve the problem well, and also
works if the client simply crashes and comes back online.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
