### PR TITLE
2.5.x: MEN-4398: Remove SSL warnings on empty HttpsClient config

### DIFF
--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -179,7 +179,6 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 
 	fakeClientConfig := client.Config{
 		ServerCert: "server.crt",
-		IsHttps:    true,
 		NoVerify:   false,
 	}
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -816,14 +816,6 @@ func (opts *setupOptionsType) saveConfigOptions(
 		{
 			ServerURL: opts.serverURL},
 	}
-	// Extract schema to set ClientProtocol
-	re, err := regexp.Compile(validURLRegularExpression)
-	if err != nil {
-		return errors.Wrap(err, "Unable to compile regular expression")
-	}
-	serverURL := opts.serverURL
-	schema := re.ReplaceAllString(serverURL, "$1")
-	config.ClientProtocol = schema
 
 	// Avoid possibility of conflicting ServerURL from an old config
 	config.ServerURL = ""
@@ -831,7 +823,7 @@ func (opts *setupOptionsType) saveConfigOptions(
 	if err := conf.SaveConfigFile(config, opts.configPath); err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(config.DeviceTypeFile,
+	err := ioutil.WriteFile(config.DeviceTypeFile,
 		[]byte("device_type="+opts.deviceType), 0644)
 	if err != nil {
 		return errors.Wrap(err, "Error writing to devicefile.")

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -561,7 +561,6 @@ func (h *HttpsClient) Validate() {
 }
 
 type Config struct {
-	IsHttps    bool
 	ServerCert string
 	*HttpsClient
 	NoVerify bool

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ func TestClientAuth(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -126,7 +126,7 @@ func TestClientAuthExpiredCert(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.expired.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.expired.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestClientAuthUnknownAuthorityCert(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.unknown-authority.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.unknown-authority.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestClientAuthDepthZeroSelfSignedCert(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.zero.depth.self.signed.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.zero.depth.self.signed.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -213,7 +213,7 @@ func TestClientAuthEndEntityKeyTooSmall(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -238,7 +238,7 @@ func TestClientAuthNoCert(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.non-existing.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.non-existing.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -251,7 +251,7 @@ func TestClientAuthHostValidationNocheck(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -275,7 +275,7 @@ func TestClientAuthHostValidationError(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.unknown-authority.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.unknown-authority.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -305,7 +305,7 @@ func TestClientAuthNotValidCertificate(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.ca.key.too.small.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.ca.key.too.small.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_inventory_test.go
+++ b/client/client_inventory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func TestInventoryClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestInventoryFallbackToPatch(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_log_test.go
+++ b/client/client_log_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func TestLogUploadClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_status_test.go
+++ b/client/client_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func TestStatusClient(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ func dummy_srvMngmntFunc(url string) func() *MenderServer {
 
 func TestHttpClient(t *testing.T) {
 	cl, _ := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, cl)
 
@@ -63,7 +63,7 @@ func TestHttpClient(t *testing.T) {
 
 	// missing cert in config should still yield usable client
 	cl, err := NewApiClient(
-		Config{ServerCert: "testdata/missing.crt", IsHttps: true},
+		Config{ServerCert: "testdata/missing.crt"},
 	)
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestHttpClient(t *testing.T) {
 
 func TestApiClientRequest(t *testing.T) {
 	cl, _ := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, cl)
 
@@ -157,7 +157,7 @@ func TestClientConnectionTimeout(t *testing.T) {
 	}()
 
 	cl, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, cl)
 	assert.NoError(t, err)
@@ -201,7 +201,6 @@ func TestLoadingTrust(t *testing.T) {
 		assert.NoError(t, err)
 
 		ctx, err = loadServerTrust(ctx, &Config{
-			IsHttps:     true,
 			ServerCert:  "missing.crt",
 			HttpsClient: nil,
 			NoVerify:    false,
@@ -209,7 +208,6 @@ func TestLoadingTrust(t *testing.T) {
 		assert.Error(t, err)
 
 		ctx, err = loadServerTrust(ctx, &Config{
-			IsHttps:     true,
 			ServerCert:  "testdata/server.crt",
 			HttpsClient: nil,
 			NoVerify:    false,
@@ -400,7 +398,7 @@ func TestUnMarshalErrorMessage(t *testing.T) {
 // In addition it also covers the case with a 'nil' ServerManagementFunc.
 func TestFailoverAPICall(t *testing.T) {
 	cl, _ := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, cl)
 

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -185,7 +185,7 @@ func Test_GetScheduledUpdate_errorParsingResponse_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "test/server.crt", IsHttps: true, NoVerify: false},
+		Config{ServerCert: "test/server.crt", NoVerify: false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -213,7 +213,7 @@ func Test_GetScheduledUpdate_responseMissingParameters_UpdateFailing(t *testing.
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -240,7 +240,7 @@ func Test_GetScheduledUpdate_ParsingResponseOK_updateSuccess(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -269,7 +269,7 @@ func Test_FetchUpdate_noContent_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "server.crt", IsHttps: true, NoVerify: false},
+		Config{ServerCert: "server.crt", NoVerify: false},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -295,7 +295,7 @@ func Test_FetchUpdate_invalidRequest_UpdateFailing(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -321,7 +321,7 @@ func Test_FetchUpdate_correctContent_UpdateFetched(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := NewApiClient(
-		Config{ServerCert: "testdata/server.crt", IsHttps: true},
+		Config{ServerCert: "testdata/server.crt"},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
@@ -455,7 +455,7 @@ func TestGetUpdateInfo(t *testing.T) {
 		defer ts.Close()
 
 		ac, err := NewApiClient(
-			Config{ServerCert: "testdata/server.crt", IsHttps: true},
+			Config{ServerCert: "testdata/server.crt"},
 		)
 		assert.NotNil(t, ac)
 		assert.NoError(t, err)

--- a/conf/config.go
+++ b/conf/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import (
 )
 
 type MenderConfigFromFile struct {
-	// ClientProtocol "https"
-	ClientProtocol string
 	// Path to the public key used to verify signed updates
 	ArtifactVerifyKey string
 	// HTTPS client parameters
@@ -255,7 +253,6 @@ func maybeHTTPSClient(c *MenderConfig) *client.HttpsClient {
 func (c *MenderConfig) GetHttpConfig() client.Config {
 	return client.Config{
 		ServerCert: c.ServerCertificate,
-		IsHttps:    c.ClientProtocol == "https",
 		// The HttpsClient config is only loaded when both a cert and
 		// key is given
 		HttpsClient: maybeHTTPSClient(c),

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import (
 )
 
 var testConfig = `{
-  "ClientProtocol": "https",
   "HttpsClient": {
     "Certificate": "/data/client.crt",
     "Key": "/data/client.key"
@@ -42,7 +41,6 @@ var testConfig = `{
 }`
 
 var testBrokenConfig = `{
-  "ClientProtocol": "https",
   "HttpsClient": {
     "Certificate": "/data/client.crt",
     "Key": "/data/client.key"
@@ -103,7 +101,6 @@ func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
 func validateConfiguration(t *testing.T, actual *MenderConfig) {
 	expectedConfig := NewMenderConfig()
 	expectedConfig.MenderConfigFromFile = MenderConfigFromFile{
-		ClientProtocol:            "https",
 		RootfsPartA:               "/dev/mmcblk0p2",
 		RootfsPartB:               "/dev/mmcblk0p3",
 		UpdatePollIntervalSeconds: 10,

--- a/statescript/statescript_test.go
+++ b/statescript/statescript_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -373,7 +373,7 @@ func TestReportScriptStatus(t *testing.T) {
 	defer ts.Close()
 
 	ac, err := client.NewApiClient(
-		client.Config{ServerCert: "", IsHttps: false, NoVerify: true},
+		client.Config{ServerCert: "", NoVerify: true},
 	)
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)

--- a/tests/mender-default-test.conf
+++ b/tests/mender-default-test.conf
@@ -1,5 +1,4 @@
 {
-  "ClientProtocol": "https",
   "HttpsClient": {
     "Certificate": "",
     "Key": ""


### PR DESCRIPTION
Cherry-picking #714.