### PR TITLE
MEN-4580: Split demo certificate into singular pieces.

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -17,9 +17,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"sort"
 	"strings"
 	"syscall"
@@ -31,7 +33,6 @@ import (
 	dev "github.com/mendersoftware/mender/device"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/store"
-	sha256 "github.com/minio/sha256-simd"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
@@ -262,45 +263,18 @@ func initDaemon(config *conf.MenderConfig,
 }
 
 func checkDemoCert() {
-	localTrustMenderCertPath := getLocalTrustMenderCertPath()
-	menderDemoCertPath := getMenderDemoCertPath()
-
-	trustStoreCert, err := os.Open(localTrustMenderCertPath)
+	entries, err := ioutil.ReadDir(DefaultLocalTrustMenderDir)
 	if err != nil {
-		log.Debugf("Could not open Mender certificate in local trust store: %s", err.Error())
+		log.Debugf("Could not open local Mender trust store directory: %s", err.Error())
 		return
 	}
-	defer trustStoreCert.Close()
 
-	demoCert, err := os.Open(menderDemoCertPath)
-	if err != nil {
-		log.Debugf("Could not open demo certificate in examples folder: %s", err.Error())
-		return
-	}
-	defer demoCert.Close()
-
-	var trustStoreSum, demoSum []byte
-	hasher := sha256.New()
-
-	_, err = io.Copy(hasher, trustStoreCert)
-	if err != nil {
-		log.Errorf("Could not obtain checksum of %s: %s", localTrustMenderCertPath, err.Error())
-		return
-	}
-	trustStoreSum = hasher.Sum(trustStoreSum)
-
-	hasher.Reset()
-	_, err = io.Copy(hasher, demoCert)
-	if err != nil {
-		log.Errorf("Could not obtain checksum of %s: %s", menderDemoCertPath, err.Error())
-		return
-	}
-	demoSum = hasher.Sum(demoSum)
-
-	if bytes.Equal(trustStoreSum, demoSum) {
-		log.Warnf("Running with demo certificate installed in trust store. This is INSECURE! "+
-			"Please remove %s if you plan to use this device in production.",
-			localTrustMenderCertPath)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), DefaultLocalTrustMenderPrefix) {
+			log.Warnf("Running with demo certificate installed in trust store. This is INSECURE! "+
+				"Please remove %s if you plan to use this device in production.",
+				path.Join(DefaultLocalTrustMenderDir, entry.Name()))
+		}
 	}
 }
 


### PR DESCRIPTION
This is required for programs that look up certificates by their hash,
such as curl. Concatenated certificates are not supported when
creating hashed symlinks and are simply ignored by
`update-ca-certificates`.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
