### PR TITLE
fix: Append log entries to syslog at the correct level

### DIFF
--- a/log/syslog/syslog.go
+++ b/log/syslog/syslog.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -41,5 +41,5 @@ func NewSyslogHook(network, raddr string,
 
 func (hook *SyslogHook) Levels() []logrus.Level {
 	// Only log level above and including hook.loglevel
-	return logrus.AllLevels[:hook.loglevel]
+	return logrus.AllLevels[:hook.loglevel+1]
 }


### PR DESCRIPTION
Currently, the syslog hook will trigger on all levels above the set log-level. This PR ensures that the syslog hook will also trigger at the log-level itself.

Changelog: Alll
Ticket: None
Signed-off-by: Mikael Torp-Holte <mikael.torp-holte@northern.tech>