### PR TITLE
Remove `PerformsFullUpdate` from `rootfs-image-v2` module.

### DIFF
--- a/tests/rootfs-image-v2
+++ b/tests/rootfs-image-v2
@@ -57,10 +57,6 @@ bootcount 0
 EOF
         ;;
 
-    PerformsFullUpdate)
-        echo "Yes"
-        ;;
-
     NeedsArtifactReboot)
         echo "Automatic"
         ;;


### PR DESCRIPTION
This was deprecated a long time ago in 7887b55224713, so make sure
it's not copied into new modules.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
