### PR TITLE
feat: Inventory push retries and backoff.

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ func NewDaemon(
 			Rebooter:      system.NewSystemRebootCmd(system.OsCalls{}),
 			WakeupChan:    make(chan bool, 1),
 			pauseReported: make(map[string]bool),
+			retryCount:    mender.GetRetryPollCount(),
 		},
 		Store:        store,
 		ForceToState: make(chan State, 1),

--- a/app/mender.go
+++ b/app/mender.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ type Controller interface {
 	GetUpdatePollInterval() time.Duration
 	GetInventoryPollInterval() time.Duration
 	GetRetryPollInterval() time.Duration
+	GetRetryPollCount() int
 
 	CheckUpdate() (*datastore.UpdateInfo, menderError)
 	FetchUpdate(url string) (io.ReadCloser, int64, error)
@@ -444,6 +445,10 @@ func (m *Mender) GetRetryPollInterval() time.Duration {
 	return t
 }
 
+func (m *Mender) GetRetryPollCount() int {
+	return m.Config.RetryPollCount
+}
+
 func (m *Mender) SetNextState(s State) {
 	m.state = s
 }
@@ -564,7 +569,7 @@ func transitionState(to State, ctx *StateContext, c Controller) (State, bool) {
 }
 
 func (m *Mender) InventoryRefresh() error {
-	ic := client.NewInventory()
+	ic := client.NewInventory(m.GetRetryPollInterval(), m.GetRetryPollCount())
 	idg := inv.NewInventoryDataRunner(path.Join(conf.GetDataDirPath(), "inventory"))
 
 	artifactName, err := m.GetCurrentArtifactName()

--- a/app/state.go
+++ b/app/state.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ type StateContext struct {
 	fetchInstallAttempts       int
 	controlMapFetchAttemps     int
 	pauseReported              map[string]bool
+	retryCount                 int
 }
 
 type StateRunner interface {
@@ -1087,6 +1088,7 @@ func (fir *fetchStoreRetryState) Handle(ctx *StateContext, c Controller) (State,
 	intvl, err := client.GetExponentialBackoffTime(
 		ctx.fetchInstallAttempts,
 		c.GetUpdatePollInterval(),
+		ctx.retryCount,
 	)
 	if err != nil {
 		if fir.err != nil {
@@ -2029,6 +2031,7 @@ func (f *fetchRetryControlMapState) Handle(ctx *StateContext, c Controller) (Sta
 	intvl, err := client.GetExponentialBackoffTime(
 		ctx.controlMapFetchAttemps,
 		c.GetUpdatePollInterval(),
+		ctx.retryCount,
 	)
 	if err != nil {
 		return f.wrappedState.HandleError(ctx, c,

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ type stateTestController struct {
 	updatePollIntvl time.Duration
 	inventPollIntvl time.Duration
 	retryIntvl      time.Duration
+	retryPollCount  int
 	state           State
 	updateResp      *datastore.UpdateInfo
 	updateRespErr   menderError
@@ -86,6 +87,10 @@ func (s *stateTestController) GetInventoryPollInterval() time.Duration {
 
 func (s *stateTestController) GetRetryPollInterval() time.Duration {
 	return s.retryIntvl
+}
+
+func (s *stateTestController) GetRetryPollCount() int {
+	return s.retryPollCount
 }
 
 func (s *stateTestController) CheckUpdate() (*datastore.UpdateInfo, menderError) {

--- a/client/client_inventory.go
+++ b/client/client_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -27,21 +28,37 @@ type InventorySubmitter interface {
 }
 
 type InventoryClient struct {
+	retryInterval time.Duration
+	maxTries      int
 }
 
-func NewInventory() InventorySubmitter {
-	return &InventoryClient{}
+func NewInventory(retryInterval time.Duration,
+	maxTries int) InventorySubmitter {
+	return &InventoryClient{
+		retryInterval: retryInterval,
+		maxTries:      maxTries,
+	}
 }
 
 // Submit reports status information to the backend
 func (i *InventoryClient) Submit(api ApiRequester, url string, data interface{}) error {
 	// PATCH used to be the only method available in Mender Product 2.5, so
 	// fall back to that if PUT fails.
-	r, err := doSubmitInventory(api, http.MethodPut, url, data)
+	r, err := doSubmitInventory(api,
+		http.MethodPut,
+		url,
+		data,
+		i.retryInterval,
+		i.maxTries)
 	if err == nil {
 		defer r.Body.Close()
 	} else if r != nil && r.StatusCode == http.StatusMethodNotAllowed {
-		r, err = doSubmitInventory(api, http.MethodPatch, url, data)
+		r, err = doSubmitInventory(api,
+			http.MethodPatch,
+			url,
+			data,
+			i.retryInterval,
+			i.maxTries)
 		if err == nil {
 			defer r.Body.Close()
 		}
@@ -60,6 +77,8 @@ func doSubmitInventory(
 	api ApiRequester,
 	method, url string,
 	data interface{},
+	retryInterval time.Duration,
+	tries int,
 ) (*http.Response, error) {
 	req, err := makeInventorySubmitRequest(method, url, data)
 	if err != nil {
@@ -68,8 +87,27 @@ func doSubmitInventory(
 
 	r, err := api.Do(req)
 	if err != nil {
-		log.Error("Failed to submit inventory data: ", err)
-		return r, errors.Wrapf(err, "inventory submit failed")
+		var e error
+		try := 1
+		for e == nil {
+			var sleepInterval time.Duration
+			sleepInterval, e = GetExponentialBackoffTime(try, retryInterval, tries)
+			if e != nil {
+				break
+			}
+			log.Infof("Send inventory waiting for re-try: %d in %.0f",
+				try, sleepInterval.Seconds())
+			time.Sleep(sleepInterval)
+			try++
+			r, err = api.Do(req)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			log.Errorf("Failed to submit inventory data: %s", err.Error())
+			return r, errors.Wrapf(err, "inventory submit failed")
+		}
 	}
 
 	defer r.Body.Close()

--- a/client/client_inventory_test.go
+++ b/client/client_inventory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ func TestInventoryClient(t *testing.T) {
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
 
-	client := NewInventory()
+	client := NewInventory(0, 0)
 	assert.NotNil(t, client)
 
 	err = client.Submit(NewMockApiClient(nil, errors.New("foo")),
@@ -96,7 +96,7 @@ func TestInventoryFallbackToPatch(t *testing.T) {
 	assert.NotNil(t, ac)
 	assert.NoError(t, err)
 
-	client := NewInventory()
+	client := NewInventory(0, 0)
 	assert.NotNil(t, client)
 
 	err = client.Submit(ac, ts.URL, InventoryData{

--- a/client/update_resumer.go
+++ b/client/update_resumer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ func (h *UpdateResumer) Read(buf []byte) (int, error) {
 		for {
 			log.Errorf("Download connection broken: %s", err.Error())
 
-			waitTime, err := GetExponentialBackoffTime(h.retryAttempts, h.maxWait)
+			waitTime, err := GetExponentialBackoffTime(h.retryAttempts, h.maxWait, 0)
 			if err != nil {
 				return int(h.offset - origOffset),
 					errors.Wrapf(err, "Cannot resume download")

--- a/conf/config.go
+++ b/conf/config.go
@@ -69,6 +69,8 @@ type MenderConfigFromFile struct {
 
 	// Global retry polling max interval for fetching update, authorize wait and update status
 	RetryPollIntervalSeconds int `json:",omitempty"`
+	// Global max retry poll count
+	RetryPollCount int `json:",omitempty"`
 
 	// State script parameters
 	StateScriptTimeoutSeconds      int `json:",omitempty"`


### PR DESCRIPTION
We use RetryPollIntervalSeconds in inventory with the exponential
backoff via GetExponentialBackoffTime together with a new setting:
* RetryPollCount -- the max number of tries
* inventory by default tries 3 times with one minute intervals
  (GetExponentialBackoffTime defaults)

ChangeLog:commit
ChangeLog:RetryPollCount applies to all places where backoff is present
Signed-off-by: Peter Grzybowski <peter@northern.tech>