### PR TITLE
fix: remove confusing hack in progress bar logic

### DIFF
--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,10 +37,7 @@ func (p *ProgressWriter) Write(data []byte) (int, error) {
 		return n, nil
 	}
 	p.bar.Tick(int64(n))
-	// Due to a small issue with logs intertwining with the progress bar,
-	// due to the actual artifact being bigger than the payload, make the
-	// progressbar a little forgiving at the end.
-	if p.bar.Percentage == 99 {
+	if p.bar.Percentage == 100 {
 		p.bar.Finish()
 		p.finished = true
 	}


### PR DESCRIPTION
In my opinion, this is a confusing hack that [cost me a day](https://hub.mender.io/t/standalone-install-progress-does-not-represent-the-full-installation/4922) :sweat_smile:. For the story, I genuinely thought that something was happening after the copy, where actually it was still working the last percent (which takes longer on my system).

I get that the reason for the hack is to make the log look like this:

```
INFO[0000] Opening device "/dev/mmcblk0p3" for writing  
INFO[0000] Native sector size of block device /dev/mmcblk0p3 is 512 bytes. Mender will write in chunks of 1048576 bytes 
.............................................................  -  100 %
INFO[0109] All bytes were successfully written to the new partition 
INFO[0109] The optimized block-device writer wrote a total of 3073 frames, where 11 frames did need to be rewritten (i.e., skipped) 
INFO[0109] Wrote 3221225472/3221225472 bytes to the inactive partition 
INFO[0109] Executing script: ArtifactInstall_Enter_01
```

instead of this:

```
INFO[0000] Opening device "/dev/mmcblk0p3" for writing  
INFO[0000] Native sector size of block device /dev/mmcblk0p3 is 512 bytes. Mender will write in chunks of 1048576 bytes 
.............................................................  -  99 %INFO[0109] All bytes were successfully written to the new partition 
INFO[0109] The optimized block-device writer wrote a total of 3073 frames, where 11 frames did need to be rewritten (i.e., skipped) 
INFO[0109] Wrote 3221225472/3221225472 bytes to the inactive partition 
.............................................................. - 100 %
INFO[0109] Executing script: ArtifactInstall_Enter_01
```

And I get that fixing it properly is more time consuming than setting the progress to 100% when it is actually 99%. However, the consequence in my case was that the progress bar took 1-2min to reach 100%, and then another 40sec to actually finish. Because apparently the copy slows down at the end.

What good is a progress bar if it does not indicate the end properly? :sweat_smile:
I am pretty sure people are used to having the last percent take longer, where staying for 40sec at 99% says "it is not finished yet, and apparently the termination takes some more time". Whereas staying for 40sec at 100% says "I'm done.", and let's the user wonder for 40 seconds about whether it failed or not :grin:.