### PR TITLE
MEN-4857: Fix configuration issues for Update Control.

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -43,7 +43,7 @@ func NewDaemon(
 	authManager AuthManager) (*MenderDaemon, error) {
 
 	updmgr := NewUpdateManager(mender.GetControlMapPool(),
-		config.UpdateControlMapExpirationTimeSeconds)
+		config.GetUpdateControlMapExpirationTimeSeconds())
 	if config.DBus.Enabled {
 		api, err := dbus.GetDBusAPI()
 		if err != nil {

--- a/app/mender.go
+++ b/app/mender.go
@@ -136,8 +136,8 @@ func NewMender(config *conf.MenderConfig, pieces MenderPieces) (*Mender, error) 
 
 	controlMapPool := NewControlMap(
 		pieces.Store,
-		config.UpdateControlMapBootExpirationTimeSeconds,
-		config.UpdateControlMapExpirationTimeSeconds,
+		config.GetUpdateControlMapBootExpirationTimeSeconds(),
+		config.GetUpdateControlMapExpirationTimeSeconds(),
 	)
 
 	m := &Mender{
@@ -370,7 +370,7 @@ func (m *Mender) handleControlMap(data *client.UpdateResponse) error {
 			data.UpdateControlMap.Stamp(
 				m.DeviceManager.Config.
 					MenderConfigFromFile.
-					UpdateControlMapExpirationTimeSeconds))
+					GetUpdateControlMapExpirationTimeSeconds()))
 	} else {
 		m.controlMapPool.DeleteAllPriorities(data.UpdateInfo.ID)
 	}

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -99,15 +99,17 @@ const (
 		`\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])`
 
 	// Default constants
-	defaultServerIP      = "127.0.0.1"
-	defaultServerURL     = "https://docker.mender.io"
-	defaultInventoryPoll = 28800 // NOTE: If changing these integer default
-	defaultRetryPoll     = 300   //       values, make sure to update the
-	defaultUpdatePoll    = 1800  //       corresponding prompt texts below.
-	demoInventoryPoll    = 5
-	demoRetryPoll        = 30
-	demoUpdatePoll       = 5
-	hostedMenderURL      = "https://hosted.mender.io"
+	defaultServerIP              = "127.0.0.1"
+	defaultServerURL             = "https://docker.mender.io"
+	defaultInventoryPoll         = 28800 // NOTE: If changing these integer default
+	defaultRetryPoll             = 300   //       values, make sure to update the
+	defaultUpdatePoll            = 1800  //       corresponding prompt texts below.
+	demoInventoryPoll            = 5
+	demoRetryPoll                = 30
+	demoUpdatePoll               = 5
+	demoControlMapExpiration     = 90
+	demoControlMapBootExpiration = 45
+	hostedMenderURL              = "https://hosted.mender.io"
 
 	// Prompt constants
 	promptWizard = "Mender Client Setup\n" +
@@ -807,6 +809,8 @@ func (opts *setupOptionsType) saveConfigOptions(
 		} else {
 			config.RetryPollIntervalSeconds = demoRetryPoll
 		}
+		config.UpdateControlMapExpirationTimeSeconds = demoControlMapExpiration
+		config.UpdateControlMapBootExpirationTimeSeconds = demoControlMapBootExpiration
 	} else {
 		config.InventoryPollIntervalSeconds = opts.invPollInterval
 		config.UpdatePollIntervalSeconds = opts.updatePollInterval

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -204,6 +204,11 @@ func TestSetupFlags(t *testing.T) {
 	assert.Equal(t, demoUpdatePoll, config.UpdatePollIntervalSeconds)
 	assert.Equal(t, demoInventoryPoll, config.InventoryPollIntervalSeconds)
 	assert.Equal(t, demoRetryPoll, config.RetryPollIntervalSeconds)
+	assert.Equal(t, demoControlMapExpiration, config.UpdateControlMapExpirationTimeSeconds)
+	assert.Equal(t, demoControlMapBootExpiration, config.UpdateControlMapBootExpirationTimeSeconds)
+
+	ctx, config, runOptions = initCLITest(t, flagSet)
+	opts = &runOptions.setupOptions
 
 	ctx.Set("device-type", "bgl-bn")
 	opts.deviceType = "bgl-bn"
@@ -231,6 +236,8 @@ func TestSetupFlags(t *testing.T) {
 	assert.Equal(t, 789, config.RetryPollIntervalSeconds)
 	assert.Equal(t, "https://docker.menderine.io",
 		config.Servers[0].ServerURL)
+	assert.Equal(t, 0, config.UpdateControlMapExpirationTimeSeconds)
+	assert.Equal(t, 0, config.UpdateControlMapBootExpirationTimeSeconds)
 
 	// Hosted Mender no demo -- same parameters as above
 	ctx.Set("hosted-mender", "true")

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -14,6 +14,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"os"
@@ -237,6 +238,18 @@ func TestSetupFlags(t *testing.T) {
 	err = doSetup(ctx, config, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://hosted.mender.io", config.Servers[0].ServerURL)
+
+	// Verify a few key variables that we know should not be in the
+	// configuration file.
+	r, err := os.Open(runOptions.setupOptions.configPath)
+	require.NoError(t, err)
+	var genericMap map[string]interface{}
+	err = json.NewDecoder(r).Decode(&genericMap)
+	assert.NoError(t, err)
+	assert.Contains(t, genericMap, "UpdatePollIntervalSeconds")
+	assert.NotContains(t, genericMap, "StateScriptTimeoutSeconds")
+	assert.NotContains(t, genericMap, "UpdateControlMapExpirationTimeSeconds")
+	assert.NotContains(t, genericMap, "UpdateControlMapBootExpirationTimeSeconds")
 }
 
 func TestInstallDemoCertificateLocalTrust(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -536,9 +536,9 @@ func newHttpsClient(conf Config) (*http.Client, error) {
 // NOTE: Careful when changing this, the struct is exposed directly in the
 // 'mender.conf' file.
 type HttpsClient struct {
-	Certificate string
-	Key         string
-	SSLEngine   string
+	Certificate string `json:",omitempty"`
+	Key         string `json:",omitempty"`
+	SSLEngine   string `json:",omitempty"`
 }
 
 // Security structure holds the configuration for the client
@@ -547,8 +547,8 @@ type HttpsClient struct {
 // NOTE: Careful when changing this, the struct is exposed directly in the
 // 'mender.conf' file.
 type Security struct {
-	AuthPrivateKey string
-	SSLEngine      string
+	AuthPrivateKey string `json:",omitempty"`
+	SSLEngine      string `json:",omitempty"`
 }
 
 func (h *HttpsClient) Validate() {

--- a/conf/config.go
+++ b/conf/config.go
@@ -32,56 +32,56 @@ const (
 
 type MenderConfigFromFile struct {
 	// Path to the public key used to verify signed updates
-	ArtifactVerifyKey string
+	ArtifactVerifyKey string `json:",omitempty"`
 	// HTTPS client parameters
-	HttpsClient client.HttpsClient
+	HttpsClient client.HttpsClient `json:",omitempty"`
 	// Security parameters
-	Security client.Security
+	Security client.Security `json:",omitempty"`
 	// Rootfs device path
-	RootfsPartA string
-	RootfsPartB string
+	RootfsPartA string `json:",omitempty"`
+	RootfsPartB string `json:",omitempty"`
 	// Path to the device type file
-	DeviceTypeFile string
+	DeviceTypeFile string `json:",omitempty"`
 	// DBus configuration
-	DBus DBusConfig
+	DBus DBusConfig `json:",omitempty"`
 	// Expiration timeout for the control map
-	UpdateControlMapExpirationTimeSeconds int
+	UpdateControlMapExpirationTimeSeconds int `json:",omitempty"`
 	// Expiration timeout for the control map when just booted
-	UpdateControlMapBootExpirationTimeSeconds int
+	UpdateControlMapBootExpirationTimeSeconds int `json:",omitempty"`
 
 	// Poll interval for checking for new updates
-	UpdatePollIntervalSeconds int
+	UpdatePollIntervalSeconds int `json:",omitempty"`
 	// Poll interval for periodically sending inventory data
-	InventoryPollIntervalSeconds int
+	InventoryPollIntervalSeconds int `json:",omitempty"`
 
 	// Skip CA certificate validation
-	SkipVerify bool
+	SkipVerify bool `json:",omitempty"`
 
 	// Global retry polling max interval for fetching update, authorize wait and update status
-	RetryPollIntervalSeconds int
+	RetryPollIntervalSeconds int `json:",omitempty"`
 
 	// State script parameters
-	StateScriptTimeoutSeconds      int
-	StateScriptRetryTimeoutSeconds int
+	StateScriptTimeoutSeconds      int `json:",omitempty"`
+	StateScriptRetryTimeoutSeconds int `json:",omitempty"`
 	// Poll interval for checking for update (check-update)
-	StateScriptRetryIntervalSeconds int
+	StateScriptRetryIntervalSeconds int `json:",omitempty"`
 
 	// Update module parameters:
 
 	// The timeout for the execution of the update module, after which it
 	// will be killed.
-	ModuleTimeoutSeconds int
+	ModuleTimeoutSeconds int `json:",omitempty"`
 
 	// Path to server SSL certificate
-	ServerCertificate string
+	ServerCertificate string `json:",omitempty"`
 	// Server URL (For single server conf)
-	ServerURL string
+	ServerURL string `json:",omitempty"`
 	// Path to deployment log file
-	UpdateLogPath string
+	UpdateLogPath string `json:",omitempty"`
 	// Server JWT TenantToken
-	TenantToken string
+	TenantToken string `json:",omitempty"`
 	// List of available servers, to which client can fall over
-	Servers []client.MenderServer
+	Servers []client.MenderServer `json:",omitempty"`
 }
 
 type MenderConfig struct {

--- a/conf/config.go
+++ b/conf/config.go
@@ -142,7 +142,7 @@ func LoadConfig(mainConfigFile string, fallbackConfigFile string) (*MenderConfig
 
 	log.Debugf("Loaded %d configuration file(s)", filesLoadedCount)
 
-	applyConfigDefaults(config)
+	checkConfigDefaults(config)
 
 	if filesLoadedCount == 0 {
 		log.Info("No configuration files present. Using defaults")
@@ -195,19 +195,31 @@ func (c *MenderConfig) Validate() error {
 	return nil
 }
 
-func applyConfigDefaults(config *MenderConfig) {
+func (c *MenderConfigFromFile) GetUpdateControlMapExpirationTimeSeconds() int {
+	if c.UpdateControlMapExpirationTimeSeconds == 0 {
+		return 2 * c.UpdatePollIntervalSeconds
+	}
+	return c.UpdateControlMapExpirationTimeSeconds
+}
+
+func (c *MenderConfigFromFile) GetUpdateControlMapBootExpirationTimeSeconds() int {
+	if c.UpdateControlMapBootExpirationTimeSeconds == 0 {
+		return DefaultUpdateControlMapBootExpirationTimeSeconds
+	}
+	return c.UpdateControlMapBootExpirationTimeSeconds
+}
+
+func checkConfigDefaults(config *MenderConfig) {
 	if config.MenderConfigFromFile.UpdateControlMapExpirationTimeSeconds == 0 {
 		log.Info("'UpdateControlMapExpirationTimeSeconds' is not set " +
 			"in the Mender configuration file." +
 			" Falling back to the default of 2*UpdatePollIntervalSeconds")
-		config.MenderConfigFromFile.UpdateControlMapExpirationTimeSeconds = 2 * config.MenderConfigFromFile.UpdatePollIntervalSeconds
 	}
 
 	if config.MenderConfigFromFile.UpdateControlMapBootExpirationTimeSeconds == 0 {
 		log.Infof("'UpdateControlMapBootExpirationTimeSeconds' is not set "+
 			"in the Mender configuration file."+
 			" Falling back to the default of %d seconds", DefaultUpdateControlMapBootExpirationTimeSeconds)
-		config.MenderConfigFromFile.UpdateControlMapBootExpirationTimeSeconds = DefaultUpdateControlMapBootExpirationTimeSeconds
 	}
 }
 

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -102,11 +102,9 @@ func Test_readConfigFile_brokenContent_returnsError(t *testing.T) {
 func validateConfiguration(t *testing.T, actual *MenderConfig) {
 	expectedConfig := NewMenderConfig()
 	expectedConfig.MenderConfigFromFile = MenderConfigFromFile{
-		RootfsPartA:                               "/dev/mmcblk0p2",
-		RootfsPartB:                               "/dev/mmcblk0p3",
-		UpdatePollIntervalSeconds:                 10,
-		UpdateControlMapExpirationTimeSeconds:     20,
-		UpdateControlMapBootExpirationTimeSeconds: 600,
+		RootfsPartA:               "/dev/mmcblk0p2",
+		RootfsPartB:               "/dev/mmcblk0p3",
+		UpdatePollIntervalSeconds: 10,
 		HttpsClient: client.HttpsClient{
 			Certificate: "/data/client.crt",
 			Key:         "/data/client.key",
@@ -288,8 +286,8 @@ func TestDBusUpdateControlMapExpirationTimeSecondsConfig(t *testing.T) {
 	tfile.WriteString(noVariableSet)
 	config, err := LoadConfig(tfile.Name(), noJson.Name())
 	require.NoError(t, err)
-	assert.Equal(t, 6*2, config.UpdateControlMapExpirationTimeSeconds)
-	assert.Equal(t, DefaultUpdateControlMapBootExpirationTimeSeconds, config.UpdateControlMapBootExpirationTimeSeconds)
+	assert.Equal(t, 6*2, config.GetUpdateControlMapExpirationTimeSeconds())
+	assert.Equal(t, DefaultUpdateControlMapBootExpirationTimeSeconds, config.GetUpdateControlMapBootExpirationTimeSeconds())
 
 	// set UpdateControlMapExpirationTimeSeconds
 	variableSet := `{
@@ -303,6 +301,6 @@ func TestDBusUpdateControlMapExpirationTimeSecondsConfig(t *testing.T) {
 	tfile.WriteString(variableSet)
 	config, err = LoadConfig(tfile.Name(), noJson.Name())
 	require.NoError(t, err)
-	assert.Equal(t, 10, config.UpdateControlMapExpirationTimeSeconds)
-	assert.Equal(t, 15, config.UpdateControlMapBootExpirationTimeSeconds)
+	assert.Equal(t, 10, config.GetUpdateControlMapExpirationTimeSeconds())
+	assert.Equal(t, 15, config.GetUpdateControlMapBootExpirationTimeSeconds())
 }


### PR DESCRIPTION
```
commit 78f1fe18be65850075f765e73cb0cf68de9cc36f
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jul 8 11:36:53 2021

    MEN-4857: Correct Update Control settings for `mender setup --demo`.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 3679422aefd35f0a64145399d8036c5d978fa6bc
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jul 8 11:24:16 2021

    MEN-4857: Remove more default values from generated config file.
    
    `UpdateControlMapExpirationTimeSeconds` and
    `UpdateControlMapBootExpirationTimeSeconds` should not be in the
    configuration file if their values are the default values.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit c99b16a797f9806bb0f6e710182cffa0cd567008
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Jul 8 10:27:17 2021

    MEN-4857: Make sure incorrect zero values are not included in config.
    
    Changelog: Do not put useless and sometimes even incorrect zero values
    in the configuration file when running `mender setup`.
    
    Note that there are still a few values that show up in the file
    without reason, like `DBus.Enabled`. Since it is set to true by
    default, we can't use `omitempty`, since it will do the opposite of
    what we want.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```