### PR TITLE
Bind to 127

### DIFF
--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	ProxyHost        = "localhost"
+	ProxyHost        = "127.0.0.1"
 	InetAddrLoopback = "127.0.0.1:0"
 )
 

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	ProxyHost = "localhost"
+	ProxyHost        = "localhost"
+	InetAddrLoopback = "127.0.0.1:0"
 )
 
 const (
@@ -117,7 +118,7 @@ func NewProxyController(
 }
 
 func newNetListener() (net.Listener, error) {
-	l, err := net.Listen("tcp", "localhost:0")
+	l, err := net.Listen("tcp", InetAddrLoopback)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create listener")
 	}

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ func TestProxyCommonRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	proxyServerUrl := proxyController.GetServerUrl()
-	assert.Contains(t, proxyServerUrl, "http://localhost")
+	assert.Contains(t, proxyServerUrl, "http://"+ProxyHost)
 
 	// API call /deployments/next
 	testUrl := fmt.Sprintf(
@@ -241,7 +241,7 @@ func TestProxyConnectionRefused(t *testing.T) {
 	defer proxyController.Stop()
 
 	proxyServerUrl := proxyController.GetServerUrl()
-	assert.Contains(t, proxyServerUrl, "http://localhost")
+	assert.Contains(t, proxyServerUrl, "http://"+ProxyHost)
 
 	// API call /deployments/next
 	testUrl := fmt.Sprintf(

--- a/app/proxy/proxy_ws_test.go
+++ b/app/proxy/proxy_ws_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ func connectProxyWsTest(
 ) *websocket.Conn {
 
 	proxyServerUrl := proxyController.GetServerUrl()
-	require.Contains(t, proxyServerUrl, "http://localhost")
+	require.Contains(t, proxyServerUrl, "http://"+ProxyHost)
 
 	testUrl := strings.Replace(proxyServerUrl, "http:", "ws:", 1) + ApiUrlDevicesConnect
 	headers := http.Header{}
@@ -202,7 +202,7 @@ func TestProxyWsWebSocketProtocolHeader(t *testing.T) {
 	defer proxyController.Stop()
 
 	proxyServerUrl := proxyController.GetServerUrl()
-	require.Contains(t, proxyServerUrl, "http://localhost")
+	require.Contains(t, proxyServerUrl, "http://"+ProxyHost)
 
 	testUrl := strings.Replace(proxyServerUrl, "http:", "ws:", 1) + ApiUrlDevicesConnect
 	headers := http.Header{}
@@ -308,7 +308,7 @@ func TestProxyWsGoroutines(t *testing.T) {
 	require.NoError(t, err)
 
 	proxyServerUrl := proxyController.GetServerUrl()
-	require.Contains(t, proxyServerUrl, "http://localhost")
+	require.Contains(t, proxyServerUrl, "http://"+ProxyHost)
 
 	// Assert num Goroutines increase
 	// assert.Eventually creates one Goroutine on its own, so take that into account


### PR DESCRIPTION
fix: Both bind to and return over D-Bus 127.0.0.1 

At the moment we bind to localhost and we also return that as a ProxyHost. We decided it to be safer to use `127.0.0.1` in both cases.

Goes with:
* https://github.com/mendersoftware/meta-mender/pull/1704/head

Changelog: Use 127.0.0.1 both as a default bind host and ProxyHost
Ticket: None
