### PR TITLE
Do not log an error in the case of no deployment available

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -323,6 +323,9 @@ func (m *Mender) CheckUpdate() (*datastore.UpdateInfo, menderError) {
 				log.Warn("can not perform reauthorization")
 			}
 		}
+		if errors.Is(err, client.ErrNoDeploymentAvailable) {
+			return ur.UpdateInfo, NewTransientError(err)
+		}
 		log.Error("Error receiving scheduled update data: ", err)
 		return ur.UpdateInfo, NewTransientError(err)
 	}


### PR DESCRIPTION
This removes the error log message:
```
level=error msg="Error receiving scheduled update data: (request_id: ): no deployment available"
 ```
when the server returns 204, no deployment available, which is not really
necessary to log as an error.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

