### PR TITLE
MEN-4074: Setup signal handler earlier to avoid unhandled SIGUSR1/2.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"runtime"
 	"strings"
@@ -137,6 +138,8 @@ func TestRunDaemon(t *testing.T) {
 			ForceToState: make(chan app.State, 1),
 		}
 		go func() {
+			SignalHandlerChan = make(chan os.Signal, 2)
+			signal.Notify(SignalHandlerChan, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM)
 			err := runDaemon(td)
 			require.Nil(t, err, "Daemon returned with an error code")
 		}()

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -66,6 +66,8 @@ var (
 	ErrSIGTERM           = errors.New("Daemon terminated with SIGTERM")
 )
 
+var SignalHandlerChan = make(chan os.Signal, 2)
+
 func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.MenderPieces, error) {
 
 	tentok := config.GetTenantToken()
@@ -309,14 +311,10 @@ func runDaemon(d *app.MenderDaemon) error {
 	// Handle user forcing update check.
 	daemonExit := make(chan error)
 	go func() {
-		c := make(chan os.Signal, 2)
-		signal.Notify(c, syscall.SIGUSR1) // SIGUSR1 forces an update check.
-		signal.Notify(c, syscall.SIGUSR2) // SIGUSR2 forces an inventory update.
-		signal.Notify(c, syscall.SIGTERM) // SIGTERM marks the exit.
-		defer signal.Stop(c)
+		defer signal.Stop(SignalHandlerChan)
 
 		for {
-			s := <-c // Block until a signal is received.
+			s := <-SignalHandlerChan // Block until a signal is received.
 			if s == syscall.SIGUSR1 {
 				log.Debug("SIGUSR1 signal received.")
 				d.ForceToState <- app.States.UpdateCheck

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -16,12 +16,21 @@ package main
 
 import (
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/cli"
 	"github.com/mendersoftware/mender/installer"
 	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	// SIGUSR1 forces an update check.
+	// SIGUSR2 forces an inventory update.
+	// SIGTERM marks the exit.
+	signal.Notify(cli.SignalHandlerChan, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM)
+}
 
 func doMain() int {
 	if err := cli.SetupCLI(os.Args); err != nil {


### PR DESCRIPTION
Changelog: The daemon will no longer crash if mender check-update or send-inventory is used before the daemon has finished its set up.

Signed-off-by: Nils Olav Kvelvane Johansen <nils.olav@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
