### PR TITLE
fix: log the fallback to the artifact_info file at log level Warn

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -136,7 +136,11 @@ func (d *DeviceManager) GetCurrentArtifactName() (string, error) {
 			log.Errorf("Could not read artifact name from database: %s", err.Error())
 		}
 	}
-	log.Debugf("Returning artifact name from %s file.", d.ArtifactInfoFile)
+	logMsg := "Returning artifact name from %s file." +
+		"This is a fallback, in case the information can not be retrieved" +
+		"from the database, and is only expected when an update has never" +
+		"been installed before."
+	log.Warnf(logMsg, d.ArtifactInfoFile)
 	return GetManifestData("artifact_name", d.ArtifactInfoFile)
 }
 


### PR DESCRIPTION
I feel like this fallback deserves a proper log mention, as the behaviour is pretty magic otherwise.