### PR TITLE
feat: Add log level parameter in configuration file

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -641,6 +641,14 @@ func (runOptions *runOptionsType) handleLogFlags(ctx *cli.Context) error {
 		return err
 	}
 	log.SetLevel(level)
+
+	if !ctx.IsSet("log-level") {
+		if configLevel, err := conf.LoadLogLevel(
+			runOptions.config,
+			runOptions.fallbackConfig); err == nil {
+			log.SetLevel(configLevel)
+		}
+	}
 
 	if level == log.DebugLevel {
 		// Add the 'func' field to the logger to improve debug log messages

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/mendersoftware/mender/client"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +39,8 @@ var testConfig = `{
   "ServerURL": "mender.io",
   "ServerCertificate": "/var/lib/mender/server.crt",
   "UpdateLogPath": "/var/lib/mender/log/deployment.log",
-  "DeviceTypeFile": "/var/lib/mender/test_device_type"
+  "DeviceTypeFile": "/var/lib/mender/test_device_type",
+  "LogLevel": "error"
 }`
 
 var testBrokenConfig = `{
@@ -144,6 +146,18 @@ func Test_LoadConfig_correctConfFile_returnsConfiguration(t *testing.T) {
 	err = config2.Validate()
 	assert.NoError(t, err)
 	validateConfiguration(t, config2)
+}
+
+func Test_LoadLogLevel(t *testing.T) {
+	configFile, _ := os.Create("mender.config")
+	defer os.Remove("mender.config")
+
+	configFile.WriteString(testConfig)
+
+	level, err := LoadLogLevel("mender.config", "does-not-exist.config")
+	assert.NoError(t, err)
+	assert.NotNil(t, level)
+	assert.Equal(t, log.ErrorLevel, level)
 }
 
 func TestServerURLConfig(t *testing.T) {


### PR DESCRIPTION
Currently, log level can only be set on the command line. This PR adds functionality to set the log level in the configuration file with keyword `LogLevel`. Log level set on the command line will override the one set in the config file. 

Changelog: Title
Ticket: MEN-5583
Signed-off-by: Mikael Torp-Holte <mikael.torp-holte@northern.tech>