### PR TITLE
MEN-4829: Fix busy-wait bug for only non-server Update Control Maps wait

### DIFF
--- a/app/updatemanager_test.go
+++ b/app/updatemanager_test.go
@@ -946,7 +946,7 @@ func TestUpdateControlMapHalfTime(t *testing.T) {
 	assert.WithinDuration(t,
 		time.Now().Add(5*time.Second),
 		func() time.Time {
-			t, _ := testMapPool.NextControlMapHalfTime("foo")
+			t, _ := testMapPool.NextIDControlMapHalfTime("foo")
 			return t
 		}(),
 		1*time.Second,


### PR DESCRIPTION
In an scenario of only non-server Update Control maps, the client was
busy looping between controlMapState (aware of an active map) and
controlMapPauseState (which checked only for maps matching a given ID).

This fix makes controlMapPauseState.Handle return either a Wait(...)
when non-server maps are present or a MultiplexWait(...) when server
maps are present. In both cases, the times for waiting are HalfWay(s).

Changelog: None