### PR TITLE
test: Unit test fails under heavy load.

### DIFF
--- a/app/auth_test.go
+++ b/app/auth_test.go
@@ -570,6 +570,6 @@ func TestAuthManagerFinalizer(t *testing.T) {
 
 	runtime.GC()
 	// Give the Go routine a little bit of cleanup time.
-	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, runtime.NumGoroutine(), goRoutines)
+	time.Sleep(400 * time.Millisecond)
+	assert.Equal(t, goRoutines, runtime.NumGoroutine())
 }


### PR DESCRIPTION
Therefore give it a bit more time, but shorter intervals should keep the
responsivity of this at a level equal to or better than already existing.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


