### PR TITLE
MEN-4703: Fix D-Bus timeout on errors by finishing handling

### DIFF
--- a/dbus/dbus_libgio.go.h
+++ b/dbus/dbus_libgio.go.h
@@ -49,6 +49,13 @@ static void handle_method_call(
     {
         g_dbus_method_invocation_return_value(invocation, response);
     }
+    else
+    {
+        g_dbus_method_invocation_return_dbus_error(
+            invocation,
+            "io.mender.Failed",
+            "Method returned error, see Mender logs for more details");
+    }
 }
 
 // handle get property events on registered objects


### PR DESCRIPTION
On errors, Mender client was not finishing the handling of the D-Bus
method call, resulting in a timeout in the bus.

This is extremely unlikely to happen with currently released interface
(Authentication1), but likely to happen in future interfaces.

Changelog: Title