### PR TITLE
[Cherry 2.3.x] MEN-4518: Always send inventory after a successful deployment

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -1307,6 +1307,9 @@ func (s *updateCleanupState) Handle(ctx *StateContext, c Controller) (State, boo
 	if lastError != nil {
 		s.status = client.StatusFailure
 	}
+
+	// Zero-time forces an inventory update on next wait
+	ctx.lastInventoryUpdateAttempt = time.Time{}
 
 	// Cleanup is done, report outcome.
 	return NewUpdateStatusReportState(s.Update(), s.status), false


### PR DESCRIPTION
Previously a reboot was needed in order to force-resend the inventory. This was
never discovered, as the client up until quite recently has almost always
rebooted.

The fix is dead simple, reset the in-memory storage of the last
inventory-update, which is equivalent to a reboot.

Changelog: Send the inventory after a successful deployment, even though the
device has not rebooted.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit de4aa783dc3bb6cfe82448a195b40514d4c8e32a)


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](../CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
