### PR TITLE
MEN-4547: Implement the UpdateControlMap expiration logic

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -247,6 +247,9 @@ func (i *idleState) Handle(ctx *StateContext, c Controller) (State, bool) {
 	// cleanup state-data if any data is still present after an update
 	RemoveStateData(ctx.Store)
 
+	// Remove the expired UpdateControlMaps from the expired pool
+	UpdateManagerMapPool.ClearExpired()
+
 	// check if client is authorized
 	if c.IsAuthorized() {
 		return States.CheckWait, false


### PR DESCRIPTION
Read the ticket: https://tracker.mender.io/browse/MEN-4547 *thoroughly*

Some points which is explicitly written, but from reading this and the other ticket's I don't fully understand why is needed are the complete separation of the expired maps, and the once still valid. Like why can they not simply be triggered by a boolean?

This would also help with this point:
* The expired pool must have the same primary keys and thread safety as the regular pool. 

* When UpdateControlMapExpirationTimeSeconds elapses without an update, the map is considered expired, and the map must be moved to a separate pool of expired maps.

This essentially requires monitoring of the maps in a separate goroutine, if they are required to _at all time_ be correct.
The way I've done it now is to simply check expiration on the `_Get_` call, which means it will (as far as I can tell), behave correctly (this is the only way to extract a map from either pool), but I will need some consensus here I think :)