### PR TITLE
style: sort the imports by global, external and local

### DIFF
--- a/app/client_closures.go
+++ b/app/client_closures.go
@@ -15,9 +15,10 @@
 package app
 
 import (
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
-	log "github.com/sirupsen/logrus"
 )
 
 // see client.go: ApiRequest.Do()

--- a/app/deployment_logger.go
+++ b/app/deployment_logger.go
@@ -26,8 +26,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/mendersoftware/mender/conf"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/mender/conf"
 )
 
 // error messages

--- a/app/standalone.go
+++ b/app/standalone.go
@@ -22,6 +22,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/datastore"
@@ -30,8 +33,6 @@ import (
 	"github.com/mendersoftware/mender/statescript"
 	"github.com/mendersoftware/mender/store"
 	"github.com/mendersoftware/mender/utils"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
@@ -32,8 +35,6 @@ import (
 	"github.com/mendersoftware/mender/statescript"
 	"github.com/mendersoftware/mender/store"
 	"github.com/mendersoftware/mender/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func getTestDeviceManager(dualRootfsDevice installer.DualRootfsDevice,

--- a/app/transition.go
+++ b/app/transition.go
@@ -16,10 +16,11 @@ package app
 import (
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/statescript"
 	"github.com/mendersoftware/mender/store"
-	"github.com/pkg/errors"
 )
 
 type Transition int

--- a/app/transition_test.go
+++ b/app/transition_test.go
@@ -20,12 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/datastore"
 	"github.com/mendersoftware/mender/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testState struct {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -30,6 +30,11 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
@@ -39,10 +44,6 @@ import (
 	"github.com/mendersoftware/mender/store"
 	"github.com/mendersoftware/mender/system"
 	stest "github.com/mendersoftware/mender/system/testing"
-	log "github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const defaultKeyPassphrase = ""

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"syscall"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
@@ -33,7 +35,6 @@ import (
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/store"
 	"github.com/mendersoftware/mender/system"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -27,11 +27,12 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/device"
 	"github.com/mendersoftware/mender/system"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"

--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -25,9 +25,10 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/system"
 	"github.com/mendersoftware/mender/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -21,8 +21,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mendersoftware/openssl"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/openssl"
 )
 
 type testAuthDataMessenger struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,9 +28,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mendersoftware/openssl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/openssl"
 )
 
 func dummy_reauthfunc(str string) (AuthToken, error) {

--- a/client/test/server.go
+++ b/client/test/server.go
@@ -26,10 +26,11 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/app/updatecontrolmap"
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/datastore"
-	log "github.com/sirupsen/logrus"
 )
 
 type updateType struct {

--- a/client/update_resumer.go
+++ b/client/update_resumer.go
@@ -16,14 +16,15 @@ package client
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type UpdateResumer struct {

--- a/client/update_resumer_test.go
+++ b/client/update_resumer_test.go
@@ -16,7 +16,6 @@ package client
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -25,6 +24,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testHandler struct {

--- a/conf/config.go
+++ b/conf/config.go
@@ -19,11 +19,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/dbus"
 	"github.com/mendersoftware/mender/installer"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -21,9 +21,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mendersoftware/mender/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender/client"
 )
 
 var testConfig = `{

--- a/conf/version_test.go
+++ b/conf/version_test.go
@@ -14,8 +14,9 @@
 package conf
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionUnknown(t *testing.T) {

--- a/device/device.go
+++ b/device/device.go
@@ -20,13 +20,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/datastore"
 	"github.com/mendersoftware/mender/installer"
 	"github.com/mendersoftware/mender/statescript"
 	"github.com/mendersoftware/mender/store"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type DeviceManager struct {

--- a/device/identity_data.go
+++ b/device/identity_data.go
@@ -17,10 +17,11 @@ import (
 	"encoding/json"
 	"path"
 
+	"github.com/pkg/errors"
+
 	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/system"
 	"github.com/mendersoftware/mender/utils"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/device/identity_data_test.go
+++ b/device/identity_data_test.go
@@ -17,8 +17,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	stest "github.com/mendersoftware/mender/system/testing"
 	"github.com/stretchr/testify/assert"
+
+	stest "github.com/mendersoftware/mender/system/testing"
 )
 
 func TestDeviceIdentityGet(t *testing.T) {

--- a/installer/block_device.go
+++ b/installer/block_device.go
@@ -20,10 +20,11 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/mendersoftware/mender/system"
-	"github.com/mendersoftware/mender/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/mender/system"
+	"github.com/mendersoftware/mender/utils"
 )
 
 var (

--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -21,9 +21,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/mender/system"
 )
 
 const (

--- a/installer/bootenv_test.go
+++ b/installer/bootenv_test.go
@@ -17,9 +17,10 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mendersoftware/mender/system"
 	stest "github.com/mendersoftware/mender/system/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 //if no config file is present

--- a/installer/dual_rootfs_device.go
+++ b/installer/dual_rootfs_device.go
@@ -21,11 +21,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/mendersoftware/mender/system"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	stest "github.com/mendersoftware/mender/system/testing"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+
+	stest "github.com/mendersoftware/mender/system/testing"
 )
 
 // implements BootEnvReadWriter

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -19,12 +19,13 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender-artifact/areader"
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/mendersoftware/mender/statescript"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type Rebooter interface {

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -21,12 +21,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mendersoftware/mender-artifact/artifact"
-	"github.com/mendersoftware/mender-artifact/awriter"
-	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/awriter"
+	"github.com/mendersoftware/mender-artifact/handlers"
 )
 
 func TestInstall(t *testing.T) {

--- a/installer/modules.go
+++ b/installer/modules.go
@@ -27,11 +27,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/mendersoftware/mender/system"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type ModuleInstaller struct {

--- a/installer/modules_test.go
+++ b/installer/modules_test.go
@@ -28,11 +28,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mendersoftware/mender-artifact/artifact"
-	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender/system"
 )
 
 type testStreamsTreeInfo struct {

--- a/installer/partitions.go
+++ b/installer/partitions.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/mender/system"
 )
 
 var (

--- a/installer/partitions_test.go
+++ b/installer/partitions_test.go
@@ -23,10 +23,11 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/mendersoftware/mender/system"
-	stest "github.com/mendersoftware/mender/system/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender/system"
+	stest "github.com/mendersoftware/mender/system/testing"
 )
 
 func Test_GetInactive_HaveActivePartitionSet_ReturnsInactive(t *testing.T) {

--- a/installer/stub_installer.go
+++ b/installer/stub_installer.go
@@ -18,11 +18,12 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/mendersoftware/mender/system"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 // A stub installer that fails nearly every step. For use as a stub when we

--- a/inventory/inventory_data.go
+++ b/inventory/inventory_data.go
@@ -20,11 +20,12 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/client"
 	"github.com/mendersoftware/mender/system"
 	"github.com/mendersoftware/mender/utils"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/inventory/inventory_data_test.go
+++ b/inventory/inventory_data_test.go
@@ -16,8 +16,9 @@ package inventory
 import (
 	"testing"
 
-	"github.com/mendersoftware/mender/client"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/mender/client"
 )
 
 func TestInventoryDataDecoder(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -19,10 +19,11 @@ import (
 	"os/signal"
 	"syscall"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mendersoftware/mender/app"
 	"github.com/mendersoftware/mender/cli"
 	"github.com/mendersoftware/mender/installer"
-	log "github.com/sirupsen/logrus"
 )
 
 var termSignalChan = make(chan os.Signal, 1)

--- a/statescript/executor.go
+++ b/statescript/executor.go
@@ -26,10 +26,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mendersoftware/mender/client"
-	"github.com/mendersoftware/mender/system"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/mender/client"
+	"github.com/mendersoftware/mender/system"
 )
 
 const (

--- a/statescript/statescript_test.go
+++ b/statescript/statescript_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mendersoftware/mender/client"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender/client"
 )
 
 func TestStore(t *testing.T) {

--- a/store/keystore.go
+++ b/store/keystore.go
@@ -19,9 +19,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mendersoftware/openssl"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/mendersoftware/openssl"
 )
 
 const (

--- a/store/keystore_test.go
+++ b/store/keystore_test.go
@@ -20,10 +20,12 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"github.com/mendersoftware/openssl"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/openssl"
 )
 
 const (

--- a/tests/common_test_modules.go
+++ b/tests/common_test_modules.go
@@ -23,10 +23,11 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/mendersoftware/mender-artifact/handlers"
-	"github.com/stretchr/testify/require"
 )
 
 const (


### PR DESCRIPTION
Ran goimports -local=github.com/mendersoftware, to sort the imports properly.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


