### PR TITLE
Changelog: Add alternate EFI path to mender-inventory-bootloader-inte…

### DIFF
--- a/support/mender-inventory-bootloader-integration
+++ b/support/mender-inventory-bootloader-integration
@@ -3,7 +3,7 @@
 # Tries to determine which type of bootloader integration has been used for the
 # running platform.
 
-if [ -d /boot/efi/EFI/BOOT/mender_grubenv1 ]; then
+if [ -d /boot/efi/EFI/BOOT/mender_grubenv1 -o -d /boot/EFI/BOOT/mender_grubenv1 ]; then
     case "$(uname -m)" in
         arm*|aarch*)
             echo mender_bootloader_integration=uboot_uefi_grub


### PR DESCRIPTION
…gration

Some systems, such as Buildroot, default the EFI partition to /boot/EFI instead
of /boot/efi/EFI. Add the /boot/EFI directory to the
mender-inventory-bootloader-integration script.

Signed-off-by: Adam Duskett <aduskett@gmail.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
