### PR TITLE
Improvements to Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,15 @@ test:
     paths:
       - unit-coverage.tar
 
+test:docker:
+  image: docker
+  needs: []
+  services:
+    - docker:19.03.5-dind
+  stage: test
+  script:
+    - ./tests/build-docker
+
 publish:tests:
   stage: publish
   image: golang:1.14-alpine3.11

--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -1,7 +1,8 @@
 # Creates a container which acts as a bare bones non-VM based Mender
 # installation, for use in tests.
-FROM ubuntu:18.04 AS build
+FROM ubuntu:20.04 AS build
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y make git build-essential golang liblzma-dev jq libssl-dev libglib2.0-dev
 
 COPY ./ /go/src/github.com/mendersoftware/mender/

--- a/tests/build-docker
+++ b/tests/build-docker
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 docker build -f "$(dirname "$0")"/Dockerfile.daemon "$@" "$(dirname "$0")"/..


### PR DESCRIPTION
* [Dockerfile.daemon] Update build image to Ubuntu 20.04
So that we have golang 1.13
Note that we keep the final image on Ubuntu 18.04 to avoid a very
strange issue with `COPY --from build` which seems to make /
non accessible. We'll follow up independently.


* [pipeline] Add smoke test to build Docker image
So that we can catch regressions faster.

* [tests/build-docker] Require sh instead of bash