### PR TITLE
Set Mender client's umask to `0077` in the systemd service

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -10,6 +10,7 @@ User=root
 Group=root
 ExecStart=/usr/bin/mender daemon
 Restart=on-abort
+UMask=0077
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Mender client does not explicitly change permissions of files and
directories created when processing artifacts. With this change, we
ensure that all the temporary files and directories created by the
Mender client will be readable by the root user only.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>