### PR TITLE
Fix Update Control Maps having no effect.

### DIFF
--- a/app/daemon_test.go
+++ b/app/daemon_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type FakeDevice struct {
@@ -168,25 +169,22 @@ func TestDaemon(t *testing.T) {
 		},
 	}
 
-	d := NewDaemon(mender, store, authManager, nil)
+	d, err := NewDaemon(&conf.MenderConfig{}, mender, store, authManager)
+	require.NoError(t, err)
 
-	err := d.Run()
+	err = d.Run()
 	assert.NoError(t, err)
 }
 
 func TestDaemonCleanup(t *testing.T) {
 	mstore := &store.MockStore{}
+	mstore.On("ReadAll", "update-control-maps").Return(nil, os.ErrNotExist)
 	mstore.On("Close").Return(nil)
-	d := NewDaemon(nil, mstore, nil, nil)
+	mender, err := NewMender(&conf.MenderConfig{}, MenderPieces{Store: mstore})
+	require.NoError(t, err)
+	d, err := NewDaemon(&conf.MenderConfig{}, mender, mstore, nil)
+	require.NoError(t, err)
 	d.Cleanup()
-	mstore.AssertExpectations(t)
-
-	mstore = &store.MockStore{}
-	mstore.On("Close").Return(errors.New("foo"))
-	assert.NotPanics(t, func() {
-		d := NewDaemon(nil, mstore, nil, nil)
-		d.Cleanup()
-	})
 	mstore.AssertExpectations(t)
 }
 
@@ -222,7 +220,8 @@ func TestDaemonRun(t *testing.T) {
 			},
 			0,
 		}
-		daemon := NewDaemon(dtc, store.NewMemStore(), nil, nil)
+		daemon, err := NewDaemon(&conf.MenderConfig{}, dtc, store.NewMemStore(), nil)
+		require.NoError(t, err)
 		dtc.state = States.Init
 		dtc.authorized = true
 
@@ -245,7 +244,8 @@ func TestDaemonRun(t *testing.T) {
 			},
 			0,
 		}
-		daemon := NewDaemon(dtc, store.NewMemStore(), nil, nil)
+		daemon, err := NewDaemon(&conf.MenderConfig{}, dtc, store.NewMemStore(), nil)
+		require.NoError(t, err)
 		dtc.authorized = true
 		daemon.StopDaemon()                                       // Stop after a single pass.
 		go func() { daemon.ForceToState <- States.UpdateCheck }() // Force updateCheck state.
@@ -262,7 +262,8 @@ func TestDaemonRun(t *testing.T) {
 			},
 			0,
 		}
-		daemon := NewDaemon(dtc, store.NewMemStore(), nil, nil)
+		daemon, err := NewDaemon(&conf.MenderConfig{}, dtc, store.NewMemStore(), nil)
+		require.NoError(t, err)
 		dtc.authorized = true
 		daemon.StopDaemon()                                           // Stop after a single pass.
 		go func() { daemon.ForceToState <- States.InventoryUpdate }() // Force inventoryUpdate state.

--- a/app/mender.go
+++ b/app/mender.go
@@ -120,10 +120,9 @@ type Mender struct {
 }
 
 type MenderPieces struct {
-	DualRootfsDevice     installer.DualRootfsDevice
-	Store                store.Store
-	AuthManager          AuthManager
-	UpdateControlManager *UpdateManager
+	DualRootfsDevice installer.DualRootfsDevice
+	Store            store.Store
+	AuthManager      AuthManager
 }
 
 func NewMender(config *conf.MenderConfig, pieces MenderPieces) (*Mender, error) {

--- a/app/mender.go
+++ b/app/mender.go
@@ -484,6 +484,7 @@ func spinEventLoop(c *ControlMapPool, to State, ctx *StateContext, controller Co
 				log.Debug("Pausing the event loop")
 				<-c.Updates
 			case "fail":
+				log.Debug("Failing due to Update Control Map")
 				next, _ := to.HandleError(ctx, controller,
 					NewTransientError(errors.New("Forced a failed update")))
 				return next

--- a/app/updatemanager.go
+++ b/app/updatemanager.go
@@ -367,6 +367,7 @@ func (c *ControlMapPool) SetStore(store store.Store) {
 }
 
 func (c *ControlMapPool) Insert(cm *UpdateControlMap) {
+	log.Debugf("Inserting Update Control Map: %v", cm)
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	nm := []*UpdateControlMap{}
@@ -414,6 +415,7 @@ func (c *ControlMapPool) Get(ID string) (active []*UpdateControlMap, expired []*
 }
 
 func (c *ControlMapPool) ClearExpired() {
+	log.Debug("Clearing expired Update Control Maps")
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	newPool := []*UpdateControlMap{}


### PR DESCRIPTION
The heart of the issue is that the control map pool was being created
twice, and then the state logic and the update logic were working on
different pools. To remedy this, move the initialization of pool into
NewDaemon, which is really where it belongs, since it cannot be used
in non-daemon mode [1]. This allows it to be created once and used
everywhere.

One of the unit tests which tests a nil argument is invalid after this
change, so just remove it.

[1] Actually the same thing can be said for the auth manager, but
    moving it has a lot more ripple effects which I don't want to deal
    with right now.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>