### PR TITLE
MEN-4851: mender-inventory-network: Use short command line options

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -195,13 +195,13 @@ func (ws *waitState) Wait(next, same State,
 	defer ticker.Stop()
 	select {
 	case <-ticker.C:
-		log.Debugf("Wait complete")
+		log.Debug("Wait complete")
 		return next, false
 	case <-ws.wakeup:
 		log.Info("Forced wake-up from sleep")
 		return next, false
 	case <-ws.cancel:
-		log.Infof("Wait canceled")
+		log.Info("Wait canceled")
 	}
 	return same, true
 }
@@ -2112,13 +2112,13 @@ func (ws *UpdateControlMapWaitState) MultiplexWait(
 	defer ticker.Stop()
 	select {
 	case <-ticker.C:
-		log.Debugf("Wait complete")
+		log.Debug("Wait complete")
 		return tickerState, false
 	case <-ws.wakeup:
 		log.Info("Forced wake-up from sleep")
 		return wakeupState, false
 	case <-ws.cancel:
-		log.Infof("Wait canceled")
+		log.Info("Wait canceled")
 	}
 	return tickerState, true
 }

--- a/support/mender-inventory-network
+++ b/support/mender-inventory-network
@@ -51,7 +51,7 @@ for devpath in $SCN/*; do
         continue
     fi
     if [ "${INCLUDE_DOCKER_INTERFACES}" = "false" ]; then
-        if echo $dev | grep --quiet --extended-regexp '^(br-.*|docker.*|veth.*)'; then
+        if echo $dev | grep -q -E '^(br-.*|docker.*|veth.*)'; then
             continue
         fi
     fi


### PR DESCRIPTION
    Fixes issue with busybox where grep does not accept long flags
    
    Changelog: mender-inventory-network: Fix incompatibility with busybox,
    by using short command line options in grep command.
