### PR TITLE
fix: Resume update after manually rebooting during pre-reboot pause.

### DIFF
--- a/app/daemon_test.go
+++ b/app/daemon_test.go
@@ -216,16 +216,14 @@ func (d *daemonTestController) RefreshServerUpdateControlMap(deploymentID string
 
 func TestDaemonRun(t *testing.T) {
 	t.Run("Testrun daemon", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip("skipping periodic update check in short tests")
+		t.Parallel()
 
-		}
-
-		pollInterval := time.Duration(30) * time.Second
+		pollInterval := time.Duration(1) * time.Second
 
 		dtc := &daemonTestController{
 			stateTestController{
 				updatePollIntvl: pollInterval,
+				inventPollIntvl: pollInterval,
 				state:           States.Init,
 			},
 			0,
@@ -242,7 +240,8 @@ func TestDaemonRun(t *testing.T) {
 		daemon.StopDaemon()
 
 		t.Logf("poke count: %v", dtc.updateCheckCount)
-		assert.False(t, dtc.updateCheckCount < (timespolled-1))
+		assert.GreaterOrEqual(t, dtc.updateCheckCount, (timespolled-1))
+		assert.Less(t, dtc.updateCheckCount, (timespolled+1))
 
 	})
 	t.Run("testing state machine interrupt functionality - updateCheck state", func(t *testing.T) {

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -518,6 +518,12 @@ func TestStateInventoryUpdate(t *testing.T) {
 }
 
 func TestStateInventoryUpdateRetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long running test")
+	}
+
+	t.Parallel()
+
 	ius := States.InventoryUpdate
 	iur := NewInventoryUpdateRetryState(ius, nil)
 	ctx := new(StateContext)
@@ -5600,6 +5606,8 @@ func TestFetchRetryUpdateControl(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long running test (1m wait)")
 	}
+
+	t.Parallel()
 
 	ms := store.NewMemStore()
 	ctx := &StateContext{

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -5483,7 +5483,7 @@ func TestControlMapState(t *testing.T) {
 			c := &stateTestController{controlMap: pool}
 			u := &datastore.UpdateInfo{}
 
-			next, _ := NewControlMapState(NewUpdateInstallState(u)).Handle(ctx, c)
+			next, _ := NewControlMapState(NewUpdateInstallState(u), nil).Handle(ctx, c)
 			assert.IsType(t, test.expected, next)
 		})
 	}
@@ -5589,7 +5589,7 @@ func TestControlMapFetch(t *testing.T) {
 				NewUpdateInstallState(
 					&datastore.UpdateInfo{
 						ID: "foobar",
-					})).
+					}), nil).
 				Handle(ctx, c)
 			assert.IsType(t, test.expectedNextState, next)
 		})
@@ -5611,7 +5611,7 @@ func TestFetchRetryUpdateControl(t *testing.T) {
 
 	next, _ := NewFetchRetryControlMapState(
 		NewUpdateInstallState(
-			&datastore.UpdateInfo{})).
+			&datastore.UpdateInfo{}), nil).
 		Handle(ctx, c)
 
 	assert.IsType(t, &fetchControlMapState{}, next)

--- a/datastore/statedata.go
+++ b/datastore/statedata.go
@@ -88,8 +88,6 @@ const (
 	MenderStateUpdateStatusReport
 	// wait before retrying sending either report or deployment logs
 	MenderStateStatusReportRetry
-	// error reporting status
-	MenderStateReportStatusError
 	// reboot
 	MenderStateReboot
 	// first state after booting device after rollback reboot
@@ -120,6 +118,9 @@ const (
 	MenderStateFetchUpdateControl
 	// retry the above state upon request errors
 	MenderStateFetchRetryUpdateControl
+
+	// No longer used
+	MenderStateReportStatusError
 )
 
 var (


### PR DESCRIPTION
In order for the spontaneous reboot recovery code to be able to
resume, we have to have recorded that we were in the
`MenderStateReboot` state when the device rebooted. This is tricky for
several reasons:

* The states that deal with Update Control are shared, so they occur
  at multiple points throughout the flow, and only the ArtifactReboot
  case should have this behavior.

* We have to check that the Update Control Maps do not resolve to a
  "fail" before we store `MenderStateReboot`. Otherwise it could be
  that the a local process requested failure and rollback, but Mender
  continues anyway.

Fortunately, the Update Control states (like `controlMapState` &
friends) do not implement the `UpdateState` interface, and hence no
database state is recorded for them. We take advantage of this by
creating one new state which does implement `UpdateState`, and which
records the `MenderStateReboot` state ID. We arrange for this state to
be invoked when there is a pause before a reboot. Transitioning to
this state then records the proper ID in the database, and we loop
once more through the `controlMapState` to do the real pausing.

For the non-reboot states we pass nil when we enter the Update Control
states, and hence they use the old behavior of pausing without
entering any explicit state.

Changelog: If paused before ArtifactReboot, and then manually
rebooting the device outside of Mender, the client will properly
resume the update now, instead of failing and rolling back.

Ticket: MEN-5709

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>