### PR TITLE
support passing docker run CLI arguments

### DIFF
--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -50,7 +50,6 @@ device_types=""
 artifact_name=""
 output_path="docker-artifact.mender"
 meta_data_file="meta-data.json"
-run_args_file="run_args"
 IMAGES=""
 passthrough=0
 passthrough_args=""
@@ -132,11 +131,6 @@ if [ -z "${IMAGES}" ]; then
   show_help_and_exit_error
 fi
 
-# Create required files for the Update Module
-tmpdir=$(mktemp -d)
-run_args_file="$tmpdir/run_args"
-echo ${run_args} > ${run_args_file}
-
 HASHES=""
 for image in $IMAGES; do
     docker pull $image
@@ -144,7 +138,7 @@ for image in $IMAGES; do
 done
 HASHES=$(echo $HASHES | tr ' ' ',')
 
-eval "jq -n --argjson c '[$HASHES]' '{\"containers\": \$c}'" > $meta_data_file
+eval "jq -n --argjson c '[$HASHES]' '{\"containers\": \$c, \"run_args\": \"${run_args}\"}'" > $meta_data_file
 
 mender-artifact write module-image \
   -T docker \
@@ -152,7 +146,6 @@ mender-artifact write module-image \
   -o $output_path \
   -n $artifact_name \
   -m $meta_data_file \
-  -f $run_args_file \
   $passthrough_args
 
 rm $meta_data_file

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -9,7 +9,7 @@ Simple tool to generate Mender Artifact suitable for docker Update Module
 
 Usage: $0 [options] IMAGE [IMAGES...] [-- [options-for-mender-artifact] ]
 
-    Options: [ -n|artifact-name -t|--device-type --software-name --software-version --software-filesystem -o|--output_path -h|--help ]
+    Options: [ -n|artifact-name -t|--device-type --software-name --software-version --software-filesystem --run-args -o|--output_path -h|--help ]
 
         --artifact-name       - Artifact name
         --device-type         - Target device type identification (can be given more than once)
@@ -17,6 +17,7 @@ Usage: $0 [options] IMAGE [IMAGES...] [-- [options-for-mender-artifact] ]
                                 instead of rootfs-image.docker.version
         --software-version    - Value for the software version, defaults to the name of the artifact
         --software-filesystem - If specified, is used instead of rootfs-image
+        --run-args            - Command line args to add when running the container(s)
         --output-path         - Path to output file. Default: docker-artifact.mender
         --help                - Show help and exit
         IMAGE [IMAGES...]     - Docker container images to add to the Artifact
@@ -49,6 +50,7 @@ device_types=""
 artifact_name=""
 output_path="docker-artifact.mender"
 meta_data_file="meta-data.json"
+run_args_file="run_args"
 IMAGES=""
 passthrough=0
 passthrough_args=""
@@ -80,6 +82,13 @@ while (( "$#" )); do
         show_help_and_exit_error
       fi
       passthrough_args="$passthrough_args $1 $2"
+      shift 2
+      ;;
+    --run-args)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      run_args=$2
       shift 2
       ;;
     --output-path | -o)
@@ -123,6 +132,11 @@ if [ -z "${IMAGES}" ]; then
   show_help_and_exit_error
 fi
 
+# Create required files for the Update Module
+tmpdir=$(mktemp -d)
+run_args_file="$tmpdir/run_args"
+echo ${run_args} > ${run_args_file}
+
 HASHES=""
 for image in $IMAGES; do
     docker pull $image
@@ -138,6 +152,7 @@ mender-artifact write module-image \
   -o $output_path \
   -n $artifact_name \
   -m $meta_data_file \
+  -f $run_args_file \
   $passthrough_args
 
 rm $meta_data_file

--- a/support/modules/docker
+++ b/support/modules/docker
@@ -6,6 +6,7 @@ STATE="$1"
 FILES="$2"
 
 prev_containers_file="$FILES"/tmp/prev_containers.list
+run_args_file="$FILES"/files/run_args
 
 case "$STATE" in
 
@@ -27,11 +28,13 @@ case "$STATE" in
 
         >&2 echo "Stopping all running containers"
         [ -n "$(cat $prev_containers_file)" ] && docker stop $(cat $prev_containers_file)
+
+        [ -e ${run_args_file} ] && run_args=$(cat "${run_args_file}")
         for container in $(jq -r ".containers[]" "$FILES"/header/meta-data); do
             >&2 echo "Pulling new container [$container]"
             docker pull $container
-            >&2 echo "Starting new container [$container]"
-            docker run -dt $container
+            >&2 echo "Starting new container [$container] with args [${run_args}]"
+            docker run -dt ${run_args} $container
         done
         ;;
 

--- a/support/modules/docker
+++ b/support/modules/docker
@@ -6,7 +6,6 @@ STATE="$1"
 FILES="$2"
 
 prev_containers_file="$FILES"/tmp/prev_containers.list
-run_args_file="$FILES"/files/run_args
 
 case "$STATE" in
 
@@ -29,7 +28,7 @@ case "$STATE" in
         >&2 echo "Stopping all running containers"
         [ -n "$(cat $prev_containers_file)" ] && docker stop $(cat $prev_containers_file)
 
-        [ -e ${run_args_file} ] && run_args=$(cat "${run_args_file}")
+        run_args=$(jq -r ".run_args | select (.!=null)" "$FILES"/header/meta-data)
         for container in $(jq -r ".containers[]" "$FILES"/header/meta-data); do
             >&2 echo "Pulling new container [$container]"
             docker pull $container


### PR DESCRIPTION
Signed-off-by: Uri Ishon <uri@cs-robotics.com>

Changelog: Support passing docker run CLI arguments when deploying an artifact using the `docker` _update module_.


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Add support for passing command line arguments to `docker run` executed when deploying docker containers. E.g., passing ports to expose when deploying an `nginx` container. Support includes an updated `docker` _update module_ as well as an updated `docker-artifact-gen` wrapper script. Note that *all* containers will be run with the passed arguments.