### PR TITLE
fix: add an After systemd dependency on mender-client-data-dir

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Mender OTA update service
 Wants=network-online.target
-After=systemd-resolved.service network-online.target mender.service
+After=systemd-resolved.service network-online.target mender.service mender-client-data-dir.service
 Conflicts=mender.service
 
 [Service]

--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Mender OTA update service
 Wants=network-online.target
-After=systemd-resolved.service network-online.target mender.service mender-client-data-dir.service
+After=systemd-resolved.service network-online.target mender.service mender-client-data-dir.service data.mount
 Conflicts=mender.service
 
 [Service]


### PR DESCRIPTION
The mender-client service file is now explicitly ordered after the
`mender-client-data-dir` service file.

Changelog: Title
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


