### PR TITLE
MEN-5273: proxy: Fix websocket connection for advanced auth settings

### DIFF
--- a/app/proxy/proxy_ws.go
+++ b/app/proxy/proxy_ws.go
@@ -84,7 +84,7 @@ func (pc *proxyControllerInner) DoWsUpgrade(w http.ResponseWriter, r *http.Reque
 
 	connBackend, resp, err := pc.wsDialer.Dial(wsUrl.String(), requestHeader)
 	if err != nil {
-		log.Errorf("couldn't dial to remote backend url %s", err)
+		log.Errorf("couldn't dial to remote backend url %q, err: %s", wsUrl.String(), err.Error())
 		if resp != nil {
 			// WebSocket handshake failed, reply the client with backend's resp
 			if err := copyResponse(w, resp); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -489,8 +489,7 @@ func loadClientTrust(ctx *openssl.Ctx, conf *Config) (*openssl.Ctx, error) {
 	return ctx, nil
 }
 
-func dialOpenSSL(ctx *openssl.Ctx, conf *Config, network string, addr string) (net.Conn, error) {
-
+func dialOpenSSL(ctx *openssl.Ctx, conf *Config, _ string, addr string) (net.Conn, error) {
 	flags := openssl.DialFlags(0)
 
 	if conf.NoVerify {
@@ -694,7 +693,7 @@ func newWebsocketDialerTLS(conf Config) (*websocket.Dialer, error) {
 	}
 
 	dialer := websocket.Dialer{
-		NetDial: func(network string, addr string) (net.Conn, error) {
+		NetDialTLS: func(network string, addr string) (net.Conn, error) {
 			return dialOpenSSL(ctx, &conf, network, addr)
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 )
 
 replace github.com/urfave/cli/v2 => github.com/mendersoftware/cli/v2 v2.1.1-minimal
+
+replace github.com/gorilla/websocket => github.com/mendersoftware/websocket v1.4.3-0.20211210145825-8a45e5d03918

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqjewrc=
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
@@ -34,6 +32,8 @@ github.com/mendersoftware/openssl v1.1.0 h1:eRiG3CwzkMIna1xrTE9SiX9lrsme9irlb6i5
 github.com/mendersoftware/openssl v1.1.0/go.mod h1:tikEC94q+Y0TU6r19L6mHzwruoTNYPEkrQPvsHEcQyU=
 github.com/mendersoftware/progressbar v0.0.3 h1:AUdBGPvXO0l9i39rmXKZbEAPet2FzBeiG8b30D5/2Vc=
 github.com/mendersoftware/progressbar v0.0.3/go.mod h1:NYaLNLhy3UXkRweGjhR3We3Q1ngmUmOWjC3+m8EzwjE=
+github.com/mendersoftware/websocket v1.4.3-0.20211210145825-8a45e5d03918 h1:bxs2j1011PQiBPAP127cmBdAnw+zzq65tWOUeCFxVXU=
+github.com/mendersoftware/websocket v1.4.3-0.20211210145825-8a45e5d03918/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/vendor/github.com/gorilla/websocket/client_clone.go
+++ b/vendor/github.com/gorilla/websocket/client_clone.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.8
 // +build go1.8
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/client_clone_legacy.go
+++ b/vendor/github.com/gorilla/websocket/client_clone_legacy.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.8
 // +build !go1.8
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/conn_write.go
+++ b/vendor/github.com/gorilla/websocket/conn_write.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.8
 // +build go1.8
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/conn_write_legacy.go
+++ b/vendor/github.com/gorilla/websocket/conn_write_legacy.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.8
 // +build !go1.8
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/mask.go
+++ b/vendor/github.com/gorilla/websocket/mask.go
@@ -2,6 +2,7 @@
 // this source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/mask_safe.go
+++ b/vendor/github.com/gorilla/websocket/mask_safe.go
@@ -2,6 +2,7 @@
 // this source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/server.go
+++ b/vendor/github.com/gorilla/websocket/server.go
@@ -115,8 +115,8 @@ func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header
 // Upgrade upgrades the HTTP server connection to the WebSocket protocol.
 //
 // The responseHeader is included in the response to the client's upgrade
-// request. Use the responseHeader to specify cookies (Set-Cookie) and the
-// application negotiated subprotocol (Sec-WebSocket-Protocol).
+// request. Use the responseHeader to specify cookies (Set-Cookie). To specify
+// subprotocols supported by the server, set Upgrader.Subprotocols directly.
 //
 // If the upgrade fails, then Upgrade replies to the client with an HTTP error
 // response.

--- a/vendor/github.com/gorilla/websocket/trace.go
+++ b/vendor/github.com/gorilla/websocket/trace.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package websocket

--- a/vendor/github.com/gorilla/websocket/trace_17.go
+++ b/vendor/github.com/gorilla/websocket/trace_17.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package websocket

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/davecgh/go-spew/spew
 # github.com/godbus/dbus v4.1.0+incompatible
 ## explicit
 github.com/godbus/dbus
-# github.com/gorilla/websocket v1.4.2
+# github.com/gorilla/websocket v1.4.2 => github.com/mendersoftware/websocket v1.4.3-0.20211210145825-8a45e5d03918
 ## explicit
 github.com/gorilla/websocket
 # github.com/klauspost/compress v1.10.5
@@ -74,3 +74,4 @@ golang.org/x/term
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3
 # github.com/urfave/cli/v2 => github.com/mendersoftware/cli/v2 v2.1.1-minimal
+# github.com/gorilla/websocket => github.com/mendersoftware/websocket v1.4.3-0.20211210145825-8a45e5d03918


### PR DESCRIPTION
By switching to the "enhanced" API for websocket.Dialer from
mendersoftware's fork.

There is a limitation in current gorilla/websocket.Dialer API in that
the user cannot specify a dial method for TLS/TCP connections. The TLS
handshake is always done by the library based on user's TLSClientConfig,
but that is not enough for Mender as we need it to be done via OpenSSL
(aka our dial wrapper for TLS) so that advance auth features like
getting the keys from HSM.

This commit switches to mendersoftware's fork and modifies the code
accordingly (one line change!).

The patch has been submitted upstream. See:
* https://github.com/gorilla/websocket/issues/745
* https://github.com/gorilla/websocket/pull/746

Changelog: None
No changelog, commit 84204a3 claims to support websockets, this commit
just fixes a bug there which has not been released.