### PR TITLE
MEN-3360: Make state trans. counter ignore certain states.

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -607,15 +607,30 @@ func transitionState(to State, ctx *StateContext, c Controller) (State, bool) {
 	c.SetNextState(to)
 
 	// If this is an update state, store new state in database.
-	if us, ok := to.(UpdateState); ok {
+	if toUs, ok := to.(UpdateState); ok {
+		// If either the state we come from, or are going to, permits
+		// looping, then we don't increase the state counter which
+		// detects state loops.
+		permitLooping := toUs.PermitLooping()
+		fromUs, ok := from.(UpdateState)
+		if ok {
+			permitLooping = permitLooping || fromUs.PermitLooping()
+		} else {
+			// States that are not UpdateStates are assumed to allow
+			// looping, since they are outside the main update
+			// flow. Usually these relate to retry mechanisms, that
+			// have their own means of expiring.
+			permitLooping = true
+		}
+
 		err := datastore.StoreStateData(ctx.Store, datastore.StateData{
-			Name:       us.Id(),
-			UpdateInfo: *us.Update(),
-		})
+			Name:       toUs.Id(),
+			UpdateInfo: *toUs.Update(),
+		}, !permitLooping)
 		if err != nil {
 			log.Error("Could not write state data to persistent storage: ", err.Error())
-			state, cancelled := us.HandleError(ctx, c, NewFatalError(err))
-			return handleStateDataError(ctx, state, cancelled, us.Id(), us.Update(), err)
+			state, cancelled := toUs.HandleError(ctx, c, NewFatalError(err))
+			return handleStateDataError(ctx, state, cancelled, toUs.Id(), toUs.Update(), err)
 		}
 	}
 

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -1082,7 +1082,7 @@ func TestStateData(t *testing.T) {
 			ID: "foobar",
 		},
 	}
-	err := datastore.StoreStateData(ms, sd)
+	err := datastore.StoreStateData(ms, sd, true)
 	assert.NoError(t, err)
 	rsd, err := datastore.LoadStateData(ms)
 	assert.NoError(t, err)
@@ -1096,7 +1096,7 @@ func TestStateData(t *testing.T) {
 	assert.Contains(t, string(data), `"Name":"init"`)
 
 	sd.Version = 999
-	err = datastore.StoreStateData(ms, sd)
+	err = datastore.StoreStateData(ms, sd, true)
 	assert.NoError(t, err)
 	_, err = datastore.LoadStateData(ms)
 	assert.Error(t, err)
@@ -1138,7 +1138,7 @@ func TestStateReportError(t *testing.T) {
 	datastore.StoreStateData(ms, datastore.StateData{
 		Name:       datastore.MenderStateReportStatusError,
 		UpdateInfo: *update,
-	})
+	}, true)
 	// update failed and we failed to report that status to the server,
 	// state data should be removed and we should go back to init
 	res = NewReportErrorState(update, client.StatusFailure)
@@ -1154,7 +1154,7 @@ func TestStateReportError(t *testing.T) {
 	datastore.StoreStateData(ms, datastore.StateData{
 		Name:       datastore.MenderStateReportStatusError,
 		UpdateInfo: *update,
-	})
+	}, true)
 	// update is already installed and we failed to report that status to
 	// the server, state data should be removed and we should go back to
 	// init
@@ -4211,45 +4211,6 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 			&updateVerifyRollbackRebootState{},
 			&updateRollbackRebootState{},
 			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
-			&updateVerifyRollbackRebootState{},
-			&updateRollbackRebootState{},
 			// Truncated after maximum number of state transitions.
 			&updateStatusReportState{},
 			&idleState{},
@@ -4312,83 +4273,6 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 			"ArtifactRollbackReboot_Leave_00",
 			"ArtifactRollbackReboot_Enter_00",
 			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
-			"ArtifactRollbackReboot_Leave_00",
-			"ArtifactRollbackReboot_Enter_00",
-			"ArtifactRollbackReboot",
-			"ArtifactVerifyRollbackReboot",
 			"ArtifactRollbackReboot_Leave_00",
 			// Truncated after maximum number of state transitions.
 		},
@@ -4436,17 +4320,6 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 			&updateErrorState{},
 			&updateErrorState{},
 			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
-			&updateErrorState{},
 			// Truncated after maximum number of state transitions.
 			&updateStatusReportState{},
 			&idleState{},
@@ -4505,31 +4378,8 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 			"ArtifactFailure",
 			"ArtifactFailure_Enter_00",
 			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
-			"ArtifactFailure_Enter_00",
-			"ArtifactFailure",
 			// Truncated after maximum number of state transitions.
+			"ArtifactFailure_Leave_00",
 		},
 		reportsLog: []string{
 			"downloading",
@@ -5032,7 +4882,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, datastore.StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd, true))
 	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
@@ -5056,7 +4906,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, datastore.StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd, true))
 	sd, err = datastore.LoadStateData(db)
 	require.NoError(t, err)
 
@@ -5081,7 +4931,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: true,
 		},
 	}
-	require.NoError(t, datastore.StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd, true))
 
 	// Check manually for both.
 	data, err := db.ReadAll(datastore.StateDataKeyUncommitted)
@@ -5124,7 +4974,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: true,
 		},
 	}
-	require.NoError(t, datastore.StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd, true))
 
 	data, err = db.ReadAll(datastore.StateDataKeyUncommitted)
 	require.NoError(t, err)
@@ -5164,7 +5014,7 @@ func TestDBSchemaUpdate(t *testing.T) {
 			HasDBSchemaUpdate: false,
 		},
 	}
-	require.NoError(t, datastore.StoreStateData(db, sd))
+	require.NoError(t, datastore.StoreStateData(db, sd, true))
 
 	_, err = db.ReadAll(datastore.StateDataKeyUncommitted)
 	assert.Error(t, err)
@@ -5222,4 +5072,120 @@ func TestAutomaticReboot(t *testing.T) {
 	logs, err := DeploymentLogger.GetLogs("abc")
 	require.NoError(t, err)
 	assert.Contains(t, string(logs), "exit status 99")
+}
+
+type loopingNotPermittedUpdateState struct {
+	updateState
+	// Sounds counter-intuitive to have loopCount in here, but we will use
+	// it to loop back to ourselves when it runs out, thereby looping
+	// "illegally" and trigger the state counter overflow, hence the struct
+	// name. While it's positive, we go to the loopingState instead, and
+	// this looping is allowed.
+	loopCount int
+	loopTo    State
+}
+type loopingPermittedUpdateState struct {
+	updateState
+	loopTo State
+}
+
+// Looping in the base state is permitted simply by power of not being an update
+// state.
+type loopingPermittedBaseState struct {
+	baseState
+	loopTo State
+}
+
+func (s *loopingNotPermittedUpdateState) Handle(ctx *StateContext, c Controller) (State, bool) {
+	s.loopCount--
+	if s.loopCount < 0 {
+		return s, false
+	} else {
+		return s.loopTo, false
+	}
+}
+
+func (s *loopingPermittedUpdateState) Handle(ctx *StateContext, c Controller) (State, bool) {
+	return s.loopTo, false
+}
+
+func (s *loopingPermittedUpdateState) PermitLooping() bool {
+	return true
+}
+
+func (s *loopingPermittedBaseState) Handle(ctx *StateContext, c Controller) (State, bool) {
+	return s.loopTo, false
+}
+
+const TestLoopingStatesCount = 500
+
+// Test that the state transitions work correctly for looping states, and do not
+// abruptly break out of loops.
+func TestLoopingStates(t *testing.T) {
+	// It should be possible to loop indefinitely when looping is permitted,
+	// but as soon as the states involved do not permit looping it should
+	// trigger a failure after a certain number of states.
+
+	// -------------- updateState ------------------
+	lpu := &loopingPermittedUpdateState{}
+	lnp := &loopingNotPermittedUpdateState{
+		loopCount: TestLoopingStatesCount,
+		loopTo:    lpu,
+	}
+	lpu.loopTo = lnp
+
+	ms := store.NewMemStore()
+	ctx := &StateContext{
+		Store: ms,
+	}
+	sc := &stateTestController{
+		state: lpu,
+	}
+
+	var count int
+	var currentState State = lpu
+	// Times two because we need to go through two states to increase the
+	// count in one of them.
+	transitionsExpected := TestLoopingStatesCount*2 + datastore.MaximumStateDataStoreCount + 2
+
+	for count = 0; count < transitionsExpected+50; count++ {
+		currentState, _ = transitionState(currentState, ctx, sc)
+		if currentState != lnp && currentState != lpu {
+			break
+		}
+	}
+	assert.Equal(t, transitionsExpected, count)
+	assert.NotEqual(t, currentState, lnp)
+	assert.NotEqual(t, currentState, lpu)
+
+	// -------------- baseState ------------------
+	lpb := &loopingPermittedBaseState{}
+	lnp = &loopingNotPermittedUpdateState{
+		loopCount: TestLoopingStatesCount,
+		loopTo:    lpb,
+	}
+	lpb.loopTo = lnp
+
+	ms = store.NewMemStore()
+	ctx = &StateContext{
+		Store: ms,
+	}
+	sc = &stateTestController{
+		state: lpb,
+	}
+
+	currentState = lpb
+	// Times two because we need to go through two states to increase the
+	// count in one of them.
+	transitionsExpected = TestLoopingStatesCount*2 + datastore.MaximumStateDataStoreCount + 2
+
+	for count = 0; count < transitionsExpected+50; count++ {
+		currentState, _ = transitionState(currentState, ctx, sc)
+		if currentState != lnp && currentState != lpb {
+			break
+		}
+	}
+	assert.Equal(t, transitionsExpected, count)
+	assert.NotEqual(t, currentState, lnp)
+	assert.NotEqual(t, currentState, lpb)
 }

--- a/app/transition_test.go
+++ b/app/transition_test.go
@@ -110,7 +110,7 @@ func TestTransitions(t *testing.T) {
 	require.Nil(t, datastore.StoreStateData(st, datastore.StateData{
 		Name:       datastore.MenderStateInit,
 		UpdateInfo: datastore.UpdateInfo{},
-	}))
+	}, true))
 
 	tc := []struct {
 		from        *testState


### PR DESCRIPTION
We divide the states into three groups: Update states which are not
allowed to loop, update states which are allowed to loop, and other
states (which are always allowed to loop). For update states
(`updateState`) we use the new `PermitLooping` interface to determine
whether it permits looping, for other states (`baseState`) it's enough
to know that they are not an `updateState`.

The motivation behind all this is to allow going back and forth
between states as long as at least one of them allows looping, which
will allow us to implement limitless state transitions during certain
operations in a deployment. This is important to support Update
Control, and may have other uses in the future as well (the ticket has
some useful links).

However, using the three groups of states, we *also* maintain the
ability to break out of loops between states that do *not* permit
looping, which typically is caused by update failures. Notice in
particular that reboots, due to calling `LoadStateData`, will always
increase the counter by at least one, even if the states involved do
permit looping.

This also reverts eb15ff94bf4ed57c, which increased the maximum number
of state transitions in order to deal with some states that can loop
for a limited time. In principle, the limit for these states could be
raised now, but it's not something I will handle in this commit.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
