### PR TITLE
[Cherry 3.1.x] MEN-4881

### DIFF
--- a/app/daemon_test.go
+++ b/app/daemon_test.go
@@ -34,16 +34,20 @@ import (
 )
 
 type FakeDevice struct {
-	RetReboot      error
-	RetStoreUpdate error
-	RetEnablePart  error
-	RetCommit      error
-	RetRollback    error
-	RetHasUpdate   bool
-	ConsumeUpdate  bool
+	RetReboot              error
+	RetStoreUpdate         error
+	RetEnablePart          error
+	RetCommit              error
+	RetRollback            error
+	RetHasUpdate           bool
+	ConsumeUpdate          bool
+	NeedsRebootReturnValue *installer.RebootAction
 }
 
 func (f FakeDevice) NeedsReboot() (installer.RebootAction, error) {
+	if f.NeedsRebootReturnValue != nil {
+		return *f.NeedsRebootReturnValue, nil
+	}
 	return installer.RebootRequired, nil
 }
 

--- a/app/state.go
+++ b/app/state.go
@@ -1651,7 +1651,7 @@ type updateRollbackState struct {
 	*updateState
 }
 
-func NewUpdateRollbackState(update *datastore.UpdateInfo) State {
+func NewUpdateRollbackState(update *datastore.UpdateInfo) *updateRollbackState {
 	return &updateRollbackState{
 		updateState: NewUpdateState(datastore.MenderStateRollback, ToArtifactRollback, update),
 	}
@@ -1673,6 +1673,11 @@ func (rs *updateRollbackState) Handle(ctx *StateContext, c Controller) (State, b
 			return rs.HandleError(ctx, c, NewFatalError(err))
 		}
 	}
+
+	// Query the rollback parameter from the Update Module, in case it has
+	// not been called previously (MEN-4882)
+	rs.queryUpdateModuleReboot(c)
+
 	for n := range c.GetInstallers() {
 		rebootRequested, err := rs.Update().RebootRequested.Get(n)
 		if err != nil {
@@ -1700,6 +1705,46 @@ func (rs *updateRollbackState) Handle(ctx *StateContext, c Controller) (State, b
 	// if no reboot is needed, just return the error and start over
 	return NewUpdateErrorState(NewTransientError(errors.New("update error")),
 		rs.Update()), false
+}
+
+func (rs *updateRollbackState) queryUpdateModuleReboot(c Controller) {
+	for n, i := range c.GetInstallers() {
+		v, err := rs.Update().RebootRequested.Get(n)
+		if err != nil {
+			log.Debugf(
+				"Failed to query the database for the Update Module's"+
+					" ArtifactRollback parameter during updateRollbackState: %s."+
+					"Will query the update module anew.",
+				err.Error())
+		}
+		switch v {
+		// If the value is 'RebootRequested', or 'RebootTypeAutomatic',
+		// do not risk writing a 'RebootTypeNone', reboot in any case
+		case datastore.RebootTypeAutomatic, datastore.RebootTypeCustom:
+			continue
+		default:
+			needsReboot, err := i.NeedsReboot()
+			if err != nil {
+				log.Error(err.Error())
+				continue
+			}
+			switch needsReboot {
+			case installer.NoReboot:
+				err = rs.Update().RebootRequested.Set(n, datastore.RebootTypeNone)
+			case installer.RebootRequired:
+				err = rs.Update().RebootRequested.Set(n, datastore.RebootTypeCustom)
+			case installer.AutomaticReboot:
+				err = rs.Update().RebootRequested.Set(n, datastore.RebootTypeAutomatic)
+			default:
+				log.Error("Unknown reboot value returned from Update Module")
+			}
+			if err != nil {
+				log.Errorf(
+					"Unable to set the value returned from the update module in the database. Error: %s",
+					err.Error())
+			}
+		}
+	}
 }
 
 func (rs *updateRollbackState) HandleError(ctx *StateContext, c Controller, merr menderError) (State, bool) {


### PR DESCRIPTION
Changelog: Title if the update module has not already requested a reboot. This
is done, in the case that ArtifactInstall never finished, and hence the reboot
information from the update module is never collected.
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit ca2ac13)