### PR TITLE
Make command output less ugly in the log.

### DIFF
--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,15 +1,3 @@
-From b563cf65e1c768bcab2c48440ea9a4da8118a9de Mon Sep 17 00:00:00 2001
-From: Ole Petter <ole.orhagen@northern.tech>
-Date: Tue, 27 Apr 2021 16:46:19 +0200
-Subject: [PATCH 1/1] Instrument mender binary
-
-Changelog: None
-Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
----
- main.go          | 39 ++++++++++++++++++++++++++++++++++++++-
- system/system.go | 13 +------------
- 2 files changed, 39 insertions(+), 13 deletions(-)
-
 diff --git a/main.go b/main.go
 index c16a2c1..a2dc924 100644
 --- a/main.go
@@ -73,20 +61,20 @@ index c16a2c1..a2dc924 100644
 +
  }
 diff --git a/system/system.go b/system/system.go
-index d5a5cbe..4e50567 100644
+index ac3046d..e3620bc 100644
 --- a/system/system.go
 +++ b/system/system.go
-@@ -18,9 +18,7 @@ import (
- 	"io"
+@@ -19,9 +19,7 @@ import (
  	"os"
  	"os/exec"
+ 	"strings"
 -	"time"
  
 -	"github.com/pkg/errors"
+ 	log "github.com/sirupsen/logrus"
  )
  
- type SystemRebootCmd struct {
-@@ -34,16 +32,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
+@@ -36,16 +34,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
  }
  
  func (s *SystemRebootCmd) Reboot() error {
@@ -104,6 +92,3 @@ index d5a5cbe..4e50567 100644
  }
  
  type Commander interface {
--- 
-2.17.1
-

--- a/system/system.go
+++ b/system/system.go
@@ -18,9 +18,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type SystemRebootCmd struct {
@@ -80,11 +82,27 @@ func (c *Cmd) StdoutPipe() (io.ReadCloser, error) {
 	return c.Cmd.StdoutPipe()
 }
 
+type cmdLogger struct {
+	cmdName string
+	stream  string
+}
+
+func (c *cmdLogger) Write(buf []byte) (int, error) {
+	lines := strings.Split(string(buf), "\n")
+	for _, line := range lines {
+		if len(line) > 0 {
+			log.Infof("Output (%s) from command %q: %s", c.stream, c.cmdName, line)
+		}
+	}
+
+	return len(buf), nil
+}
+
 func Command(name string, arg ...string) *Cmd {
 	var cmd Cmd
 	cmd.Cmd = exec.Command(name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = &cmdLogger{cmdName: name, stream: "stdout"}
+	cmd.Stderr = &cmdLogger{cmdName: name, stream: "stderr"}
 	return &cmd
 }
 


### PR DESCRIPTION
This is a followup to 26f2ccbd523932. After that commit, the output is
printed correctly, but completely without context, making it hard to
follow in logs. Since the primary purpose of having this output is
debugging, wrap it in a writer to prettify the output.

No changelog, since this is just augmenting the mentioned commit.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
