### PR TITLE
pipeline: deactivate child pipelines when running on schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,9 @@ generate-qa-trigger:
   extends: .qa-trigger-template
   image: python:alpine
   stage: trigger_prep
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
   before_script:
     - apk add --no-cache git
     - pip3 install pyyaml
@@ -108,6 +111,9 @@ generate-qa-trigger:
 trigger:mender-qa:
   extends: .qa-trigger-template
   stage: trigger
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
   trigger:
     include:
       - artifact: gitlab-ci-client-qemu-publish-job.yml
@@ -130,6 +136,8 @@ trigger:mender-dist-packages:
       https://gitlab.com/api/v4/projects/14968223/trigger/pipeline
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
 
 trigger:mender-docs-site:
   image: alpine
@@ -149,11 +157,15 @@ trigger:mender-docs-site:
     - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
       changes:
       - Documentation/*
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
 
 trigger:integration:
   stage: trigger
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
   trigger:
     project: Northern.tech/Mender/integration
     branch: master


### PR DESCRIPTION
For weekly scheduled builds, we don't want to trigger child pipelines
that just flood our CI infra. Specially for mender-dist-packages, where
each pipeline builds/tests/publishes all packages.