### PR TITLE
client: Avoid server certificate errors/warnings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -375,19 +375,23 @@ func loadServerTrust(ctx *openssl.Ctx, conf *Config) (*openssl.Ctx, error) {
 			err.Error(),
 		)
 	}
-	// Load the server certificate into the OpenSSL context
-	err = ctx.LoadVerifyLocations(conf.ServerCert, "")
-	if err != nil {
-		if strings.Contains(err.Error(), "No such file or directory") {
-			log.Warnf(errMissingServerCertF, conf.ServerCert)
-		} else {
-			log.Errorf("Failed to Load the Server certificate. Err %s", err.Error())
+	if conf.ServerCert != "" {
+		// Load the server certificate into the OpenSSL context
+		err = ctx.LoadVerifyLocations(conf.ServerCert, "")
+		if err != nil {
+			if strings.Contains(err.Error(), "No such file or directory") {
+				log.Warnf(errMissingServerCertF, conf.ServerCert)
+			} else {
+				log.Errorf("Failed to Load the Server certificate. Err %s", err.Error())
+			}
+			// If no system certificates, nor a server certificate is found,
+			// warn the user, as this is a pretty common error.
+			if sysCertsFound == 0 {
+				log.Error(errMissingCerts)
+			}
 		}
-		// If no system certificates, nor a server certificate is found,
-		// warn the user, as this is a pretty common error.
-		if sysCertsFound == 0 {
-			log.Error(errMissingCerts)
-		}
+	} else if sysCertsFound == 0 {
+		log.Warn(errMissingCerts)
 	}
 	return ctx, err
 }


### PR DESCRIPTION
Calling SSL_CTX_load_verify_locations with CAfile==NULL and CApath==NULL
will make the operation fail. This results in many eror/warning messages
in the mender-client log:

time="2022-03-01T10:11:14Z" level=error msg="Failed to Load the Server certificate. Err SSL errors: "
time="2022-03-01T10:11:14Z" level=error msg="Failed to Load the Server certificate. Err SSL errors: "
time="2022-03-01T10:11:14Z" level=warning msg="Failed to load the server TLS certificate settings: SSL errors: "
time="2022-03-01T10:11:14Z" level=warning msg="Failed to load the server TLS certificate settings: SSL errors: "

Changelog: None
Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
