### PR TITLE
Fix: Correctly log the error response message from server errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -621,8 +621,12 @@ func unmarshalErrorMessage(r io.Reader) string {
 	e := new(struct {
 		Error string `json:"error"`
 	})
-	if err := json.NewDecoder(r).Decode(e); err != nil {
-		return fmt.Sprintf("failed to parse server response: %v", err)
+	resp, err := ioutil.ReadAll(r)
+	if err != nil {
+		return fmt.Sprintf("Failed to read the response body %s", err)
+	}
+	if err = json.Unmarshal(resp, e); err != nil {
+		return string(resp)
 	}
 	return e.Error
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -587,4 +588,32 @@ func TestListSystemCertsFound(t *testing.T) {
 		test.assertFunc(t, err)
 		assert.Equal(t, test.certificatesExpected, sysCerts, name)
 	}
+}
+
+func TestErrorUnmarshaling(t *testing.T) {
+
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"Regular JSON": {
+			input: `{
+    "error": "foobar"
+}`,
+			expected: "foobar",
+		},
+		"Simply an error string": {
+			input:    "Error message from the server",
+			expected: "Error message from the server",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := unmarshalErrorMessage(strings.NewReader(test.input))
+			assert.Equal(t, test.expected, res)
+		})
+	}
+
 }


### PR DESCRIPTION
In some cases the server does not return JSON data, as is advertised in the API
upon errors. Instead it simply returns an error string.

Therefore, in the cases in which the error cannot be unmarshalled to JSON, fall
back to returning the response body as a string.

An example of the error can be seen here:

```
level=error msg="Error receiving scheduled update data: (request_id: ): Invalid response received from server server error message: failed to parse server response: json: cannot unmarshal object into Go struct field .error of type string"
```

The error stems from the migration to Traefic, which does some magic rewriting
of our error responses.

Changelog: Title
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

