### PR TITLE
Reset `inventory` and `updateControl` retry counters when done with the retry process.

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -2076,6 +2076,9 @@ func (c *fetchControlMapState) Handle(ctx *StateContext, controller Controller) 
 		return NewFetchRetryControlMapState(c.wrappedState), false
 	}
 
+	// Reset the retry count
+	ctx.controlMapFetchAttempts = 0
+
 	return NewControlMapState(c.wrappedState), false
 }
 

--- a/app/state.go
+++ b/app/state.go
@@ -1281,6 +1281,10 @@ func (iu *inventoryUpdateState) Handle(ctx *StateContext, c Controller) (State, 
 	} else {
 		log.Debugf("Inventory refresh complete")
 	}
+
+	// Reset the counter when done with retrying
+	ctx.inventoryUpdateAttempts = 0
+
 	return States.CheckWait, false
 }
 


### PR DESCRIPTION
The counters were simply never reset in code. At least the `updateControl` counter can cause  some issues when the daemon is not rebooted in a long time, as you can imagine.

The inventory retry counter actually does not trigger the same kind of bug, due to the logic surrounding it, and hence does not have a `Changelog`.

