### PR TITLE
MEN-4518: Always send inventory after a successful deployment

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -1289,6 +1289,9 @@ func (s *updateCleanupState) Handle(ctx *StateContext, c Controller) (State, boo
 	if lastError != nil {
 		s.status = client.StatusFailure
 	}
+
+	// Zero-time forces an inventory update on next wait
+	ctx.lastInventoryUpdateAttempt = time.Time{}
 
 	// Cleanup is done, report outcome.
 	return NewUpdateStatusReportState(s.Update(), s.status), false


### PR DESCRIPTION
Previously a reboot was needed in order to force-resend the inventory. This was
never discovered, as the client up until quite recently has almost always
rebooted.

The fix is dead simple, reset the in-memory storage of the last
inventory-update, which is equivalent to a reboot.

Changelog: Send the inventory after a successful deployment, even though the
device has not rebooted.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
