### PR TITLE
change mender-inventory-hostinfo to use the output of hostname

### DIFF
--- a/support/mender-inventory-hostinfo
+++ b/support/mender-inventory-hostinfo
@@ -17,5 +17,7 @@ cat /proc/meminfo | awk '
 /MemTotal/ {printf("mem_total_kB=%d\n", $2)}
 '
 
-echo "hostname=$(cat /etc/hostname)"
-
+hostname="localhost"
+hostname >/dev/null 2>&1 && hostname="$(hostname)"
+[ "$hostname" = "" ] && [ -f /etc/hostname ] && hostname=$(cat /etc/hostname 2>/dev/null)
+echo hostname=${hostname:-"localhost"}


### PR DESCRIPTION
Signed-off-by: Luis Ramirez Vargas <luis.ramirez@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

By using `cat` you will print the comments in the file, while the actual command ignore them, if a user has in `/etc/hostname`:

```bash
#Any comment
actualHostName
```

The script will fail. Even busybox has the `hostname` command available
 
Thank you!
