### PR TITLE
Revert "Make command output less ugly in the log."

### DIFF
--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,3 +1,15 @@
+From b563cf65e1c768bcab2c48440ea9a4da8118a9de Mon Sep 17 00:00:00 2001
+From: Ole Petter <ole.orhagen@northern.tech>
+Date: Tue, 27 Apr 2021 16:46:19 +0200
+Subject: [PATCH 1/1] Instrument mender binary
+
+Changelog: None
+Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
+---
+ main.go          | 39 ++++++++++++++++++++++++++++++++++++++-
+ system/system.go | 13 +------------
+ 2 files changed, 39 insertions(+), 13 deletions(-)
+
 diff --git a/main.go b/main.go
 index c16a2c1..a2dc924 100644
 --- a/main.go
@@ -61,20 +73,20 @@ index c16a2c1..a2dc924 100644
 +
  }
 diff --git a/system/system.go b/system/system.go
-index ac3046d..e3620bc 100644
+index d5a5cbe..4e50567 100644
 --- a/system/system.go
 +++ b/system/system.go
-@@ -19,9 +19,7 @@ import (
+@@ -18,9 +18,7 @@ import (
+ 	"io"
  	"os"
  	"os/exec"
- 	"strings"
 -	"time"
  
 -	"github.com/pkg/errors"
- 	log "github.com/sirupsen/logrus"
  )
  
-@@ -36,16 +34,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
+ type SystemRebootCmd struct {
+@@ -34,16 +32,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
  }
  
  func (s *SystemRebootCmd) Reboot() error {
@@ -92,3 +104,6 @@ index ac3046d..e3620bc 100644
  }
  
  type Commander interface {
+-- 
+2.17.1
+

--- a/system/system.go
+++ b/system/system.go
@@ -18,11 +18,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type SystemRebootCmd struct {
@@ -82,27 +80,11 @@ func (c *Cmd) StdoutPipe() (io.ReadCloser, error) {
 	return c.Cmd.StdoutPipe()
 }
 
-type cmdLogger struct {
-	cmdName string
-	stream  string
-}
-
-func (c *cmdLogger) Write(buf []byte) (int, error) {
-	lines := strings.Split(string(buf), "\n")
-	for _, line := range lines {
-		if len(line) > 0 {
-			log.Infof("Output (%s) from command %q: %s", c.stream, c.cmdName, line)
-		}
-	}
-
-	return len(buf), nil
-}
-
 func Command(name string, arg ...string) *Cmd {
 	var cmd Cmd
 	cmd.Cmd = exec.Command(name, arg...)
-	cmd.Stdout = &cmdLogger{cmdName: name, stream: "stdout"}
-	cmd.Stderr = &cmdLogger{cmdName: name, stream: "stderr"}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	return &cmd
 }
 


### PR DESCRIPTION
Our own mender-inventory-mender-configure script for some reason logs
one byte at a time, which triggers a new long line for every
character, like this:

```
Jul 05 20:54:51 qemux86-64 mender[236]: time="2021-07-05T20:54:51Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": T"
Jul 05 20:54:51 qemux86-64 mender[236]: time="2021-07-05T20:54:51Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": o"
Jul 05 20:54:51 qemux86-64 mender[236]: time="2021-07-05T20:54:51Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": t"
Jul 05 20:54:51 qemux86-64 mender[236]: time="2021-07-05T20:54:51Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": a"
Jul 05 20:54:51 qemux86-64 mender[236]: time="2021-07-05T20:54:51Z" level=info msg="Output (stderr) from command \"/usr/share/mender/inventory/mender-inventory-mender-configure\": l"
```

Until we have a better fix for this which buffers line by line, revert
this.

Changelog: None

This reverts commit 8c672c35290a1dae9021a29264365ddb39a0300f.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
