### PR TITLE
MEN-4179: fix, support white spaces in single-file artifacts' names

### DIFF
--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -168,12 +168,12 @@ fi
 mender-artifact write module-image \
   -T single-file \
   $device_types \
-  -o $output_path \
-  -n $artifact_name \
-  -f $dest_dir_file \
-  -f $filename_file \
-  -f $permissions_file \
-  -f $file \
+  -o "$output_path" \
+  -n "$artifact_name" \
+  -f "$dest_dir_file" \
+  -f "$filename_file" \
+  -f "$permissions_file" \
+  -f "$file" \
   $passthrough_args
 
 rm $dest_dir_file


### PR DESCRIPTION
Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit 80af399cb7c967a8a9c5fb4388ba77f4437fc461)

