### PR TITLE
Add reboot type AutomaticRebootSkipStatusReport for update modules

### DIFF
--- a/Documentation/update-modules-v3-file-api.md
+++ b/Documentation/update-modules-v3-file-api.md
@@ -84,6 +84,12 @@ The module should print one of the valid responses:
   reboot. **This is usually the best choice** for all modules that just require
   a normal reboot, but modules that reboot a peripheral device may need to use
   `Yes` instead, and implement their own method.
+* `AutomaticSkipStatusReport` - Almost identical semantics to `Automatic` - the
+  only difference being that **the mender client will not try to send a status
+  report to the server saying that the device is rebooting before carrying out
+  the reboot.** This response should be used specifically for update modules
+  which are expected to break upstream connectivity such that the client is
+  expected to be unable to report status to the server until after rebooting.
 * `Yes` - Mender will run the update module with the `ArtifactReboot`
   argument. Use this when you want to reboot a peripheral device that's
   connected to the host. Don't use this if you want to reboot the host that
@@ -99,6 +105,11 @@ performed after the `ArtifactReboot` state of all update modules that responded
 responded `Automatic` will always come after one that responded `Yes`, even
 though that may not be the original order in the Artifact.
 
+If any update module returns `AutomaticSkipStatusReport`, **the mender client
+will not try to report update status to the server before rebooting**, even if
+other modules responded with `Yes` or `Automatic`. The semantics are otherwise
+identical to `Automatic`.
+
 Unless all modules responded `No` in the `NeedsArtifactReboot` query, the
 `ArtifactReboot` state executes after `ArtifactInstall`. Inside this state it is
 permitted to call commands that reboot the system. However, if this happens,
@@ -113,7 +124,7 @@ cause problems, one of the following conditions should always be true:
   peripheral devices
 * All payloads reboot only peripheral devices, not the host system
 * If there is a mix, all payloads that want to reboot the host system respond
-  `Automatic` to the `NeedsArtifactReboot` query
+  `Automatic`/`AutomaticSkipStatusReport` to the `NeedsArtifactReboot` query
 
 If all update modules in the Artifact returned `No`, then the state scripts
 associated with this state, if any, will not run either.

--- a/app/state.go
+++ b/app/state.go
@@ -998,7 +998,11 @@ func (is *updateInstallState) Handle(ctx *StateContext, c Controller) (State, bo
 		case datastore.RebootTypeNone:
 			// Do nothing.
 
-		case datastore.RebootTypeCustom, datastore.RebootTypeAutomatic:
+		case datastore.RebootTypeCustom:
+			fallthrough
+		case datastore.RebootTypeAutomatic:
+			fallthrough
+		case datastore.RebootTypeAutomaticSkipStatusReport:
 			// Go to reboot state if at least one payload requested it.
 			return NewFetchControlMapState(NewUpdateRebootState(is.Update())), false
 
@@ -1029,6 +1033,8 @@ func (is *updateInstallState) handleRebootType(
 			err = is.Update().RebootRequested.Set(n, datastore.RebootTypeCustom)
 		case installer.AutomaticReboot:
 			err = is.Update().RebootRequested.Set(n, datastore.RebootTypeAutomatic)
+		case installer.AutomaticRebootSkipStatusReport:
+			err = is.Update().RebootRequested.Set(n, datastore.RebootTypeAutomaticSkipStatusReport)
 		default:
 			state, cancelled := is.HandleError(ctx, c, NewFatalError(errors.New(
 				"Unknown reply from NeedsReboot. Should not happen")))
@@ -1530,9 +1536,31 @@ func (e *updateRebootState) Handle(ctx *StateContext, c Controller) (State, bool
 
 	log.Debug("Handling reboot state")
 
-	merr := c.ReportUpdateStatus(e.Update(), client.StatusRebooting)
-	if merr != nil && merr.IsFatal() {
-		return NewUpdateRollbackState(e.Update()), false
+	// Avoid attempting to report status to the server if any payload indicated a reboot of
+	// type `RebootTypeAutomaticSkipStatusReport` (even if other modules exist which
+	// use other reboot types, we need to assume that upstream connectivity will be broken by
+	// the payload which indicated `RebootTypeAutomaticSkipStatusReport`).
+	shouldPhoneHomeBeforeReboot := true
+	for n := range c.GetInstallers() {
+		rebootRequested, err := e.Update().RebootRequested.Get(n)
+		if err != nil {
+			return e.HandleError(ctx, c, NewTransientError(errors.Wrap(
+				err, "Unable to get requested reboot type")))
+		}
+		if rebootRequested == datastore.RebootTypeAutomaticSkipStatusReport {
+			log.Warnf(
+				"Found update with reboot type %s - NOT reporting status before reboot!",
+				datastore.RebootTypeAutomaticSkipStatusReport)
+
+			shouldPhoneHomeBeforeReboot = false
+		}
+	}
+
+	if shouldPhoneHomeBeforeReboot {
+		merr := c.ReportUpdateStatus(e.Update(), client.StatusRebooting)
+		if merr != nil && merr.IsFatal() {
+			return NewUpdateRollbackState(e.Update()), false
+		}
 	}
 
 	log.Info("Rebooting device(s)")
@@ -1551,7 +1579,7 @@ func (e *updateRebootState) Handle(ctx *StateContext, c Controller) (State, bool
 				return NewUpdateRollbackState(e.Update()), false
 			}
 
-		case datastore.RebootTypeAutomatic:
+		case datastore.RebootTypeAutomatic, datastore.RebootTypeAutomaticSkipStatusReport:
 			systemRebootRequested = true
 		}
 	}
@@ -1656,7 +1684,11 @@ func (rs *updateRollbackState) Handle(ctx *StateContext, c Controller) (State, b
 		case datastore.RebootTypeNone:
 			// Do nothing.
 
-		case datastore.RebootTypeCustom, datastore.RebootTypeAutomatic:
+		case datastore.RebootTypeCustom:
+			fallthrough
+		case datastore.RebootTypeAutomatic:
+			fallthrough
+		case datastore.RebootTypeAutomaticSkipStatusReport:
 			// Enter rollback reboot state if at least one payload
 			// asked for it.
 			log.Debug("Will try to rollback reboot the device")
@@ -1760,7 +1792,7 @@ func (rs *updateRollbackRebootState) Handle(ctx *StateContext, c Controller) (St
 				// VerifyRollbackReboot state regardless.
 			}
 
-		case datastore.RebootTypeAutomatic:
+		case datastore.RebootTypeAutomatic, datastore.RebootTypeAutomaticSkipStatusReport:
 			systemRebootRequested = true
 		}
 	}

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -216,9 +216,10 @@ func (s *SupportsRollbackType) Set(value SupportsRollbackType) error {
 type RebootType string
 
 const (
-	RebootTypeNone      = ""
-	RebootTypeCustom    = "reboot-type-custom"
-	RebootTypeAutomatic = "reboot-type-automatic"
+	RebootTypeNone                      = ""
+	RebootTypeCustom                    = "reboot-type-custom"
+	RebootTypeAutomatic                 = "reboot-type-automatic"
+	RebootTypeAutomaticSkipStatusReport = "reboot-type-automatic-skip-status-report"
 )
 
 type RebootRequestedType []RebootType
@@ -229,7 +230,7 @@ func (r *RebootRequestedType) Get(n int) (RebootType, error) {
 			"Reboot information missing for payload %04d", n)
 	}
 	switch (*r)[n] {
-	case RebootTypeNone, RebootTypeCustom, RebootTypeAutomatic:
+	case RebootTypeNone, RebootTypeCustom, RebootTypeAutomatic, RebootTypeAutomaticSkipStatusReport:
 		return (*r)[n], nil
 	default:
 		return RebootTypeNone, errors.Errorf(

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -77,6 +77,15 @@ const (
 	NoReboot = iota
 	RebootRequired
 	AutomaticReboot
+	// Reboot type intended to be used by an update module whose `ArtifactInstall` stage is
+	// expected to break upstream connectivity and therefore prohibit the mender client
+	// from notifying the server of a state transition into `ArtifactReboot`.
+	//
+	// Similar to `AutomaticReboot` in that this will cause the mender client to reboot
+	// the host device after handling all payloads. However, if ANY payload requests a reboot
+	// of this type, the mender client will NOT try to notify the server of the state transition
+	// to `ArtifactReboot` before rebooting the host device.
+	AutomaticRebootSkipStatusReport
 )
 
 var (

--- a/installer/modules.go
+++ b/installer/modules.go
@@ -739,6 +739,9 @@ func (mod *ModuleInstaller) NeedsReboot() (RebootAction, error) {
 	} else if output == "Automatic" {
 		log.Debug("Module needs host reboot")
 		return AutomaticReboot, nil
+	} else if output == "AutomaticSkipStatusReport" {
+		log.Debug("Module needs host reboot - skipping status report before rebooting")
+		return AutomaticRebootSkipStatusReport, nil
 	} else {
 		return NoReboot, fmt.Errorf(
 			"Unexpected reply from update module NeedsArtifactReboot query: %s",


### PR DESCRIPTION
Changelog: Allow update modules to optionally skip reporting status to the
server before rebooting


We have encountered a situation where this functionality would be useful - would the mender team be open to accepting a patch for this?

## Description

Before this change, after installing an update module, the mender client would unconditionally try to notify the server of the client's upcoming state transition from ArtifactInstall -> ArtifactReboot. This poses a problem for update modules which (for some reason or another) are expected to break upstream connectivity for the target device. In this case, the mender client will "hang" for a while trying to report status until eventually the client errors out and the update fails.

This change allows an update module to respond with "AutomaticSkipStatusReport" in order to reboot the host device after installing the update module while bypassing mender's normal routine of notifying the server before the state transition into ArtifactReboot. This option should be used by update modules which have an install stage that is expected to break upstream connectivity to the mender server.