### PR TITLE
Changelog: Add alternate EFI path to mender-inventory-bootloader-inte…

### DIFF
--- a/support/mender-inventory-bootloader-integration
+++ b/support/mender-inventory-bootloader-integration
@@ -3,7 +3,7 @@
 # Tries to determine which type of bootloader integration has been used for the
 # running platform.
 
-if [ -d /boot/efi/EFI/BOOT/mender_grubenv1 ]; then
+if [ -d /boot/efi/EFI/BOOT/mender_grubenv1 -o -d /boot/EFI/BOOT/mender_grubenv1 ]; then
     case "$(uname -m)" in
         arm*|aarch*)
             echo mender_bootloader_integration=uboot_uefi_grub


### PR DESCRIPTION
…gration

Some systems, such as Buildroot, default the EFI partition to /boot/EFI instead
of /boot/efi/EFI. Add the /boot/EFI directory to the
mender-inventory-bootloader-integration script.

Signed-off-by: Adam Duskett <aduskett@gmail.com>
(cherry picked from commit 945c2c67de6ba8c61a12fe72226ac8b6864a0f59)
