### PR TITLE
MEN-4808: Deprecate single hyphen commands

### DIFF
--- a/Documentation/update-modules-v3-file-api.md
+++ b/Documentation/update-modules-v3-file-api.md
@@ -250,12 +250,12 @@ a data migration step that was done before or during the install.
 
 ### Command line invocation
 
-Calling the Mender client from the command line with the `-install` argument
+Calling the Mender client from the command line with the `install` command
 will only invoke the two first states, `Download` and
 `ArtifactInstall`. Additionally, `ArtifactFailure` may be executed if there is
 an error.
 
-Calling the Mender client from the command line with the `-commit` argument will
+Calling the Mender client from the command line with the `commit` command will
 only invoke the two last states, `ArtifactCommit` and `Cleanup`. Additionally,
 `ArtifactRollback` and `ArtifactFailure` may be executed if there is an error.
 

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ func doStandaloneInstallStates(art io.ReadCloser, key []byte,
 	}
 
 	if rollbackSupport {
-		fmt.Println("Use -commit to update, or -rollback to roll back the update.")
+		fmt.Println("Use 'commit' to update, or 'rollback' to roll back the update.")
 	} else {
 		fmt.Println("Artifact doesn't support rollback. Committing immediately.")
 		err = DoStandaloneCommit(device, stateExec)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -355,12 +355,6 @@ func SetupCLI(args []string) error {
 			Value:       "info",
 			Destination: &runOptions.logOptions.logLevel},
 		&cli.StringFlag{
-			Name:    "log-modules",
-			Aliases: []string{"m"},
-			Usage: "-log-modules is accepted for compatibility " +
-				"but has no effect",
-			Destination: &runOptions.logOptions.logModules},
-		&cli.StringFlag{
 			Name:        "trusted-certs",
 			Aliases:     []string{"E"},
 			Usage:       "Trusted server certificates `FILE` path.",

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -39,9 +39,6 @@ import (
 var (
 	deprecatedCommandArgs = [...]string{"-install", "-commit", "-rollback", "-daemon",
 		"-bootstrap", "-check-update", "-send-inventory", "-show-artifact"}
-	deprecatedFlagArgs = [...]string{"-version", "-config", "-fallback-config",
-		"-trusted-certs", "-forcebootstrap", "-skipverify", "-log-level",
-		"-log-modules", "-no-syslog", "-log-file"}
 	errDumpTerminal = errors.New("Refusing to write to terminal")
 )
 
@@ -79,7 +76,7 @@ func ShowVersion() string {
 		conf.VersionString(), runtime.Version())
 }
 
-func transformDeprecatedArgs(args []string) []string {
+func checkDeprecatedArgs(args []string) error {
 	argInSlice := func(arg string, slice []string) bool {
 		for _, s := range slice {
 			if arg == s {
@@ -90,32 +87,24 @@ func transformDeprecatedArgs(args []string) []string {
 	}
 	for i := 0; i < len(args); i++ {
 		if argInSlice(args[i], deprecatedCommandArgs[:]) {
-			// Remove hyphen
-			args[i] = args[i][1:]
-		} else if argInSlice(args[i], deprecatedFlagArgs[:]) {
-			// Prepend hyphen
-			args[i] = "-" + args[i]
-		} else if args[i] == "-info" {
-			// replace with log-level flags
-			args = append(args[:i],
-				append([]string{"--log-level", "info"},
-					args[i+1:]...)...)
-		} else if args[i] == "-debug" {
-			// replace with log-level flags
-			args = append(args[:i],
-				append([]string{"--log-level", "debug"},
-					args[i+1:]...)...)
+			return errors.New(fmt.Sprintf("deprecated command %q, use %q instead", args[i], args[i][1:]))
+		}
+		if args[i] == "-info" || args[i] == "-debug" {
+			return errors.New(fmt.Sprintf("deprecated flag %q, use \"--log-level %s\" instead", args[i], args[i][1:]))
 		}
 	}
-	return args
+	return nil
 }
 
 func SetupCLI(args []string) error {
 	runOptions := &runOptionsType{}
 
-	// Filter commandline arguments for backwards compatibility.
-	// FIXME: Remove argument filtering in Mender v3.0
-	args = transformDeprecatedArgs(args)
+	// Detect and error on deprecated commands.
+	// FIXME: Remove in Mender v4.0
+	err := checkDeprecatedArgs(args)
+	if err != nil {
+		return err
+	}
 
 	app := &cli.App{
 		Before:      runOptions.handleLogFlags,
@@ -621,7 +610,7 @@ func (runOptions *runOptionsType) handleLogFlags(ctx *cli.Context) error {
 			"", "", syslog.LOG_DEBUG|syslog.LOG_USER, "mender", level)
 		if err != nil {
 			log.Warnf("Could not connect to syslog daemon: %s. "+
-				"(use -no-syslog to disable completely)",
+				"(use --no-syslog to disable completely)",
 				err.Error())
 		} else {
 			log.AddHook(hook)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -40,10 +40,9 @@ import (
 )
 
 type logOptionsType struct {
-	logLevel   string
-	logModules string
-	logFile    string
-	noSyslog   bool
+	logLevel string
+	logFile  string
+	noSyslog bool
 }
 
 type runOptionsType struct {

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -7,4 +7,4 @@ if [ -n "$TENANT_TOKEN" ]; then
 fi
 
 /etc/init.d/ssh start
-mender -daemon
+mender daemon


### PR DESCRIPTION
    On deprecated single hyphen commands, the CLI now prints and error and
    exits.
    
    Note: the previous code was also amending single hyphen flags with
    double hyphen syntax. However, closer inspection to urfave/cli package
    showed that both syntax are accepted for flags (for example --log-level
    and -log-level are both valid). Remove that part of the amending just
    for clarification (they were some flags not caught there too).
    
    Tests modified accordingly.
    
    And uses of flags modified also for double hyphen (both work, but we
    prefer this syntax).
    
    Changelog: CLI commands prefixed with hyphen are now deprecated, use
    instead directly the command name. For example `mender daemon`, `mender
    commit`, `mender show-artifact`, etc.

Additionally:

    MEN-4808: Remove deprecated flag --log-modules
    
    Which had no effect anymore.
    
    Changelog: Title