### PR TITLE
fix: the periodic update check bug in checkWaitState

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -1241,68 +1241,29 @@ func (cw *checkWaitState) Cancel() bool {
 func (cw *checkWaitState) Handle(ctx *StateContext, c Controller) (State, bool) {
 
 	log.Debugf("Handle check wait state")
-
-	// calculate next interval
-	update := ctx.lastUpdateCheckAttempt.Add(c.GetUpdatePollInterval())
-	inventory := ctx.lastInventoryUpdateAttempt.Add(c.GetInventoryPollInterval())
-
-	// if we haven't sent inventory so far
+	// Inventory should be sent at first try
 	if ctx.lastInventoryUpdateAttempt.IsZero() {
-		inventory = ctx.lastInventoryUpdateAttempt
+		return States.InventoryUpdate, false
 	}
 
-	log.Debugf("Check wait state; next checks: (update: %v) (inventory: %v)",
-		update, inventory)
+	nextUpdateCheck := ctx.lastUpdateCheckAttempt.Add(c.GetUpdatePollInterval())
+	nextInventoryCheck := ctx.lastInventoryUpdateAttempt.Add(c.GetInventoryPollInterval())
 
-	next := struct {
-		when  time.Time
-		state State
-	}{
-		// assume update will be the next state
-		when:  update,
-		state: States.UpdateCheck,
+	if nextUpdateCheck.Before(nextInventoryCheck) {
+		return cw.Wait(
+			States.UpdateCheck,
+			cw,
+			time.Until(nextUpdateCheck),
+			ctx.WakeupChan,
+		)
 	}
 
-	if inventory.Before(update) {
-		next.when = inventory
-		next.state = States.InventoryUpdate
-	}
-
-	now := time.Now()
-	log.Debugf("Next check: %v:%v, (%v)", next.when, next.state, now)
-
-	// check if we should wait for the next state or we should return
-	// immediately
-	var wait time.Duration
-	if next.when.After(now) {
-		wait = next.when.Sub(now)
-	}
-
-	// (MEN-2195): Set the last update/inventory check time to now, as an error in an enter script
-	// will hinder these states from ever running, and thus causing an infinite loop if the script
-	// keeps returning the same error.
-	switch (next.state).(type) {
-	case *inventoryUpdateState:
-		if wait == 0 {
-			ctx.lastInventoryUpdateAttempt = now
-		} else {
-			ctx.lastInventoryUpdateAttempt = next.when
-		}
-	case *updateCheckState:
-		if wait == 0 {
-			ctx.lastUpdateCheckAttempt = now
-		} else {
-			ctx.lastUpdateCheckAttempt = next.when
-		}
-	}
-
-	if wait != 0 {
-		log.Debugf("Waiting %s for the next state", wait)
-		return cw.Wait(next.state, cw, wait, ctx.WakeupChan)
-	}
-
-	log.Debugf("Check wait returned: %v", next.state)
-	return next.state, false
+	return cw.Wait(
+		States.InventoryUpdate,
+		cw,
+		time.Until(nextInventoryCheck),
+		ctx.WakeupChan,
+	)
 }
 
 type inventoryUpdateState struct {


### PR DESCRIPTION
Changelog: The client update and inventory checks are now unaffected by the use
of the `check-update` and `send-inventory` commands. While previously, this
would both move the intervals at which checks we're done, and also extend them
beyond the expected polling intervals configured.

Ticket: MEN-5547

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

In short:

Simplified the `checkWait` logic a lot by moving the last attempt out of the `state.go` file, and into `daemon.go`.

While maybe not completely kosher on the surface, but if you look through the code, you will realize that this does indeed simplify our somewhat fragile logic here a lot, and should now be fairly fool-proof, as opposed to previously, where it has broken for us multiple times.

I also, added an exception for the manual forced update and inventory checks from the cli, so that they do no longer interfere with the regularity of the intervals at which the update checks are done by the state machine. I'm sure we could do something clever here, but I figured a simple bool if, INF-1000 style would suffice here.

Have a lookover, and see what you think :)