### PR TITLE
Fix: typo in installDemoCertificateLocalTrust

### DIFF
--- a/cli/setup.go
+++ b/cli/setup.go
@@ -927,7 +927,7 @@ func (opts *setupOptionsType) installDemoCertificateLocalTrust() error {
 	}
 	defer s.Close()
 
-	dir := filepath.Base(localTrustMenderCertPath)
+	dir := filepath.Dir(localTrustMenderCertPath)
 	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
 		err := os.MkdirAll(dir, 0755)


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit ecc22acdd6342b3896da90c43a24712aa8fe8d0f)
