### PR TITLE
MEN-5340: Fix incorrect logic if `reboot` is killed before the client.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Northern.tech AS
+Copyright 2022 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,5 +1,5 @@
 # Apache-2.0 license.
-b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  LICENSE
+1033348db7606a7e61b6484f293847cf8d7a35766efebb97e304d4bd5d7f3f6b  LICENSE
 b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  vendor/github.com/mendersoftware/mender-artifact/LICENSE
 73ba74dfaa520b49a401b5d21459a8523a146f3b7518a833eea5efa85130bf68  vendor/github.com/mendersoftware/openssl/LICENSE
 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  vendor/github.com/minio/sha256-simd/LICENSE

--- a/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
+++ b/patches/0001-Instrument-Mender-client-for-coverage-analysis.patch
@@ -1,18 +1,18 @@
-From 10eeda6a93a13b3a96c7fc2a6e4f6b4eb4690458 Mon Sep 17 00:00:00 2001
+From 4b5cf8ce62086b028811617080af6689507b0334 Mon Sep 17 00:00:00 2001
 From: Lluis Campos <lluis.campos@northern.tech>
 Date: Tue, 30 Nov 2021 19:40:35 +0100
-Subject: [PATCH] Instrument mender binary
+Subject: [PATCH 1/1] Instrument mender binary
 
 Changelog: None
 
 Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
 ---
  main.go          | 39 ++++++++++++++++++++++++++++++++++++++-
- system/system.go | 13 +------------
- 2 files changed, 39 insertions(+), 13 deletions(-)
+ system/system.go | 21 +--------------------
+ 2 files changed, 39 insertions(+), 21 deletions(-)
 
 diff --git a/main.go b/main.go
-index 23a6f614..1195d3ab 100644
+index 23a6f61..1195d3a 100644
 --- a/main.go
 +++ b/main.go
 @@ -18,6 +18,8 @@ import (
@@ -74,7 +74,7 @@ index 23a6f614..1195d3ab 100644
 +
  }
 diff --git a/system/system.go b/system/system.go
-index 969275ee..c4bb61c1 100644
+index cc67a01..c4bb61c 100644
 --- a/system/system.go
 +++ b/system/system.go
 @@ -19,9 +19,7 @@ import (
@@ -87,18 +87,26 @@ index 969275ee..c4bb61c1 100644
  	log "github.com/sirupsen/logrus"
  )
  
-@@ -36,16 +34,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
+@@ -36,24 +34,7 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
  }
  
  func (s *SystemRebootCmd) Reboot() error {
 -	err := s.command.Command("reboot").Run()
+-
+-	// *Any* return from this function is an error.
+-
 -	if err != nil {
+-		// MEN-5340: If there's an error, it may be because systemd is
+-		// in the process of shutting down our service, and happens to
+-		// kill `reboot` first. Give it a few seconds to follow up with
+-		// killing the client.
+-		time.Sleep(10 * time.Second)
 -		return err
 -	}
 -
 -	// Wait up to ten minutes for reboot to kill the client, otherwise the
 -	// client may mistake a successful return code as "reboot is complete,
--	// continue". *Any* return from this function is an error.
+-	// continue".
 -	time.Sleep(10 * time.Minute)
 -	return errors.New("System did not reboot, even though 'reboot' call succeeded.")
 +	panic("Client needs reboot!")
@@ -106,5 +114,5 @@ index 969275ee..c4bb61c1 100644
  
  type Commander interface {
 -- 
-2.30.2
+2.17.1
 

--- a/system/system.go
+++ b/system/system.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,13 +37,21 @@ func NewSystemRebootCmd(command Commander) *SystemRebootCmd {
 
 func (s *SystemRebootCmd) Reboot() error {
 	err := s.command.Command("reboot").Run()
+
+	// *Any* return from this function is an error.
+
 	if err != nil {
+		// MEN-5340: If there's an error, it may be because systemd is
+		// in the process of shutting down our service, and happens to
+		// kill `reboot` first. Give it a few seconds to follow up with
+		// killing the client.
+		time.Sleep(10 * time.Second)
 		return err
 	}
 
 	// Wait up to ten minutes for reboot to kill the client, otherwise the
 	// client may mistake a successful return code as "reboot is complete,
-	// continue". *Any* return from this function is an error.
+	// continue".
 	time.Sleep(10 * time.Minute)
 	return errors.New("System did not reboot, even though 'reboot' call succeeded.")
 }


### PR DESCRIPTION
Changelog: Fix a race condition which can happen during a reboot if
systemd kills the `reboot` command before it kills the Mender client.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
