### PR TITLE
Do not close stdout/stderr on child process execution by default.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"strings"
@@ -144,8 +143,8 @@ func SetupCLI(args []string) error {
 			Usage: "Force update check.",
 			Action: func(_ *cli.Context) error {
 				return sendSignalToProcess(
-					exec.Command("kill", "-USR1"),
-					exec.Command("systemctl",
+					system.Command("kill", "-USR1"),
+					system.Command("systemctl",
 						"show", "-p",
 						"MainPID", "mender-client"))
 			},
@@ -197,8 +196,8 @@ func SetupCLI(args []string) error {
 			Usage: "Force inventory update.",
 			Action: func(_ *cli.Context) error {
 				return sendSignalToProcess(
-					exec.Command("kill", "-USR2"),
-					exec.Command("systemctl",
+					system.Command("kill", "-USR2"),
+					system.Command("systemctl",
 						"show", "-p",
 						"MainPID", "mender-client"))
 			},

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path"
 	"runtime"
@@ -38,6 +37,7 @@ import (
 	dev "github.com/mendersoftware/mender/device"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/store"
+	"github.com/mendersoftware/mender/system"
 	stest "github.com/mendersoftware/mender/system/testing"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
@@ -482,19 +482,19 @@ func TestPrintProvides(t *testing.T) {
 
 func TestGetMenderDaemonPID(t *testing.T) {
 	tests := map[string]struct {
-		cmd      *exec.Cmd
+		cmd      *system.Cmd
 		expected string
 	}{
 		"error": {
-			exec.Command("abc"),
+			system.Command("abc"),
 			"getMenderDaemonPID: Failed to run systemctl",
 		},
 		"error: no output": {
-			exec.Command("printf", ""),
+			system.Command("printf", ""),
 			"could not find the PID of the mender daemon",
 		},
 		"return PID": {
-			exec.Command("echo", "MainPID=123"),
+			system.Command("echo", "MainPID=123"),
 			"123",
 		},
 	}
@@ -507,8 +507,8 @@ func TestGetMenderDaemonPID(t *testing.T) {
 			assert.Equal(t, test.expected, pid, name)
 		}
 	}
-	cmdKill := exec.Command("abc")
-	cmdPID := exec.Command("echo", "123")
+	cmdKill := system.Command("abc")
+	cmdPID := system.Command("echo", "123")
 	assert.Error(t, sendSignalToProcess(cmdKill, cmdPID))
 }
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path"
 	"sort"
@@ -33,6 +32,7 @@ import (
 	dev "github.com/mendersoftware/mender/device"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/store"
+	"github.com/mendersoftware/mender/system"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
@@ -182,7 +182,7 @@ func doBootstrapAuthorize(config *conf.MenderConfig, opts *runOptionsType) error
 	return nil
 }
 
-func getMenderDaemonPID(cmd *exec.Cmd) (string, error) {
+func getMenderDaemonPID(cmd *system.Cmd) (string, error) {
 	buf := bytes.NewBuffer(nil)
 	cmd.Stdout = buf
 	err := cmd.Run()
@@ -335,7 +335,7 @@ func runDaemon(d *app.MenderDaemon) error {
 }
 
 // sendSignalToProcess sends a SIGUSR{1,2} signal to the running mender daemon.
-func sendSignalToProcess(cmdKill, cmdGetPID *exec.Cmd) error {
+func sendSignalToProcess(cmdKill, cmdGetPID *system.Cmd) error {
 	pid, err := getMenderDaemonPID(cmdGetPID)
 	if err != nil {
 		return errors.Wrap(err, "failed to force updateCheck")

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -31,6 +30,7 @@ import (
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/device"
+	"github.com/mendersoftware/mender/system"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
@@ -968,7 +968,7 @@ func (opts *setupOptionsType) installDemoCertificateLocalTrust() error {
 		}
 	}
 
-	cmd := exec.Command("update-ca-certificates")
+	cmd := system.Command("update-ca-certificates")
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/mendersoftware/mender/system"
@@ -187,7 +186,7 @@ func (e *UBootEnv) writeEnvImpl(vars BootVars, separator string) error {
 	return nil
 }
 
-func getEnvironmentVariable(cmd *exec.Cmd) (BootVars, error) {
+func getEnvironmentVariable(cmd *system.Cmd) (BootVars, error) {
 	cmdReader, err := cmd.StdoutPipe()
 
 	if err != nil {

--- a/installer/modules.go
+++ b/installer/modules.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"strings"
@@ -30,6 +29,7 @@ import (
 
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -89,7 +89,7 @@ func (mod *ModuleInstaller) callModule(state string, capture bool) (string, erro
 	payloadPath := mod.payloadPath()
 
 	log.Debugf("Calling module: %s %s %s", mod.programPath, state, payloadPath)
-	cmd := exec.Command(mod.programPath, state, payloadPath)
+	cmd := system.Command(mod.programPath, state, payloadPath)
 	cmd.Dir = mod.payloadPath()
 
 	stdoutLogger := newReadLogger(capture)
@@ -360,7 +360,7 @@ type namedReader struct {
 
 type moduleDownload struct {
 	payloadPath string
-	proc        *exec.Cmd
+	proc        *system.Cmd
 
 	// Channel for supplying new payload files while the download loop is
 	// running
@@ -396,7 +396,7 @@ type moduleDownload struct {
 	////////////////////////////////////////////////////////////////////////
 }
 
-func newModuleDownload(payloadPath string, proc *exec.Cmd) *moduleDownload {
+func newModuleDownload(payloadPath string, proc *system.Cmd) *moduleDownload {
 	return &moduleDownload{
 		payloadPath:        payloadPath,
 		proc:               proc,
@@ -696,7 +696,7 @@ func (mod *ModuleInstaller) PrepareStoreUpdate() error {
 	payloadPath := mod.payloadPath()
 
 	log.Debugf("Calling module: %s Download %s", mod.programPath, payloadPath)
-	storeUpdateCmd := exec.Command(mod.programPath, "Download", payloadPath)
+	storeUpdateCmd := system.Command(mod.programPath, "Download", payloadPath)
 	storeUpdateCmd.Dir = mod.payloadPath()
 
 	stdoutLogger := newReadLogger(false)

--- a/installer/modules_test.go
+++ b/installer/modules_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"reflect"
 	"runtime"
@@ -30,6 +29,7 @@ import (
 	"time"
 
 	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -262,7 +262,7 @@ func moduleDownloadSetup(t *testing.T, tmpdir, helperArg string) (*moduleDownloa
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	cmd := exec.Command(path.Join(cwd, "modules_test_helper.sh"), helperArg)
+	cmd := system.Command(path.Join(cwd, "modules_test_helper.sh"), helperArg)
 	cmd.Dir = tmpdir
 	// Create new process group so we can kill them all instead of just the parent.
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/installer/partitions_test.go
+++ b/installer/partitions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -67,11 +66,11 @@ func Test_GetInactive_HaveActivePartitionSet_ReturnsInactive(t *testing.T) {
 
 type fakeStatCommander struct {
 	file os.FileInfo
-	cmd  *exec.Cmd
+	cmd  *system.Cmd
 	err  error
 }
 
-func (sc fakeStatCommander) Command(name string, arg ...string) *exec.Cmd {
+func (sc fakeStatCommander) Command(name string, arg ...string) *system.Cmd {
 	return sc.cmd
 }
 

--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,7 +1,7 @@
-From 2304cc8bafca2b7de4f929795124c15e5120978f Mon Sep 17 00:00:00 2001
+From d7b1e2e5cb0fd9f70fc3e5f83a3bc376fecb7bc8 Mon Sep 17 00:00:00 2001
 From: Ole Petter <ole.orhagen@northern.tech>
 Date: Tue, 27 Apr 2021 16:46:19 +0200
-Subject: [PATCH] Instrument mender binary
+Subject: [PATCH 1/1] Instrument mender binary
 
 Changelog: None
 Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
@@ -73,11 +73,11 @@ index 98e138a..ecb5730 100644
 +
  }
 diff --git a/system/system.go b/system/system.go
-index a96d7d8..b4ceb1a 100644
+index d5a5cbe..4e50567 100644
 --- a/system/system.go
 +++ b/system/system.go
-@@ -17,9 +17,7 @@ package system
- import (
+@@ -18,9 +18,7 @@ import (
+ 	"io"
  	"os"
  	"os/exec"
 -	"time"
@@ -86,7 +86,7 @@ index a96d7d8..b4ceb1a 100644
  )
  
  type SystemRebootCmd struct {
-@@ -33,16 +31,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
+@@ -34,16 +32,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
  }
  
  func (s *SystemRebootCmd) Reboot() error {
@@ -105,5 +105,5 @@ index a96d7d8..b4ceb1a 100644
  
  type Commander interface {
 -- 
-2.31.1
+2.17.1
 

--- a/statescript/executor.go
+++ b/statescript/executor.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/mendersoftware/mender/client"
+	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -203,7 +204,7 @@ func (l Launcher) get(state, action string) ([]os.FileInfo, string, error) {
 
 func execute(name string, timeout time.Duration) error {
 
-	cmd := exec.Command(name)
+	cmd := system.Command(name)
 
 	var stderr io.ReadCloser
 	var err error

--- a/system/testing/os_calls.go
+++ b/system/testing/os_calls.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -15,17 +15,18 @@ package testing
 
 import (
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"strconv"
+
+	"github.com/mendersoftware/mender/system"
 )
 
 // The test runner, which simulates output and return code.
 type TestOSCalls struct {
 	Output  string
 	RetCode int
-	*exec.Cmd
+	*system.Cmd
 	File os.FileInfo
 	Err  error
 }
@@ -42,7 +43,7 @@ func (sc *TestOSCalls) Stat(name string) (os.FileInfo, error) {
 	return sc.File, sc.Err
 }
 
-func (sc *TestOSCalls) Command(command string, args ...string) *exec.Cmd {
+func (sc *TestOSCalls) Command(command string, args ...string) *system.Cmd {
 	_, file, _, _ := runtime.Caller(0)
 
 	// Append helper process return code converted to string and return message
@@ -51,7 +52,7 @@ func (sc *TestOSCalls) Command(command string, args ...string) *exec.Cmd {
 	// Find script to call
 	script := path.Join(path.Dir(file), "os_calls_helper.sh")
 
-	cmd := exec.Command(script, subArgs...)
+	cmd := system.Command(script, subArgs...)
 
 	return cmd
 }


### PR DESCRIPTION
Golang has a somewhat unusual default in that it closes all output
file descriptors for child processes unless you keep them open
actively. Make this the default across the Mender client, since output
from various processes we call may be helpful when reading user logs.

We have to create our own type for this unfortunately, because the
existing exec.Cmd type does not tolerate Stdout and Stderr being
non-nil when calling functions that change them (like StdoutPipe()).

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
