### PR TITLE
ci: Do not inherit parent variables on child pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,6 +164,8 @@ trigger:mender-docs-site:
 
 trigger:integration:
   stage: trigger
+  inherit:
+    variables: false
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'


### PR DESCRIPTION
So that we have full control of which variables to pass downstream by opting-in explicitly the required ones.

See: https://docs.gitlab.com/ee/ci/yaml/#inherit

Ticket: QA-352