### PR TITLE
Add missing filesystem sync after populating Update Module's file tree.

### DIFF
--- a/installer/modules.go
+++ b/installer/modules.go
@@ -529,7 +529,11 @@ func (d *moduleDownload) handleStreamChannel(err error) error {
 func (d *moduleDownload) handleFinishChannel() error {
 	d.finishFlag = true
 
-	if d.downloaderType != menderDownloader {
+	if d.downloaderType == menderDownloader {
+		// Make sure the file tree is synced and will not vanish across
+		// a reboot.
+		syscall.Sync()
+	} else {
 		// Publish empty entry to signal end of streams.
 		var err error
 		d.streamNext, err = d.publishNameInStreamNext("")


### PR DESCRIPTION
Changelog: Add missing filesystem sync which could produce an empty or
corrupted Update Module file tree in
`/var/lib/mender/modules/v3/payloads/0000/tree/files/` after an
unexpected reboot.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
