### PR TITLE
3.0.x: fix: Don't accumulate zombies when command output parsing fails.

### DIFF
--- a/app/process_leaking_test.go
+++ b/app/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package app
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/app/updatecontrolmap/process_leaking_test.go
+++ b/app/updatecontrolmap/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package updatecontrolmap
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/cli/process_leaking_test.go
+++ b/cli/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package cli
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/client/process_leaking_test.go
+++ b/client/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package client
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/conf/process_leaking_test.go
+++ b/conf/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package conf
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/datastore/process_leaking_test.go
+++ b/datastore/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package datastore
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/dbus/process_leaking_test.go
+++ b/dbus/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package dbus
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/device/identity_data.go
+++ b/device/identity_data.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -68,12 +68,17 @@ func (id IdentityDataRunner) Get() (string, error) {
 	}
 
 	p := utils.KeyValParser{}
-	if err := p.Parse(out); err != nil {
-		return "", errors.Wrapf(err, "failed to parse identity data")
-	}
+	parseErr := p.Parse(out)
 
 	if err := cmd.Wait(); err != nil {
+		if parseErr != nil {
+			err = errors.Wrapf(parseErr, "failed to parse identity data")
+		}
 		return "", errors.Wrapf(err, "wait for helper failed")
+	}
+
+	if parseErr != nil {
+		return "", errors.Wrapf(parseErr, "failed to parse identity data")
 	}
 
 	collected := p.Collect()

--- a/device/process_leaking_test.go
+++ b/device/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package device
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/installer/bootenv.go
+++ b/installer/bootenv.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -214,8 +214,18 @@ func getEnvironmentVariable(cmd *system.Cmd) (BootVars, error) {
 
 		//we have some malformed data or Warning/Error
 		if len(splited_line) != 2 {
+			// Empty scanner to avoid deadlock.
+			for scanner.Scan() {
+			}
+			err = cmd.Wait()
+			message := "Invalid U-Boot variable or error: " + scanner.Text()
+			if err != nil {
+				err = errors.Wrap(err, message)
+			} else {
+				err = errors.New(message)
+			}
 			log.Error("U-Boot variable malformed or error occurred")
-			return nil, errors.New("Invalid U-Boot variable or error: " + scanner.Text())
+			return nil, err
 		}
 
 		env_variables[splited_line[0]] = splited_line[1]

--- a/installer/process_leaking_test.go
+++ b/installer/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package installer
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/inventory/inventory_data.go
+++ b/inventory/inventory_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -88,16 +88,18 @@ func (id *InventoryDataRunner) Get() (client.InventoryData, error) {
 		}
 
 		p := utils.KeyValParser{}
-		if err := p.Parse(out); err != nil {
-			log.Warnf("Inventory tool %s returned unparsable output: %v", t, err)
-			continue
+		var parseErr error
+		if parseErr = p.Parse(out); parseErr != nil {
+			log.Warnf("Inventory tool %s returned unparsable output: %v", t, parseErr)
 		}
 
 		if err := cmd.Wait(); err != nil {
 			log.Warnf("Inventory tool %s wait failed: %v", t, err)
 		}
 
-		idec.AppendFromRaw(p.Collect())
+		if parseErr == nil {
+			idec.AppendFromRaw(p.Collect())
+		}
 	}
 	return idec.GetInventoryData(), nil
 }

--- a/inventory/process_leaking_test.go
+++ b/inventory/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package inventory
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/process_leaking_test.go
+++ b/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/statescript/process_leaking_test.go
+++ b/statescript/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package statescript
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/store/process_leaking_test.go
+++ b/store/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package store
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}

--- a/system/testing/os_calls.go
+++ b/system/testing/os_calls.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/system/testing/process_testing.go
+++ b/system/testing/process_testing.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package testing
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This won't run automatically because of the filename of this file, but it is
+// exported and tests from other packages are meant to call it directly.
+func TestZombieProcessLeaking(t *testing.T) {
+	// Test that we don't leave behind any zombies after a test run.
+
+	// Perform a sanity check first. Make a zombie process so that we can
+	// verify that our detection works.
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Start())
+	require.Eventually(t, func() bool {
+		_, _, result := zombieProcessesPresent()
+		return result
+	},
+		1*time.Second,
+		100*time.Millisecond,
+		"Zombie detection doesn't work. Perhaps ps works differently on this platform?",
+	)
+	require.NoError(t, cmd.Wait())
+
+	// This is not primarily to enable parallalism, but to move the test to
+	// the end of the run, since Go executes all parallel tests at the
+	// end. This doesn't guarantee that it's the last one though, since we
+	// can execute at the same time as the others.
+	t.Parallel()
+
+	var output string
+	var err error
+	// Use Eventually(), since we aren't guaranteed to be the last test.
+	assert.Eventuallyf(t, func() bool {
+		var result bool
+		output, err, result = zombieProcessesPresent()
+		return !result
+	},
+		60*time.Second,
+		1*time.Second,
+		"Zombie processes are still present! Missing Wait()?",
+	)
+	if t.Failed() {
+		t.Logf("ps output: %s, error: %v", output, err)
+	}
+}
+
+func zombieProcessesPresent() (string, error, bool) {
+	cmdStr := fmt.Sprintf("ps -ef | grep %d | grep '<defunct>' | grep -v grep", os.Getpid())
+	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	output, err := cmd.Output()
+	if err == nil {
+		return string(output), err, true
+	} else {
+		return string(output), err, false
+	}
+}

--- a/utils/process_leaking_test.go
+++ b/utils/process_leaking_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package utils
+
+import (
+	"testing"
+
+	stest "github.com/mendersoftware/mender/system/testing"
+)
+
+func TestZombieProcessLeaking(t *testing.T) {
+	stest.TestZombieProcessLeaking(t)
+}


### PR DESCRIPTION
Also add a test to every package that makes sure we are not leaking
any zombies.

Changelog: Title
Ticket: MEN-5587

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 74c8c5c63ea9d08798d0a29da1da699b1ce7ba6f)
