### PR TITLE
Resolv symlink /dev/root while getting active partition

### DIFF
--- a/installer/partitions.go
+++ b/installer/partitions.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -170,6 +170,9 @@ func (p *partitions) getAndCacheActivePartition(rootChecker func(system.StatComm
 
 	// First check if mountCandidate matches rootDevice
 	if mountCandidate != "" {
+		// Resolve link if /dev/root
+		mountCandidate = maybeResolveLink(mountCandidate)
+
 		if rootChecker(p, mountCandidate, rootDevice) {
 			p.active = mountCandidate
 			log.Debugf("Setting active partition from mount candidate: %s", p.active)
@@ -241,8 +244,8 @@ func maybeResolveLink(unresolvedPath string) string {
 		return unresolvedPath
 	}
 	// MEN-2302
-	// Only resolve /dev/disk/by-partuuid/
-	if path.Dir(unresolvedPath) == "/dev/disk/by-partuuid" {
+	// Only resolve /dev/disk/by-partuuid/ and /dev/root
+	if unresolvedPath == "/dev/root" || path.Dir(unresolvedPath) == "/dev/disk/by-partuuid" {
 		return resolvedPath
 	}
 	return unresolvedPath


### PR DESCRIPTION
Changelog: Fix error not finding active partition for systems where /dev/root is a symlink

Signed-off-by: Jesus <wjaxxx@gmail.com>

### Description

Fix an error where mender is not able to match the returned mount device with RootfsA or B. This happens in systems where /dev/root is a symlink to the actual partition
