### PR TITLE
MEN-5012: Remove ability to compile without glib and D-Bus support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ DBUS_POLICY_FILES = \
 	support/dbus/io.mender.AuthenticationManager.conf \
 	support/dbus/io.mender.UpdateManager.conf
 
+DBUS_INTERFACE_FILES = \
+	Documentation/io.mender.Authentication1.xml \
+	Documentation/io.mender.Update1.xml
+
 build:
 	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
@@ -106,6 +110,8 @@ install-datadir:
 install-dbus: install-datadir
 	install -m 755 -d $(prefix)$(datadir)/dbus-1/system.d
 	install -m 644 $(DBUS_POLICY_FILES) $(prefix)$(datadir)/dbus-1/system.d/
+	install -m 755 -d $(prefix)$(datadir)/dbus-1/interface
+	install -m 644 $(DBUS_INTERFACE_FILES) $(prefix)$(datadir)/dbus-1/interface/
 
 install-identity-scripts: install-datadir
 	install -m 755 -d $(prefix)$(datadir)/mender/identity
@@ -160,6 +166,10 @@ uninstall-dbus:
 		rm -f $(prefix)$(datadir)/dbus-1/system.d/$$(basename $$policy); \
 	done
 	-rmdir -p $(prefix)$(datadir)/dbus-1/system.d
+	for interface in $(DBUS_INTERFACE_FILES); do \
+		rm -f $(prefix)$(datadir)/dbus-1/interface/$$(basename $$interface); \
+	done
+	-rmdir -p $(prefix)$(datadir)/dbus-1/interface
 
 uninstall-identity-scripts:
 	for script in $(IDENTITY_SCRIPTS); do \

--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ dependency and substitute the `make` commands in the instructions below for:
 make TAGS=nolzma
 ```
 
-#### D-Bus support opt-out
-
-If no D-Bus support is desired, you can ignore the `libglib2.0-dev` package dependency and substitute
-the `make` commands in the instructions below for:
-
-```
-make TAGS=nodbus
-```
-
 ### Steps
 
 To install Mender on a device from source, first clone the repository in the correct folder

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -44,13 +44,8 @@ func NewDaemon(
 
 	updmgr := NewUpdateManager(mender.GetControlMapPool(),
 		config.GetUpdateControlMapExpirationTimeSeconds())
-	if config.DBus.Enabled {
-		api, err := dbus.GetDBusAPI()
-		if err != nil {
-			return nil, errors.Wrap(err, "DBus API support not available, but DBus is enabled")
-		}
-		updmgr.EnableDBus(api)
-	}
+
+	updmgr.EnableDBus(dbus.GetDBusAPI())
 
 	daemon := MenderDaemon{
 		AuthManager:          authManager,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -151,15 +151,11 @@ func commonInit(config *conf.MenderConfig, opts *runOptionsType) (*app.Mender, *
 		return nil, nil, errors.New("error initializing authentication manager")
 	}
 
-	if config.DBus.Enabled {
-		api, err := dbus.GetDBusAPI()
-		if err != nil {
-			// close DB store explicitly
-			dbstore.Close()
-			return nil, nil, errors.Wrap(err, "DBus API support not available, but DBus is enabled")
-		}
-		authmgr.EnableDBus(api)
+	if !config.DBus.Enabled {
+		log.Warn(`Support for turning off DBus has been removed. "DBus.Enabled: false" setting ignored.`)
 	}
+
+	authmgr.EnableDBus(dbus.GetDBusAPI())
 
 	mp := app.MenderPieces{
 		Store:       dbstore,
@@ -279,9 +275,6 @@ func initDaemon(config *conf.MenderConfig,
 
 	// add logging hook; only daemon needs this
 	log.AddHook(app.NewDeploymentLogHook(app.DeploymentLogger))
-
-	// At the moment we don't do anything with this, just force linking to it.
-	_, _ = dbus.GetDBusAPI()
 
 	return daemon, nil
 }

--- a/conf/config.go
+++ b/conf/config.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/mendersoftware/mender/client"
-	"github.com/mendersoftware/mender/dbus"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -133,11 +132,9 @@ func LoadConfig(mainConfigFile string, fallbackConfigFile string) (*MenderConfig
 	var filesLoadedCount int
 	config := NewMenderConfig()
 
-	// If DBus is compiled in, enable it by default
-	_, err := dbus.GetDBusAPI()
-	if err == nil {
-		config.DBus.Enabled = true
-	}
+	// It's no longer possible to turn this off, but set it to true, since
+	// it is warned about if set to false in the config file.
+	config.DBus.Enabled = true
 
 	if loadErr := loadConfigFile(fallbackConfigFile, config, &filesLoadedCount); loadErr != nil {
 		return nil, loadErr

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -16,15 +16,13 @@ package dbus
 
 import (
 	"unsafe"
-
-	"github.com/pkg/errors"
 )
 
 // These are unsafe pointers, only prettier :)
 type Handle unsafe.Pointer
 type MainLoop unsafe.Pointer
 
-var dbusAPI DBusAPI = nil
+var dbusAPI DBusAPI = NewDBusAPILibGio()
 
 // DBusAPI is the interface which describes a DBus API
 type DBusAPI interface {
@@ -66,11 +64,8 @@ type TokenAndServerURL struct {
 }
 
 // GetDBusAPI returns the global DBusAPI object
-func GetDBusAPI() (DBusAPI, error) {
-	if dbusAPI != nil {
-		return dbusAPI, nil
-	}
-	return nil, errors.New("no D-Bus interface available")
+func GetDBusAPI() DBusAPI {
+	return dbusAPI
 }
 
 func setDBusAPI(api DBusAPI) {

--- a/dbus/dbus_libgio.go
+++ b/dbus/dbus_libgio.go
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 package dbus
 
@@ -31,6 +30,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+func NewDBusAPILibGio() *dbusAPILibGio {
+	return &dbusAPILibGio{
+		MethodCallCallbacks: make(map[string]MethodCallCallback),
+	}
+}
 
 type dbusAPILibGio struct {
 	MethodCallCallbacksMutex sync.Mutex
@@ -227,7 +232,7 @@ func handle_method_call_callback(objectPath, interfaceName, methodName *C.gchar,
 	goMethodName := C.GoString(methodName)
 	goParameters := C.GoString(parameters)
 	key := keyForPathInterfaceNameAndMethod(goObjectPath, goInterfaceName, goMethodName)
-	api, _ := GetDBusAPI()
+	api := GetDBusAPI()
 
 	d := api.(*dbusAPILibGio)
 	d.MethodCallCallbacksMutex.Lock()
@@ -246,10 +251,4 @@ func handle_method_call_callback(objectPath, interfaceName, methodName *C.gchar,
 
 func keyForPathInterfaceNameAndMethod(path string, interfaceName string, method string) string {
 	return path + "/" + interfaceName + "." + method
-}
-
-func init() {
-	dbusAPI = &dbusAPILibGio{
-		MethodCallCallbacks: make(map[string]MethodCallCallback),
-	}
 }

--- a/dbus/dbus_libgio_helpers.go
+++ b/dbus/dbus_libgio_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 // Based on: https://github.com/gotk3/gotk3/blob/v0.5.0/gio/utils.go
 

--- a/dbus/dbus_libgio_test.go
+++ b/dbus/dbus_libgio_test.go
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 package dbus
 

--- a/dbus/dbus_test.go
+++ b/dbus/dbus_test.go
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 package dbus
 
@@ -24,8 +23,6 @@ import (
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // We need to start our own DBus server to avoid the need for a session DBus
@@ -79,10 +76,4 @@ func TestMain(m *testing.M) {
 	defer os.Setenv("DBUS_SESSION_BUS_ADDRESS", oldEnv)
 
 	m.Run()
-}
-
-func TestGetDBusAPI(t *testing.T) {
-	api, err := GetDBusAPI()
-	assert.NoError(t, err)
-	assert.NotNil(t, api)
 }

--- a/dbus/error.go
+++ b/dbus/error.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 package dbus
 

--- a/dbus/error_test.go
+++ b/dbus/error_test.go
@@ -11,7 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nodbus,cgo
 
 package dbus
 


### PR DESCRIPTION
Clients from now on will be relying on a separate authentication
manager on the D-Bus.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
