### PR TITLE
Fix use-after-free issue when receiving signal.

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -490,10 +490,10 @@ func spinEventLoop(c *ControlMapPool, to State, ctx *StateContext, controller Co
 			return to
 		case "pause":
 			// wait until further notice
-			log.Debug("Pausing the event loop")
+			log.Infof("Update Control: Pausing before entering %s state", mapState)
 			<-c.Updates
 		case "fail":
-			log.Debug("Failing due to Update Control Map")
+			log.Infof("Update Control: Failing update at %s state", mapState)
 			next, _ := to.HandleError(ctx, controller,
 				NewTransientError(errors.New("Forced a failed update")))
 			return next

--- a/app/updatemanager.go
+++ b/app/updatemanager.go
@@ -568,6 +568,7 @@ func (c *ControlMapPool) QueryAndUpdate(state string) (action string) {
 	defer c.saveToStore()
 
 	maps := c.Pool
+	log.Debugf("Querying Update Control maps. Currently active maps: '%v'", maps)
 	sort.Slice(maps, func(i, j int) bool {
 		return maps[i].Priority > maps[j].Priority
 	})
@@ -593,10 +594,12 @@ func (c *ControlMapPool) QueryAndUpdate(state string) (action string) {
 		)
 		v := queryActionList(actions)
 		if v != "" {
+			log.Debugf("Returning action %q", v)
 			return v
 		}
 	}
 	// No valid values
+	log.Debug("Returning action \"continue\"")
 	return "continue"
 }
 

--- a/app/updatemanager.go
+++ b/app/updatemanager.go
@@ -265,10 +265,30 @@ func (s *UpdateControlMapState) Sanitize() {
 	}
 }
 
+func isUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range strings.ToLower(s) {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 func (m UpdateControlMap) Validate() error {
-	// ID is mandatory
-	if m.ID == "" {
-		return errors.New("ID cannot be empty")
+	// ID must be a UUID.
+	if !isUUID(m.ID) {
+		return errors.New("ID must be a UUID")
 	}
 
 	// Priority must be in range [-10,10]

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -64,7 +64,6 @@ var out io.Writer = os.Stdout
 
 var (
 	errArtifactNameEmpty = errors.New("The Artifact name is empty. Please set a valid name for the Artifact!")
-	ErrSIGTERM           = errors.New("Daemon terminated with SIGTERM")
 )
 
 func initDualRootfsDevice(config *conf.MenderConfig) installer.DualRootfsDevice {
@@ -333,7 +332,6 @@ func PrintProvides(device *dev.DeviceManager) error {
 
 func runDaemon(d *app.MenderDaemon) error {
 	// Handle user forcing update check.
-	daemonExit := make(chan error)
 	go func() {
 		defer signal.Stop(SignalHandlerChan)
 
@@ -345,17 +343,12 @@ func runDaemon(d *app.MenderDaemon) error {
 			} else if s == syscall.SIGUSR2 {
 				log.Debug("SIGUSR2 signal received.")
 				d.ForceToState <- app.States.InventoryUpdate
-			} else if s == syscall.SIGTERM {
-				daemonExit <- ErrSIGTERM
 			}
 			d.Sctx.WakeupChan <- true
 			log.Debug("Sent wake up!")
 		}
 	}()
-	go func() {
-		daemonExit <- d.Run()
-	}()
-	return <-daemonExit
+	return d.Run()
 }
 
 // sendSignalToProcess sends a SIGUSR{1,2} signal to the running mender daemon.

--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,7 +1,7 @@
-From 2304cc8bafca2b7de4f929795124c15e5120978f Mon Sep 17 00:00:00 2001
+From 5f96bfe20a16ffdb95153ff044ae13689b84c0c2 Mon Sep 17 00:00:00 2001
 From: Ole Petter <ole.orhagen@northern.tech>
 Date: Tue, 27 Apr 2021 16:46:19 +0200
-Subject: [PATCH] Instrument mender binary
+Subject: [PATCH 1/1] Instrument mender binary
 
 Changelog: None
 Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
@@ -11,7 +11,7 @@ Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
  2 files changed, 39 insertions(+), 13 deletions(-)
 
 diff --git a/main.go b/main.go
-index 98e138a..ecb5730 100644
+index d8dc29b..d76d52e 100644
 --- a/main.go
 +++ b/main.go
 @@ -18,6 +18,8 @@ import (
@@ -23,8 +23,8 @@ index 98e138a..ecb5730 100644
  
  	"github.com/mendersoftware/mender/app"
  	"github.com/mendersoftware/mender/cli"
-@@ -32,6 +34,21 @@ func init() {
- 	signal.Notify(cli.SignalHandlerChan, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM)
+@@ -35,6 +37,21 @@ func init() {
+ 	signal.Notify(termSignalChan, syscall.SIGTERM)
  }
  
 +// All this code is simply stolen from the
@@ -43,9 +43,9 @@ index 98e138a..ecb5730 100644
 +}
 +
  func doMain() int {
- 	if err := cli.SetupCLI(os.Args); err != nil {
- 		switch err {
-@@ -52,5 +69,25 @@ func doMain() int {
+ 	cliResultChan := make(chan error, 1)
+ 	go func() {
+@@ -66,5 +83,25 @@ func doMain() int {
  }
  
  func main() {
@@ -105,5 +105,5 @@ index a96d7d8..b4ceb1a 100644
  
  type Commander interface {
 -- 
-2.31.1
+2.17.1
 


### PR DESCRIPTION
When runDaemon() returns, the first thing that happens is that it
cleans up the resources used by the MenderDaemon structure. But if we
got a signal, we escaped runDaemon without finishing Run(), which
means this memory is still in use. This is worse than simply exiting,
because operations can be corrupted, as opposed to simply
truncated. There is no way to make this safe with the current design.

Therefore split the signal handling, so that SIGTERM is handled in
doMain, directly where we want to exit from. This means that runDaemon
can keep running without its data being destroyed.

An alternative would have been to simply call os.Exit() from the old
location, but it seemed better to keep the exit codes in one place.

Changelog: Fix occasional crash when exiting using SIGTERM.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
