### PR TITLE
MEN-4360: Extend the D-Bus API to return the server URL

### DIFF
--- a/app/auth.go
+++ b/app/auth.go
@@ -166,6 +166,17 @@ func NewAuthManager(conf AuthManagerConfig) *MenderAuthManager {
 		}
 	}
 
+	// get the first server URL available in the config file
+	serverURL := ""
+	if conf.Config != nil {
+		serverIterator := nextServerIterator(*conf.Config)
+		if serverIterator != nil {
+			if server := serverIterator(); server != nil {
+				serverURL = server.ServerURL
+			}
+		}
+	}
+
 	mgr := &MenderAuthManager{
 		&menderAuthManagerService{
 			inChan:         make(chan AuthManagerRequest, authManagerInMessageChanSize),
@@ -180,6 +191,7 @@ func NewAuthManager(conf AuthManagerConfig) *MenderAuthManager {
 			keyStore:       conf.KeyStore,
 			idSrc:          conf.IdentitySource,
 			tenantToken:    client.AuthToken(conf.TenantToken),
+			serverURL:      serverURL,
 		},
 	}
 

--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -378,7 +378,7 @@ func TestMenderAuthorize(t *testing.T) {
 		AuthManagerDBusPath,
 		AuthManagerDBusInterfaceName,
 		AuthManagerDBusSignalJwtTokenStateChange,
-		mock.AnythingOfType("string"),
+		mock.AnythingOfType("dbus.TokenAndServerURL"),
 	).Return(nil)
 
 	dbusAPI.On("MainLoopQuit", dbusLoop)

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -59,6 +59,12 @@ type DBusAPI interface {
 // MethodCallCallback represents a method_call callback
 type MethodCallCallback = func(objectPath string, interfaceName string, methodName string) (interface{}, error)
 
+// TokenAndServerURL stores values for the JWT token and the server URL
+type TokenAndServerURL struct {
+	Token     string
+	ServerURL string
+}
+
 // GetDBusAPI returns the global DBusAPI object
 func GetDBusAPI() (DBusAPI, error) {
 	if dbusAPI != nil {

--- a/dbus/dbus_libgio.go
+++ b/dbus/dbus_libgio.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -30,6 +30,11 @@ import (
 
 type dbusAPILibGio struct {
 	MethodCallCallbacks map[string]MethodCallCallback
+}
+
+type TokenAndServerURL struct {
+	Token     string
+	ServerURL string
 }
 
 // GenerateGUID generates a D-Bus GUID that can be used with e.g. g_dbus_connection_new().
@@ -185,7 +190,13 @@ func (d *dbusAPILibGio) EmitSignal(conn Handle, destinationBusName string, objec
 }
 
 func interfaceToGVariant(result interface{}) *C.GVariant {
-	if v, ok := result.(string); ok {
+	if v, ok := result.(TokenAndServerURL); ok {
+		strToken := C.CString(v.Token)
+		strServerURL := C.CString(v.ServerURL)
+		defer C.free(unsafe.Pointer(strToken))
+		defer C.free(unsafe.Pointer(strServerURL))
+		return C.g_variant_new_from_two_strings((*C.gchar)(strToken), (*C.gchar)(strServerURL))
+	} else if v, ok := result.(string); ok {
 		str := C.CString(v)
 		defer C.free(unsafe.Pointer(str))
 		return C.g_variant_new_from_string((*C.gchar)(str))

--- a/dbus/dbus_libgio.go
+++ b/dbus/dbus_libgio.go
@@ -32,11 +32,6 @@ type dbusAPILibGio struct {
 	MethodCallCallbacks map[string]MethodCallCallback
 }
 
-type TokenAndServerURL struct {
-	Token     string
-	ServerURL string
-}
-
 // GenerateGUID generates a D-Bus GUID that can be used with e.g. g_dbus_connection_new().
 // https://developer.gnome.org/gio/stable/gio-D-Bus-Utilities.html#g-dbus-generate-guid
 func (d *dbusAPILibGio) GenerateGUID() string {

--- a/dbus/dbus_libgio.go.h
+++ b/dbus/dbus_libgio.go.h
@@ -20,6 +20,12 @@ static GVariant *g_variant_new_from_string(gchar *value)
     return g_variant_new("(s)", value);
 }
 
+// create a new GVariant from two string values
+static GVariant *g_variant_new_from_two_strings(gchar *value1, gchar *value2)
+{
+    return g_variant_new("(ss)", value1, value2);
+}
+
 // create a new GVariant from a boolean valule
 static GVariant *g_variant_new_from_boolean(gboolean value)
 {


### PR DESCRIPTION
We extend the D-Bus API (GetJwtToken, JwtTokenStateChange) to return a
gvariant containing two strings: the first string contains the JWT
token, the second one the URL of the server.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>