### PR TITLE
Fix bug which caused rollback after commit if status report fails.

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -382,6 +382,24 @@ func (i *initState) getNextState(ctx *StateContext, sd *datastore.StateData,
 	case datastore.MenderStateUpdateCleanup:
 		return NewUpdateCleanupState(&sd.UpdateInfo, client.StatusFailure), false
 
+	// Status reports should be retried. It is possible that the original
+	// status report had a different status than Failure, but worst case
+	// this is simply a wrong report, the device will be fine, and the logs
+	// will reveal what happened.
+	case datastore.MenderStateUpdateStatusReport,
+		datastore.MenderStateStatusReportRetry:
+
+		return NewUpdateStatusReportState(&sd.UpdateInfo, client.StatusFailure), false
+
+	// Historical state. This state is not used anymore in current
+	// clients. In the past it was used at the very end of the update
+	// process if there were errors during reporting. But the handling was
+	// wrong and hence this state was removed. Should we encounter it (which
+	// is unlikely, but possible), we should be at the very end of an
+	// update, and should just go back to Idle.
+	case datastore.MenderStateReportStatusError:
+		return States.Idle, false
+
 	// All other states go to either error or rollback state, depending on
 	// what's supported.
 	default:
@@ -1410,8 +1428,9 @@ func (usr *updateStatusReportState) Handle(ctx *StateContext, c Controller) (Sta
 
 		log.Errorf("Failed to send status to server: %v", err)
 		if err.IsFatal() {
-			// there is no point in retrying
-			return NewReportErrorState(usr.Update(), usr.status), false
+			// There is no point in retrying, and there is nothing
+			// we can do.
+			return States.Idle, false
 		}
 		return NewUpdateStatusReportRetryState(usr, usr.Update(), usr.status,
 			usr.triesSendingReport), false
@@ -1424,8 +1443,9 @@ func (usr *updateStatusReportState) Handle(ctx *StateContext, c Controller) (Sta
 
 			log.Errorf("Failed to send deployment logs to server: %v", err)
 			if err.IsFatal() {
-				// there is no point in retrying
-				return NewReportErrorState(usr.Update(), usr.status), false
+				// There is no point in retrying, and there is nothing
+				// we can do.
+				return States.Idle, false
 			}
 			return NewUpdateStatusReportRetryState(usr, usr.Update(), usr.status,
 				usr.triesSendingLogs), false
@@ -1452,10 +1472,10 @@ func NewUpdateStatusReportRetryState(reportState State,
 	update *datastore.UpdateInfo, status string, tries int) State {
 	return &updateStatusReportRetryState{
 		baseState: baseState{
-			id: datastore.MenderStatusReportRetryState,
+			id: datastore.MenderStateStatusReportRetry,
 			t:  ToNone,
 		},
-		WaitState:    NewWaitState(datastore.MenderStatusReportRetryState, ToNone),
+		WaitState:    NewWaitState(datastore.MenderStateStatusReportRetry, ToNone),
 		reportState:  reportState,
 		update:       *update,
 		status:       status,
@@ -1504,7 +1524,9 @@ func (usr *updateStatusReportRetryState) Handle(ctx *StateContext, c Controller)
 	if usr.triesSending < maxTrySending {
 		return usr.Wait(usr.reportState, usr, c.GetRetryPollInterval(), ctx.WakeupChan)
 	}
-	return NewReportErrorState(&usr.update, usr.status), false
+	// If we have exhausted every attempt, there is nothing more we can
+	// do. The update is over.
+	return States.Idle, false
 }
 
 func (usr *updateStatusReportRetryState) Update() *datastore.UpdateInfo {
@@ -1515,50 +1537,6 @@ func (usr *updateStatusReportRetryState) PermitLooping() bool {
 	// This state already has maxSendingAttempts() to limit number of
 	// invocations.
 	return true
-}
-
-type reportErrorState struct {
-	*updateState
-	updateStatus string
-}
-
-func NewReportErrorState(update *datastore.UpdateInfo, status string) State {
-	return &reportErrorState{
-		updateState: NewUpdateState(datastore.MenderStateReportStatusError,
-			ToArtifactFailure, update),
-		updateStatus: status,
-	}
-}
-
-func (res *reportErrorState) Handle(ctx *StateContext, c Controller) (State, bool) {
-	// start deployment logging; no error checking
-	// we can do nothing here; either we will have the logs or not...
-	DeploymentLogger.Enable(res.Update().ID)
-
-	log.Errorf("Handling report error state with status: %v", res.updateStatus)
-
-	switch res.updateStatus {
-	case client.StatusSuccess:
-		// error while reporting success; rollback
-		return NewUpdateRollbackState(res.Update()), false
-	case client.StatusFailure:
-		// error while reporting failure;
-		// start from scratch as previous update was broken
-		log.Errorf("Error while performing update: %v (%v)", res.updateStatus, *res.Update())
-		return States.Idle, false
-	case client.StatusAlreadyInstalled:
-		// we've failed to report already-installed status, not a big
-		// deal, start from scratch
-		return States.Idle, false
-	default:
-		// should not end up here
-		return States.Final, false
-	}
-}
-
-func (res *reportErrorState) HandleError(ctx *StateContext, c Controller, merr menderError) (State, bool) {
-	log.Errorf("Reached final error state: %s", merr.Error())
-	return States.Idle, false
 }
 
 type updateRebootState struct {

--- a/app/state.go
+++ b/app/state.go
@@ -801,7 +801,7 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 	installer, err := c.ReadArtifactHeaders(u.imagein)
 	if err != nil {
 		log.Errorf("Fetching Artifact headers failed: %s", err)
-		return NewUpdateCleanupState(&u.update, client.StatusFailure), false
+		return NewUpdateStatusReportState(&u.update, client.StatusFailure), false
 	}
 
 	installers := c.GetInstallers()

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -746,7 +746,7 @@ func TestStateUpdateFetch(t *testing.T) {
 	uis := s.(*updateStoreState)
 	assert.Equal(t, stream, uis.imagein)
 	s, c = transitionState(s, &ctx, sc)
-	assert.IsType(t, &updateCleanupState{}, s)
+	assert.IsType(t, &updateStatusReportState{}, s)
 	assert.False(t, c)
 
 	ud, err := datastore.LoadStateData(ms)

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -81,7 +81,7 @@ const (
 	// status report
 	MenderStateUpdateStatusReport
 	// wait before retrying sending either report or deployment logs
-	MenderStatusReportRetryState
+	MenderStateStatusReportRetry
 	// error reporting status
 	MenderStateReportStatusError
 	// reboot
@@ -117,6 +117,9 @@ const (
 )
 
 var (
+	// These are values that are stored in the client database during an
+	// upgrade from one client to the next. Backwards compatibility is
+	// paramount here, so be careful when changing these.
 	stateNames = map[MenderState]string{
 		MenderStateInit:                             "init",
 		MenderStateIdle:                             "idle",
@@ -136,8 +139,7 @@ var (
 		MenderStateUpdateAfterFirstCommit:           "update-after-first-commit",
 		MenderStateUpdateAfterCommit:                "update-after-commit",
 		MenderStateUpdateStatusReport:               "update-status-report",
-		MenderStatusReportRetryState:                "update-retry-report",
-		MenderStateReportStatusError:                "status-report-error",
+		MenderStateStatusReportRetry:                "update-retry-report",
 		MenderStateReboot:                           "reboot",
 		MenderStateVerifyReboot:                     "verify-reboot",
 		MenderStateAfterReboot:                      "after-reboot",
@@ -153,6 +155,11 @@ var (
 		MenderStateUpdateControlPause:               "mender-update-control-pause",
 		MenderStateFetchUpdateControl:               "mender-update-control-refresh-maps",
 		MenderStateFetchRetryUpdateControl:          "mender-update-control-retry-refresh-maps",
+
+		// No longer used. Since this used to be at the very end of an
+		// update, if we encounter it in the database during startup, we
+		// just go back to Idle.
+		MenderStateReportStatusError: "status-report-error",
 	}
 )
 


### PR DESCRIPTION
```
    The problem stems from two separate sources:
    
    1. The reportErrorState has long been wrong in handling errors when
       the original status submitted into it was StatusSuccess. In this
       case it tries to roll back. However, we can't do that, because this
       state is always invoked after committing, so it's too late for
       that. In fact, there is nothing we can do, and it should do the
       same as all the other statuses, namely go back to the Idle
       state. So there is no need for this state at all, and it has been
       removed.
    
    2. If a spontaneous reboot happens, the updateStatusReportState and
       updateStatusReportRetryState states were not being handled
       correctly, and the client would go down the ArtifactRollback or
       ArtifactFailure path, both of which are wrong. The mentioned
       StatusReport states always happen after one or both of those
       failure states have been visited, or after we have committed, so we
       can't visit them again. Instead, go back to try to submit the
       report, which will either succedd or eventually expire if
       unsuccessful.
    
    Existing tests have been updated to cope with the new flow, but I have
    not added any test for the second point above. There does not seem to
    be much need, since all we will test is that two values from the
    database leads to a particular state being returned, which is already
    clear as day in the code. Everything afterwards (the actual reporting
    itself), is tested elsewhere.
    
    Fixes MEN-4830.
    
    Changelog: Fix a bug which could sometimes lead the client to do a
    rollback after it had already committed. This could happen if the
    client happened to spontaneously reboot or fail during the status
    update to the server. Doing this is not correct according to the state
    flow, and can have unexpected consequences depending on the
    combination of Update Modules and State Scripts.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```