### PR TITLE
Fix infinite carriage return output when running in ADB shell

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -558,7 +558,7 @@ func upgradeHelpPrinter(defaultPrinter func(w io.Writer, templ string, data inte
 		var buf bytes.Buffer
 		defaultPrinter(&buf, templ, data)
 		terminalWidth, _, err := terminal.GetSize(int(os.Stdout.Fd()))
-		if err != nil {
+		if err != nil || terminalWidth <= 0 {
 			// Just write help as is.
 			stdout.Write(buf.Bytes())
 			return


### PR DESCRIPTION
Seems that getting the terminal width when running in an ADB shell returns 0, not an error.
This results in an infinite loop of outputting carriage returns when any help output is displayed.
Added test for positive terminal width, else falling back to normal output.

Changelog: Title

Signed-off-by: Grant Sloman <gs@violet-ultra.co.uk>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
