### PR TITLE
pipeline: misc improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include:
 
 test:
   stage: test
-  image: golang:1.16
+  image: golang:1.17
   before_script:
     - apt-get update && apt-get install -yyq liblzma-dev libssl-dev libglib2.0-dev dbus clang-format-9
     - make get-tools
@@ -58,7 +58,7 @@ test:docker:
 
 publish:tests:
   stage: publish
-  image: golang:1.16-alpine3.14
+  image: golang:1.17-alpine3.14
   dependencies:
     - test
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,10 +18,8 @@ test:
   before_script:
     - apt-get update && apt-get install -yyq liblzma-dev libssl-dev libglib2.0-dev dbus clang-format-9
     - make get-tools
-    - go install gotest.tools/gotestsum@latest
   script:
     - git ls-tree -r --name-only HEAD | grep -v vendor/ | grep '\.[ch]$' | xargs clang-format-9 -i
-    - gotestsum --junitfile report.xml --format testname # Report unit tests
     - make extracheck
     - make coverage
     - make

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//go:build !local
 // +build !local
 
 package conf

--- a/conf/paths_local.go
+++ b/conf/paths_local.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//go:build local
 // +build local
 
 package conf

--- a/dbus/dbus_libgio.go
+++ b/dbus/dbus_libgio.go
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 package dbus

--- a/dbus/dbus_libgio_helpers.go
+++ b/dbus/dbus_libgio_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 // Based on: https://github.com/gotk3/gotk3/blob/v0.5.0/gio/utils.go

--- a/dbus/dbus_libgio_test.go
+++ b/dbus/dbus_libgio_test.go
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 package dbus

--- a/dbus/dbus_test.go
+++ b/dbus/dbus_test.go
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 package dbus

--- a/dbus/error.go
+++ b/dbus/error.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 package dbus

--- a/dbus/error_test.go
+++ b/dbus/error_test.go
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+//go:build !nodbus && cgo
 // +build !nodbus,cgo
 
 package dbus

--- a/system/ioctl_linux.go
+++ b/system/ioctl_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package system

--- a/system/ioctl_test.go
+++ b/system/ioctl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package system


### PR DESCRIPTION
* Makefile: extend coverage target to generate junit results
    And clean-up the pipeline to not run unit tests twice
* pipeline: Switch to golang 1.17
    This only affects unit tests, static checks, etc. The actual building of
    the binary happens either in meta-mender or mender-dist-packages, which
    might have different golang versions.
    
