### PR TITLE
MEN-4669: Device_type_file is now consistent with -d flag & mender.conf

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -421,6 +421,23 @@ func (runOptions *runOptionsType) commonCLIHandler(
 		return nil, nil, err
 	}
 
+	// Make sure that paths that are not configurable via the config file is conconsistent with --data flag
+	config.ArtifactScriptsPath = path.Join(runOptions.dataStore, "scripts")
+	config.ModulesWorkPath = path.Join(runOptions.dataStore, "modules", "v3")
+
+	// Checks if the DeviceTypeFile is defined in config file.
+	if config.MenderConfigFromFile.DeviceTypeFile != "" {
+		// Sets the config.DeviceTypeFile to the value in config file.
+		config.DeviceTypeFile = config.MenderConfigFromFile.DeviceTypeFile
+
+	} else {
+		// If --data flag is not used then dataStore is /var/lib/mender
+		config.MenderConfigFromFile.DeviceTypeFile = path.Join(
+			runOptions.dataStore, "device_type")
+		config.DeviceTypeFile = path.Join(
+			runOptions.dataStore, "device_type")
+	}
+
 	// Skip verify for setup, as the configuration will be overridden
 	if ctx.Command.Name != "setup" {
 		err := config.Validate()
@@ -488,10 +505,6 @@ func (runOptions *runOptionsType) handleCLIOptions(ctx *cli.Context) error {
 		if err = checkWritePermissions(runOptions.dataStore); err != nil {
 			return err
 		}
-		// Make sure that device_type file is consistent
-		// with flag options.
-		config.MenderConfigFromFile.DeviceTypeFile = path.Join(
-			runOptions.dataStore, "device_type")
 		// Run cli setup prompts.
 
 		if err := doSetup(ctx, &config.MenderConfigFromFile,

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -824,7 +824,7 @@ func (opts *setupOptionsType) saveConfigOptions(
 	// Make sure devicetypefile and serverURL is set
 	if config.DeviceTypeFile == "" {
 		// Default devicetype file as defined in device.go
-		config.DeviceTypeFile = conf.DefaultDeviceTypeFile
+		config.DeviceTypeFile = path.Join(conf.GetStateDirPath(), "device_type")
 	}
 	config.Servers = []client.MenderServer{
 		{

--- a/conf/config.go
+++ b/conf/config.go
@@ -95,14 +95,12 @@ type DBusConfig struct {
 
 func NewMenderConfig() *MenderConfig {
 	return &MenderConfig{
-		MenderConfigFromFile: MenderConfigFromFile{
-			DeviceTypeFile: DefaultDeviceTypeFile,
-		},
-		ModulesPath:         DefaultModulesPath,
-		ModulesWorkPath:     DefaultModulesWorkPath,
-		ArtifactInfoFile:    DefaultArtifactInfoFile,
-		ArtifactScriptsPath: DefaultArtScriptsPath,
-		RootfsScriptsPath:   DefaultRootfsScriptsPath,
+		MenderConfigFromFile: MenderConfigFromFile{},
+		ModulesPath:          DefaultModulesPath,
+		ModulesWorkPath:      DefaultModulesWorkPath,
+		ArtifactInfoFile:     DefaultArtifactInfoFile,
+		ArtifactScriptsPath:  DefaultArtScriptsPath,
+		RootfsScriptsPath:    DefaultRootfsScriptsPath,
 	}
 }
 

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ var (
 var (
 	// device specific paths
 	DefaultArtifactInfoFile  = path.Join(GetConfDirPath(), "artifact_info")
-	DefaultDeviceTypeFile    = path.Join(GetStateDirPath(), "device_type")
 	DefaultArtScriptsPath    = path.Join(GetStateDirPath(), "scripts")
 	DefaultRootfsScriptsPath = path.Join(GetConfDirPath(), "scripts")
 	DefaultModulesPath       = path.Join(GetDataDirPath(), "modules", "v3")


### PR DESCRIPTION
Changelog: The location of the device type file is now determined by the mender.conf file. If the device type file is not used in mender.conf, the device type file is determined by the --data flag and if the flag is not used, the device type file is set to default. In addition, the scripts and modules directories location is consistent with the --data flag now.

Signed-off-by: Nils Olav Kvelvane Johansen <nils.olav@northern.tech>
(cherry picked from commit c775e759c3b556a2d09d7dcd0a3d30d4713ad574)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
