### PR TITLE
Add artifact_name to device provides if not found in store

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -637,3 +637,18 @@ func (m *Mender) InventoryRefresh() error {
 func (m *Mender) CheckScriptsCompatibility() error {
 	return m.stateScriptExecutor.CheckRootfsScriptsVersion()
 }
+
+func verifyAndSetArtifactNameInProvides(provides map[string]string, getArtifactName func() (string, error)) error {
+	if _, ok := provides["artifact_name"]; !ok {
+		artifactName, err := getArtifactName()
+		if err != nil || artifactName == "" {
+			log.Error("could not get the current Artifact name")
+			if err == nil {
+				err = errors.New("artifact name is empty")
+			}
+			return err
+		}
+		provides["artifact_name"] = artifactName
+	}
+	return nil
+}

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -149,6 +149,17 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 		if err != nil {
 			return nil, err
 		}
+		if _, ok := currentProvides["artifact_name"]; !ok {
+			artifactName, err := device.GetCurrentArtifactName()
+			if err != nil || artifactName == "" {
+				log.Error("could not get the current Artifact name")
+				if err == nil {
+					err = errors.New("artifact name is empty")
+				}
+				return nil, err
+			}
+			currentProvides["artifact_name"] = artifactName
+		}
 		if err = verifyArtifactDependencies(depends, currentProvides); err != nil {
 			log.Error(err.Error())
 			return nil, err

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -149,16 +149,9 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := currentProvides["artifact_name"]; !ok {
-			artifactName, err := device.GetCurrentArtifactName()
-			if err != nil || artifactName == "" {
-				log.Error("could not get the current Artifact name")
-				if err == nil {
-					err = errors.New("artifact name is empty")
-				}
-				return nil, err
-			}
-			currentProvides["artifact_name"] = artifactName
+		if err = verifyAndSetArtifactNameInProvides(currentProvides, device.GetCurrentArtifactName); err != nil {
+			log.Error(err.Error())
+			return nil, err
 		}
 		if err = verifyArtifactDependencies(depends, currentProvides); err != nil {
 			log.Error(err.Error())

--- a/app/state.go
+++ b/app/state.go
@@ -835,7 +835,7 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 			client.StatusFailure), false
 	}
 
-	err = u.maybeVerifyArtifactDependsAndProvides(ctx, installer)
+	err = u.maybeVerifyArtifactDependsAndProvides(ctx, installer, c)
 	if err != nil {
 		return NewUpdateStatusReportState(u.Update(),
 			client.StatusFailure), false
@@ -880,7 +880,7 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 }
 
 func (u *updateStoreState) maybeVerifyArtifactDependsAndProvides(
-	ctx *StateContext, installer *installer.Installer) error {
+	ctx *StateContext, installer *installer.Installer, c Controller) error {
 	// For artifact version >= 3 we need to fetch the artifact provides of
 	// the previous artifact from the datastore, and verify that the
 	// provides match artifact dependencies.
@@ -894,6 +894,17 @@ func (u *updateStoreState) maybeVerifyArtifactDependsAndProvides(
 		if err != nil {
 			log.Error(err.Error())
 			return err
+		}
+		if _, ok := provides["artifact_name"]; !ok {
+			artifactName, err := c.GetCurrentArtifactName()
+			if err != nil || artifactName == "" {
+				log.Error("could not get the current Artifact name")
+				if err == nil {
+					err = errors.New("artifact name is empty")
+				}
+				return err
+			}
+			provides["artifact_name"] = artifactName
 		}
 		if err = verifyArtifactDependencies(
 			depends, provides); err != nil {

--- a/app/state.go
+++ b/app/state.go
@@ -895,16 +895,9 @@ func (u *updateStoreState) maybeVerifyArtifactDependsAndProvides(
 			log.Error(err.Error())
 			return err
 		}
-		if _, ok := provides["artifact_name"]; !ok {
-			artifactName, err := c.GetCurrentArtifactName()
-			if err != nil || artifactName == "" {
-				log.Error("could not get the current Artifact name")
-				if err == nil {
-					err = errors.New("artifact name is empty")
-				}
-				return err
-			}
-			provides["artifact_name"] = artifactName
+		if err = verifyAndSetArtifactNameInProvides(provides, c.GetCurrentArtifactName); err != nil {
+			log.Error(err.Error())
+			return err
 		}
 		if err = verifyArtifactDependencies(
 			depends, provides); err != nil {

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -1033,6 +1033,7 @@ func TestStateUpdateInstallFailed(t *testing.T) {
 	}
 	uis := NewUpdateStoreState(stream, update)
 	ms := store.NewMemStore()
+	ms.WriteAll(datastore.ArtifactNameKey, []byte("preexisting-name"))
 	ctx := StateContext{
 		Store: ms,
 	}


### PR DESCRIPTION
Signed-off-by: Prashanth Joseph Babu <prashanthjbabu@gmail.com>
Changelog: Commit


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

This PR fixes a corner case for delta updates. 
Consider a fresh device which has no device provides . 
Now when we ask for an update(`deployment/next` API) , we provide `artifact_name` as device provides by getting it from `GetCurrentArtifactName`
Now once the client gets the artifact from the server and when it comes to installing the artifact , the device calls `maybeVerifyArtifactDependsAndProvides` to ensure that the `depends` of the artifact matches with the `provides` of the device .
In such a case for a fresh device which has `no provides` in the datastore , the `LoadProvides` function does not have `artifact_name` in it causing the artifact install to fail since it wouldnt match with the `artifact_name` depends of the artifact.
To take care of this , we need to ensure that if the datastore does not return `artifact_name` we take it from `GetCurrentArtifactName`( which ensures it takes it from the artifact_info file if not present in the store.)

This issue is not seen if the first deployment is not a delta deployment since after the first deployment , the mender client stores the `artifact_name` in provides section of data store.
