### PR TITLE
fix: Revert "Remove Makefile optimization to reuse old binary if source is unchanged."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ DBUS_POLICY_FILES = \
 	support/dbus/io.mender.AuthenticationManager.conf \
 	support/dbus/io.mender.UpdateManager.conf
 
-build:
-	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+build: mender
 
-mender: build
+mender: $(PKGFILES)
+	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
 install: install-bin \
 	install-conf \


### PR DESCRIPTION
This reverts commit b6e20f1f274e55fc09c9b0c09b5c8f9429ca2b05.

The problem with not having the optimization is that the `install-bin`
target tries to rebuild the client. This leads to several issues:

* It is incompatible with the fix for CVE-2022-24765 (see links in
  changelog tag), which forbids any kind of access to a repository by
  any other user than the owning one. This is problematic when
  building because we use Git to determine the client version, and the
  `install` target is usually invoked with `sudo`. By building
  separately and then installing, this is avoided.

* Related to the above, if both the `do_compile` and the `do_install`
  Bitbake targets in Yocto touch the same file, the fakeroot
  mechanism can get confused. This can lead to some very hard to
  detect races and "pseudo abort" error messages.

Changelog: Fix Git error when installing after the fix for the
[CVE-2022-24765 Git
vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2022-24765)
([Github's description of the
issue](https://github.blog/2022-04-12-git-security-vulnerability-announced/)).
This also fixes a subtle "pseudo abort" issue which can occur in the
Yocto build environment.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
