### PR TITLE
Prevent conflicting mender services from running simultaneously.

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Mender OTA update service
 Wants=network-online.target
-After=systemd-resolved.service network-online.target
+After=systemd-resolved.service network-online.target mender.service
+Conflicts=mender.service
 
 [Service]
 Type=idle


### PR DESCRIPTION
Changelog: Fix: `mender-client.service` and the old `mender.service`
services can no longer run at the same time. If anyone has both, then
`mender.service` should be removed from the system.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
