### PR TITLE
Fix: Sanitized maps are not updated in the control struct

### DIFF
--- a/app/updatemanager.go
+++ b/app/updatemanager.go
@@ -302,6 +302,7 @@ func (m UpdateControlMap) Sanitize() {
 	}
 	for stateKey, state := range m.States {
 		state.Sanitize()
+		m.States[stateKey] = state
 		if state == defaultState {
 			log.Debugf("Default state %q, removing", stateKey)
 			delete(m.States, stateKey)


### PR DESCRIPTION
This is due to the copy semantics of the Golang for loop.

Fix is real easy, just re-assign the state after modification.