### PR TITLE
3.1.x: Update mender-artifact library to latest 3.6.x

### DIFF
--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 # Apache-2.0 license.
 1033348db7606a7e61b6484f293847cf8d7a35766efebb97e304d4bd5d7f3f6b  LICENSE
-32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99  vendor/github.com/mendersoftware/mender-artifact/LICENSE
+b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  vendor/github.com/mendersoftware/mender-artifact/LICENSE
 73ba74dfaa520b49a401b5d21459a8523a146f3b7518a833eea5efa85130bf68  vendor/github.com/mendersoftware/openssl/LICENSE
 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  vendor/github.com/minio/sha256-simd/LICENSE
 8f5d89b47d7a05a199b77b7e0f362dad391d451ebda4ef48ba11c50c071564c7  vendor/github.com/mendersoftware/progressbar/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/mendersoftware/mender-artifact v0.0.0-20201109124241-8c0fc025ea52
 	github.com/mendersoftware/openssl v1.1.0
 	github.com/mendersoftware/progressbar v0.0.3
-	github.com/minio/sha256-simd v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/remyoudompheng/go-liblzma v0.0.0-20190506200333-81bf2d431b96 // indirect
 	github.com/sirupsen/logrus v1.4.3-0.20200306102446-7ea96a3284ed

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/bmatsuo/lmdb-go v1.6.1-0.20160816100615-69ad631904c9
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/godbus/dbus v4.1.0+incompatible
-	github.com/mendersoftware/mender-artifact v0.0.0-20201109124241-8c0fc025ea52
+	github.com/mendersoftware/mender-artifact v0.0.0-20210927105858-af2a3e3fb006
+	github.com/mendersoftware/mendertesting v0.0.1 // indirect
 	github.com/mendersoftware/openssl v1.1.0
 	github.com/mendersoftware/progressbar v0.0.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/mendersoftware/cli/v2 v2.1.1-minimal h1:NWX83kF8Eobfb3oBWeUmw9Ef2H9Zq
 github.com/mendersoftware/cli/v2 v2.1.1-minimal/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/mendersoftware/mender-artifact v0.0.0-20201109124241-8c0fc025ea52 h1:AuDunjmWENdTSLS3QgHWoap/LvOeXz1ZUxgJ8XRFaXo=
 github.com/mendersoftware/mender-artifact v0.0.0-20201109124241-8c0fc025ea52/go.mod h1:0WP2ZiHCDj6A88zCHjbSx4F6tKZ+RxUo+EHgnl+v6PM=
+github.com/mendersoftware/mender-artifact v0.0.0-20210927105858-af2a3e3fb006 h1:wp1XG6yTYh42gNQl+z65aa7vnqGL2JL5CJ7ekUw2nA4=
+github.com/mendersoftware/mender-artifact v0.0.0-20210927105858-af2a3e3fb006/go.mod h1:K2ee/Breld8qcB9JtHv/G3v9gdrDEbeJLLEPv25mSb4=
 github.com/mendersoftware/mendertesting v0.0.1/go.mod h1:WZyiX1zeljfyFaTjmbR84+wHjzmPDLDvOdRHZnnLM/0=
 github.com/mendersoftware/openssl v1.1.0 h1:eRiG3CwzkMIna1xrTE9SiX9lrsme9irlb6i5vvMfU9s=
 github.com/mendersoftware/openssl v1.1.0/go.mod h1:tikEC94q+Y0TU6r19L6mHzwruoTNYPEkrQPvsHEcQyU=
@@ -62,6 +64,8 @@ github.com/ungerik/go-sysfs v0.0.0-20190613143942-7f098ddb67a6 h1:2SY3Pt3iDT6V26
 github.com/ungerik/go-sysfs v0.0.0-20190613143942-7f098ddb67a6/go.mod h1:uNntZOmY9FPCii3WLtdFVh1QQ1qKoB4lpnwVyX3LMjQ=
 github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f h1:kz4KIr+xcPUsI3VMoqWfPMvtnJ6MGfiVwsWSVzphMO4=
 golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/vendor/github.com/mendersoftware/mender-artifact/LICENSE
+++ b/vendor/github.com/mendersoftware/mender-artifact/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 Northern.tech AS
+Copyright 2021 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/vendor/github.com/mendersoftware/mender-artifact/artifact/scripter.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/artifact/scripter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -54,14 +54,14 @@ func (s *Scripts) Add(path string) error {
 	// the second one shold be the name of the state
 	matches := re.FindStringSubmatch(name)
 	if matches == nil || len(matches) < 3 {
-		return errors.Errorf("scripter: invalid script: %s", name)
+		return errors.Errorf("Invalid script name: %q. Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.", name)
 	}
 	if _, found := availableScriptType[matches[1]]; !found {
-		return errors.Errorf("scripter: unsupported script state: %s", matches[1])
+		return errors.Errorf("Unsupported script state: %s", matches[1])
 	}
 
 	if _, exists := s.names[name]; exists {
-		return errors.Errorf("scripter: script already exists: %s", name)
+		return errors.Errorf("Script already exists: %s", name)
 	}
 
 	s.names[name] = path

--- a/vendor/github.com/mendersoftware/mender-artifact/artifact/stage/stage.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/artifact/stage/stage.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package stage
+
+// The stages the Artifact parser/writer is in
+const (
+	Version           = "Version"
+	Manifest          = "Manifest"
+	ManifestSignature = "Manifest signature"
+	ManifestAugment   = "Manifest augment"
+	Header            = "Header"
+	HeaderAugment     = "Header Augment"
+	Data              = "Payload"
+)

--- a/vendor/github.com/mendersoftware/mender-artifact/utils/attributes.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/utils/attributes.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -43,14 +43,14 @@ func StringsMatchingWildcards(attributes, wildcards []string) ([]string, error) 
 						"Expression cannot end with a backslash: \"%s\"",
 						wildcard)
 				}
-				b.WriteString(wildcard[i:i+2])
+				b.WriteString(wildcard[i : i+2])
 				i++
 
 			case '*':
 				b.WriteString(".*")
 
 			default:
-				b.WriteString(regexp.QuoteMeta(wildcard[i:i+1]))
+				b.WriteString(regexp.QuoteMeta(wildcard[i : i+1]))
 			}
 		}
 		b.WriteRune('$')

--- a/vendor/github.com/mendersoftware/mender-artifact/utils/progress.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/utils/progress.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"io"
+
+	"github.com/mendersoftware/progressbar"
+)
+
+type ProgressReader struct {
+	bar *progressbar.Bar
+	io.Reader
+}
+
+func NewProgressReader() *ProgressReader {
+	return &ProgressReader{}
+}
+
+func (p *ProgressReader) Wrap(r io.Reader, size int64) io.Reader {
+	bar := progressbar.New(size)
+	bar.Size = size
+	return &ProgressReader{
+		Reader: r,
+		bar:    bar,
+	}
+}
+
+func (p *ProgressReader) Read(b []byte) (int, error) {
+	n, err := p.Reader.Read(b)
+	p.bar.Tick(int64(n))
+	return n, err
+}
+
+type ProgressWriter struct {
+	bar    *progressbar.Bar
+	Writer io.WriteCloser
+	tot    int
+}
+
+func NewProgressWriter() *ProgressWriter {
+	return &ProgressWriter{}
+}
+
+func (p *ProgressWriter) Wrap(w io.WriteCloser) io.Writer {
+	p.Writer = w
+	return p
+}
+
+func (p *ProgressWriter) Reset(size int64, filename string, payloadNumber int) {
+	p.bar = progressbar.New(size)
+	p.bar.Size = size
+}
+
+func (p *ProgressWriter) Finish() {
+	if p.bar != nil {
+		p.bar.Finish()
+	}
+}
+
+func (p *ProgressWriter) Write(b []byte) (int, error) {
+	n, err := p.Writer.Write(b)
+	p.bar.Tick(int64(n))
+	return n, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,13 +16,16 @@ github.com/klauspost/pgzip
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
-# github.com/mendersoftware/mender-artifact v0.0.0-20201109124241-8c0fc025ea52
+# github.com/mendersoftware/mender-artifact v0.0.0-20210927105858-af2a3e3fb006
 ## explicit
 github.com/mendersoftware/mender-artifact/areader
 github.com/mendersoftware/mender-artifact/artifact
+github.com/mendersoftware/mender-artifact/artifact/stage
 github.com/mendersoftware/mender-artifact/awriter
 github.com/mendersoftware/mender-artifact/handlers
 github.com/mendersoftware/mender-artifact/utils
+# github.com/mendersoftware/mendertesting v0.0.1
+## explicit
 # github.com/mendersoftware/openssl v1.1.0
 ## explicit
 github.com/mendersoftware/openssl
@@ -31,7 +34,6 @@ github.com/mendersoftware/openssl/utils
 ## explicit
 github.com/mendersoftware/progressbar
 # github.com/minio/sha256-simd v0.1.1
-## explicit
 github.com/minio/sha256-simd
 # github.com/pkg/errors v0.9.1
 ## explicit


### PR DESCRIPTION
Mainly to bring:
    * https://github.com/mendersoftware/mender-artifact/commit/cf280f954fdc42dc5ed998fb58b9d43bc2a073ae

Changelog: Bump github.com/mendersoftware/mender-artifact to 3.6.x