### PR TITLE
Inventory retry.

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/app/mender.go
+++ b/app/mender.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ type Controller interface {
 	GetUpdatePollInterval() time.Duration
 	GetInventoryPollInterval() time.Duration
 	GetRetryPollInterval() time.Duration
+	GetRetryPollCount() int
 
 	CheckUpdate() (*datastore.UpdateInfo, menderError)
 	FetchUpdate(url string) (io.ReadCloser, int64, error)
@@ -442,6 +443,10 @@ func (m *Mender) GetRetryPollInterval() time.Duration {
 		t = 5 * time.Minute
 	}
 	return t
+}
+
+func (m *Mender) GetRetryPollCount() int {
+	return m.Config.RetryPollCount
 }
 
 func (m *Mender) SetNextState(s State) {

--- a/app/state.go
+++ b/app/state.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ type StateContext struct {
 	lastInventoryUpdateAttempt time.Time
 	fetchInstallAttempts       int
 	controlMapFetchAttemps     int
+	inventoryUpdateAttempts    int
+	nextAttemptAt              time.Time
 	pauseReported              map[string]bool
 }
 
@@ -86,12 +88,7 @@ var States = StateCollection{
 			t:  ToIdle,
 		},
 	},
-	InventoryUpdate: &inventoryUpdateState{
-		baseState{
-			id: datastore.MenderStateInventoryUpdate,
-			t:  ToSync,
-		},
-	},
+	InventoryUpdate: NewInventoryUpdateState().(*inventoryUpdateState),
 	UpdateCheck: &updateCheckState{
 		baseState{
 			id: datastore.MenderStateUpdateCheck,
@@ -1087,6 +1084,7 @@ func (fir *fetchStoreRetryState) Handle(ctx *StateContext, c Controller) (State,
 	intvl, err := client.GetExponentialBackoffTime(
 		ctx.fetchInstallAttempts,
 		c.GetUpdatePollInterval(),
+		c.GetRetryPollCount(),
 	)
 	if err != nil {
 		if fir.err != nil {
@@ -1102,6 +1100,74 @@ func (fir *fetchStoreRetryState) Handle(ctx *StateContext, c Controller) (State,
 
 	log.Debugf("Wait %v before next fetch/install attempt", intvl)
 	return fir.Wait(NewUpdateFetchState(&fir.update), fir, intvl, ctx.WakeupChan)
+}
+
+type inventoryUpdateRetry struct {
+	baseState
+	WaitState
+	from State
+	err  error
+}
+
+func NewInventoryUpdateRetryState(from State,
+	err error) State {
+	return &inventoryUpdateRetry{
+		baseState: baseState{
+			id: datastore.MenderStateInventoryUpdateRetryWait,
+			t:  ToSync,
+		},
+		WaitState: NewWaitState(datastore.MenderStateInventoryUpdateRetryWait, ToSync),
+		from:      from,
+		err:       err,
+	}
+}
+
+func (fir *inventoryUpdateRetry) Cancel() bool {
+	return fir.WaitState.Cancel()
+}
+
+func (fir *inventoryUpdateRetry) Handle(ctx *StateContext, c Controller) (State, bool) {
+	if ctx.nextAttemptAt.After(time.Now()) {
+		remainingWaitDuration := time.Until(ctx.nextAttemptAt)
+		configuredInterval := c.GetRetryPollInterval()
+		if remainingWaitDuration.Seconds() > configuredInterval.Seconds() {
+			remainingWaitDuration = configuredInterval
+		}
+		log.Infof("Handle update inventory retry state: not the time yet; %ds/%v remaining.",
+			remainingWaitDuration/time.Second, time.Until(ctx.nextAttemptAt))
+		return fir.Wait(NewInventoryUpdateState(), fir, remainingWaitDuration, ctx.WakeupChan)
+	}
+	log.Infof("Handle update inventory retry state try: %d", ctx.inventoryUpdateAttempts)
+	err := c.InventoryRefresh()
+	if err != nil {
+		log.Warnf("Failed to refresh inventory: %v", err)
+		if errors.Cause(err) == errNoArtifactName {
+			return NewErrorState(NewTransientError(err)), false
+		}
+	} else {
+		return States.CheckWait, false
+	}
+
+	interval, err := client.GetExponentialBackoffTime(
+		ctx.inventoryUpdateAttempts,
+		c.GetRetryPollInterval(),
+		c.GetRetryPollCount(),
+	)
+	ctx.nextAttemptAt = time.Now().Add(interval)
+	if err != nil {
+		log.Infof("Handle update inventory retry state: failed to send inventory: %s", err.Error())
+		return States.CheckWait, false
+	}
+
+	ctx.inventoryUpdateAttempts++
+
+	configuredInterval := c.GetRetryPollInterval()
+	if interval.Seconds() > configuredInterval.Seconds() {
+		interval = configuredInterval
+	}
+	log.Infof("Wait %v before next inventory update attempt in %v",
+		interval, time.Until(ctx.nextAttemptAt))
+	return fir.Wait(NewInventoryUpdateState(), fir, interval, ctx.WakeupChan)
 }
 
 type checkWaitState struct {
@@ -1194,6 +1260,15 @@ type inventoryUpdateState struct {
 	baseState
 }
 
+func NewInventoryUpdateState() State {
+	return &inventoryUpdateState{
+		baseState: baseState{
+			id: datastore.MenderStateInventoryUpdate,
+			t:  ToSync,
+		},
+	}
+}
+
 func (iu *inventoryUpdateState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	err := c.InventoryRefresh()
@@ -1202,6 +1277,7 @@ func (iu *inventoryUpdateState) Handle(ctx *StateContext, c Controller) (State, 
 		if errors.Cause(err) == errNoArtifactName {
 			return NewErrorState(NewTransientError(err)), false
 		}
+		return NewInventoryUpdateRetryState(iu, err), false
 	} else {
 		log.Debugf("Inventory refresh complete")
 	}
@@ -2029,6 +2105,7 @@ func (f *fetchRetryControlMapState) Handle(ctx *StateContext, c Controller) (Sta
 	intvl, err := client.GetExponentialBackoffTime(
 		ctx.controlMapFetchAttemps,
 		c.GetUpdatePollInterval(),
+		c.GetRetryPollCount(),
 	)
 	if err != nil {
 		return f.wrappedState.HandleError(ctx, c,

--- a/app/state.go
+++ b/app/state.go
@@ -43,7 +43,7 @@ type StateContext struct {
 	lastUpdateCheckAttempt     time.Time
 	lastInventoryUpdateAttempt time.Time
 	fetchInstallAttempts       int
-	controlMapFetchAttemps     int
+	controlMapFetchAttempts    int
 	inventoryUpdateAttempts    int
 	nextAttemptAt              time.Time
 	pauseReported              map[string]bool
@@ -2103,7 +2103,7 @@ func (f *fetchRetryControlMapState) Handle(ctx *StateContext, c Controller) (Sta
 	log.Debugf("Handle fetch update control retry state")
 
 	intvl, err := client.GetExponentialBackoffTime(
-		ctx.controlMapFetchAttemps,
+		ctx.controlMapFetchAttempts,
 		c.GetUpdatePollInterval(),
 		c.GetRetryPollCount(),
 	)
@@ -2112,7 +2112,7 @@ func (f *fetchRetryControlMapState) Handle(ctx *StateContext, c Controller) (Sta
 			NewTransientError(err))
 	}
 
-	ctx.controlMapFetchAttemps++
+	ctx.controlMapFetchAttempts++
 
 	log.Infof("Wait %v before next update control map fetch/update attempt", intvl)
 	return f.Wait(

--- a/client/client_inventory.go
+++ b/client/client_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/client/update_resumer.go
+++ b/client/update_resumer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ func (h *UpdateResumer) Read(buf []byte) (int, error) {
 		for {
 			log.Errorf("Download connection broken: %s", err.Error())
 
-			waitTime, err := GetExponentialBackoffTime(h.retryAttempts, h.maxWait)
+			waitTime, err := GetExponentialBackoffTime(h.retryAttempts, h.maxWait, 0)
 			if err != nil {
 				return int(h.offset - origOffset),
 					errors.Wrapf(err, "Cannot resume download")

--- a/conf/config.go
+++ b/conf/config.go
@@ -69,6 +69,8 @@ type MenderConfigFromFile struct {
 
 	// Global retry polling max interval for fetching update, authorize wait and update status
 	RetryPollIntervalSeconds int `json:",omitempty"`
+	// Global max retry poll count
+	RetryPollCount int `json:",omitempty"`
 
 	// State script parameters
 	StateScriptTimeoutSeconds      int `json:",omitempty"`

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -57,6 +57,8 @@ const (
 
 	// inventory update
 	MenderStateInventoryUpdate
+	// wait before retrying update inventory
+	MenderStateInventoryUpdateRetryWait
 	// wait for new update or inventory sending
 	MenderStateCheckWait
 	// check update
@@ -130,6 +132,7 @@ var (
 		MenderStateAuthorize:                        "authorize",
 		MenderStateAuthorizeWait:                    "authorize-wait",
 		MenderStateInventoryUpdate:                  "inventory-update",
+		MenderStateInventoryUpdateRetryWait:         "inventory-update-retry-wait",
 		MenderStateCheckWait:                        "check-wait",
 		MenderStateUpdateCheck:                      "update-check",
 		MenderStateUpdateFetch:                      "update-fetch",


### PR DESCRIPTION
We use RetryPollIntervalSeconds in inventory with the exponential
backoff via GetExponentialBackoffTime together with a new setting:
* RetryPollCount -- the max number of tries
* inventory by default tries 3 times with one minute intervals
  (GetExponentialBackoffTime defaults)

ChangeLog:commit
ChangeLog:RetryPollCount applies to all places where backoff is present
Signed-off-by: Peter Grzybowski <peter@northern.tech>