### PR TITLE
2.6.x: MEN-4851: mender-inventory-network: Use short command line options

### DIFF
--- a/support/mender-inventory-network
+++ b/support/mender-inventory-network
@@ -51,7 +51,7 @@ for devpath in $SCN/*; do
         continue
     fi
     if [ "${INCLUDE_DOCKER_INTERFACES}" = "false" ]; then
-        if echo $dev | grep --quiet --extended-regexp '^(br-.*|docker.*|veth.*)'; then
+        if echo $dev | grep -q -E '^(br-.*|docker.*|veth.*)'; then
             continue
         fi
     fi


### PR DESCRIPTION
Fixes issue with busybox where grep does not accept long flags

Changelog: mender-inventory-network: Fix incompatibility with busybox,
by using short command line options in grep command.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit fc8784bff2665f80a910463444454b89a3962e48)