### PR TITLE
MEN-4785: Add support for v2/deployments/next endpoint.

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -303,10 +303,9 @@ func (m *Mender) CheckUpdate() (*datastore.UpdateInfo, menderError) {
 			reauthorize(m)),
 		m.Config.Servers[0].ServerURL,
 		&client.CurrentUpdate{
-			Artifact:         currentArtifactName,
-			DeviceType:       deviceType,
-			Provides:         provides,
-			UpdateControlMap: true, // Always true for newer clients
+			Artifact:   currentArtifactName,
+			DeviceType: deviceType,
+			Provides:   provides,
 		})
 
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	apiPrefix = "/api/devices/v1/"
+	apiPrefix = "/api/devices/"
 
 	errMissingServerCertF = "IGNORING ERROR: The client server-certificate can not be " +
 		"loaded: (%s). The client will continue running, but may not be able to " +

--- a/client/client_auth.go
+++ b/client/client_auth.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ func (u *AuthClient) Request(api ApiRequester, server string, dataSrc AuthDataMe
 }
 
 func makeAuthRequest(server string, dataSrc AuthDataMessenger) (*http.Request, error) {
-	url := buildApiURL(server, "/authentication/auth_requests")
+	url := buildApiURL(server, "/v1/authentication/auth_requests")
 
 	req, err := dataSrc.MakeAuthRequest()
 	if err != nil {

--- a/client/client_inventory.go
+++ b/client/client_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ func doSubmitInventory(api ApiRequester, method, url string, data interface{}) (
 }
 
 func makeInventorySubmitRequest(method, server string, data interface{}) (*http.Request, error) {
-	url := buildApiURL(server, "/inventory/device/attributes")
+	url := buildApiURL(server, "/v1/inventory/device/attributes")
 
 	out := &bytes.Buffer{}
 	enc := json.NewEncoder(out)

--- a/client/client_inventory_test.go
+++ b/client/client_inventory_test.go
@@ -70,7 +70,7 @@ func TestInventoryClient(t *testing.T) {
 	assert.JSONEq(t,
 		`[{"name": "foo", "value": "bar"},{"name": "bar", "value": ["baz", "zen"]}]`,
 		string(responder.recdata))
-	assert.Equal(t, apiPrefix+"inventory/device/attributes", responder.path)
+	assert.Equal(t, apiPrefix+"v1/inventory/device/attributes", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Submit(ac, ts.URL, nil)

--- a/client/client_log.go
+++ b/client/client_log.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ func (u *LogUploadClient) Upload(api ApiRequester, url string, logs LogData) err
 }
 
 func makeLogUploadRequest(server string, logs *LogData) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/device/deployments/%s/log",
+	path := fmt.Sprintf("/v1/deployments/device/deployments/%s/log",
 		logs.DeploymentID)
 	url := buildApiURL(server, path)
 

--- a/client/client_log_test.go
+++ b/client/client_log_test.go
@@ -80,7 +80,7 @@ func TestLogUploadClient(t *testing.T) {
 	          "msg": "log bar"
 	      }
 	   ]}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/device/deployments/deployment1/log", responder.path)
+	assert.Equal(t, apiPrefix+"v1/deployments/device/deployments/deployment1/log", responder.path)
 
 	responder.httpStatus = 401
 	err = client.Upload(ac, ts.URL, LogData{

--- a/client/client_status.go
+++ b/client/client_status.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ func (u *StatusClient) Report(api ApiRequester, url string, report StatusReport)
 }
 
 func makeStatusReportRequest(server string, report StatusReport) (*http.Request, error) {
-	path := fmt.Sprintf("/deployments/device/deployments/%s/status",
+	path := fmt.Sprintf("/v1/deployments/device/deployments/%s/status",
 		report.DeploymentID)
 	url := buildApiURL(server, path)
 

--- a/client/client_status_test.go
+++ b/client/client_status_test.go
@@ -70,7 +70,7 @@ func TestStatusClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, responder.recdata)
 	assert.JSONEq(t, `{"status": "failure"}`, string(responder.recdata))
-	assert.Equal(t, apiPrefix+"deployments/device/deployments/deployment1/status", responder.path)
+	assert.Equal(t, apiPrefix+"v1/deployments/device/deployments/deployment1/status", responder.path)
 
 	responder.httpStatus = http.StatusUnauthorized
 	err = client.Report(ac, ts.URL, StatusReport{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -188,10 +188,10 @@ func TestHttpClientUrl(t *testing.T) {
 	u = buildURL("foo.bar")
 	assert.Equal(t, "https://foo.bar", u)
 
-	u = buildApiURL("foo.bar", "/zed")
+	u = buildApiURL("foo.bar", "/v1/zed")
 	assert.Equal(t, "https://foo.bar/api/devices/v1/zed", u)
 
-	u = buildApiURL("foo.bar", "zed")
+	u = buildApiURL("foo.bar", "/v1/zed")
 	assert.Equal(t, "https://foo.bar/api/devices/v1/zed", u)
 }
 


### PR DESCRIPTION
Changelog: The client now supports the HTTP Device API v2.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
