### PR TITLE
3.0.x: Fix crash when device has no Provides and artifact has Depends info.

### DIFF
--- a/app/mender.go
+++ b/app/mender.go
@@ -638,7 +638,7 @@ func (m *Mender) CheckScriptsCompatibility() error {
 	return m.stateScriptExecutor.CheckRootfsScriptsVersion()
 }
 
-func verifyAndSetArtifactNameInProvides(provides map[string]string, getArtifactName func() (string, error)) error {
+func verifyAndSetArtifactNameInProvides(provides map[string]string, getArtifactName func() (string, error)) (map[string]string, error) {
 	if _, ok := provides["artifact_name"]; !ok {
 		artifactName, err := getArtifactName()
 		if err != nil || artifactName == "" {
@@ -646,9 +646,12 @@ func verifyAndSetArtifactNameInProvides(provides map[string]string, getArtifactN
 			if err == nil {
 				err = errors.New("artifact name is empty")
 			}
-			return err
+			return provides, err
+		}
+		if provides == nil {
+			provides = make(map[string]string)
 		}
 		provides["artifact_name"] = artifactName
 	}
-	return nil
+	return provides, nil
 }

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -149,7 +149,7 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 		if err != nil {
 			return nil, err
 		}
-		if err = verifyAndSetArtifactNameInProvides(currentProvides, device.GetCurrentArtifactName); err != nil {
+		if currentProvides, err = verifyAndSetArtifactNameInProvides(currentProvides, device.GetCurrentArtifactName); err != nil {
 			log.Error(err.Error())
 			return nil, err
 		}

--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -321,20 +321,32 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		ArtifactScriptsPath: tmpdir,
 	}
 
+	testDevMgr := getTestDeviceManager(fakeDev, &config, deviceType, dbdir)
+
 	// First check that unmet dependencies returns an error, and add
 	// one dependency at the time untill the artifact should be accepted.
-	testDevMgr := getTestDeviceManager(fakeDev, &config, deviceType, dbdir)
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
 		nil, dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
+	// Try with existing, but null typeInfoProvides.
+	testDevMgr.Store.WriteAll(
+		datastore.ArtifactTypeInfoProvidesKey, []byte("null"))
+	err = DoStandaloneInstall(testDevMgr,
+		imageFileName, client.Config{},
+		nil, dev.NewStateScriptExecutor(&config), false)
+	assert.Error(t, err)
+
+	// Try with artifact_name inserted.
 	testDevMgr.Store.WriteAll(datastore.ArtifactNameKey,
 		[]byte("OldArtifact"))
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
 		nil, dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
+
+	// Try with artifact_group inserted.
 	testDevMgr.Store.WriteAll(datastore.ArtifactGroupKey,
 		[]byte("testGroup"))
 	err = DoStandaloneInstall(testDevMgr,
@@ -342,6 +354,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		nil, dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
+	// Try with typeInfoProvides inserted.
 	typeProvidesBuf, err := json.Marshal(typeInfoDepends)
 	assert.NoError(t, err)
 	testDevMgr.Store.WriteAll(

--- a/app/state.go
+++ b/app/state.go
@@ -895,7 +895,7 @@ func (u *updateStoreState) maybeVerifyArtifactDependsAndProvides(
 			log.Error(err.Error())
 			return err
 		}
-		if err = verifyAndSetArtifactNameInProvides(provides, c.GetCurrentArtifactName); err != nil {
+		if provides, err = verifyAndSetArtifactNameInProvides(provides, c.GetCurrentArtifactName); err != nil {
 			log.Error(err.Error())
 			return err
 		}


### PR DESCRIPTION
The circumstances triggering this bug are a bit specific. There needs
to be an available artifact_name, either through the database or
through `/etc/mender/artifact_info`, the artifact must come with
"Depends" fields, and the `artifact-provides` key in the database must
exist, but contain a null value. I have not figured out the exact
steps which lead to such an `artifact_provides` value, I only know
that it must be at least somewhat rare, since we have not seen in our
tests at all. However, one of our users came across it as described in
the linked ticket. In the tests I have recreated the circumstances
artificially, since it is in any case a valid database entry.

In the described circumstances, the `provide` map is nil, but since
114df81b8bcd5, we always add artifact_name to the map, so we need to
create the map if it's nil.

Fixes MEN-5073.

Changelog: None
No changelog, since this was never released in any version.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 532374ba5345c9e4c901eaacfb119dacb641c3f0)
