### PR TITLE
feat: Support multiple verification keys

### DIFF
--- a/app/standalone.go
+++ b/app/standalone.go
@@ -50,7 +50,7 @@ type standaloneData struct {
 
 // This will be run manually from command line ONLY
 func DoStandaloneInstall(device *dev.DeviceManager, updateURI string,
-	clientConfig client.Config, vKey []byte,
+	clientConfig client.Config,
 	stateExec statescript.Executor, rebootExitCode bool) error {
 
 	var image io.ReadCloser
@@ -93,10 +93,10 @@ func DoStandaloneInstall(device *dev.DeviceManager, updateURI string,
 	p := utils.NewProgressWriter(imageSize)
 	tr := io.TeeReader(image, p)
 
-	return doStandaloneInstallStates(ioutil.NopCloser(tr), vKey, device, stateExec, rebootExitCode)
+	return doStandaloneInstallStates(ioutil.NopCloser(tr), device, stateExec, rebootExitCode)
 }
 
-func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
+func doStandaloneInstallStatesDownload(art io.ReadCloser,
 	device *dev.DeviceManager, stateExec statescript.Executor) (*standaloneData, error) {
 
 	dt, err := device.GetDeviceType()
@@ -113,7 +113,7 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 		// No doStandaloneFailureStates here, since we have not done anything yet.
 		return nil, err
 	}
-	installer, installers, err := installer.ReadHeaders(art, dt, key,
+	installer, installers, err := installer.ReadHeaders(art, dt, &device.Config,
 		device.StateScriptPath, &device.InstallerFactories)
 	standaloneData := &standaloneData{
 		installers: installers,
@@ -179,11 +179,11 @@ func doStandaloneInstallStatesDownload(art io.ReadCloser, key []byte,
 	return standaloneData, nil
 }
 
-func doStandaloneInstallStates(art io.ReadCloser, key []byte,
+func doStandaloneInstallStates(art io.ReadCloser,
 	device *dev.DeviceManager, stateExec statescript.Executor,
 	rebootExitCode bool) error {
 
-	standaloneData, err := doStandaloneInstallStatesDownload(art, key, device, stateExec)
+	standaloneData, err := doStandaloneInstallStatesDownload(art, device, stateExec)
 	if err != nil {
 		return err
 	}

--- a/app/standalone_test.go
+++ b/app/standalone_test.go
@@ -98,9 +98,9 @@ func Test_doManualUpdate_noParams_fail(t *testing.T) {
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
 
-	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 	if err := DoStandaloneInstall(getTestDeviceManager(dualRootfsDevice, &config, deviceType, dbdir),
-		"", client.Config{}, nil, dev.NewStateScriptExecutor(&config), false); err == nil {
+		"", client.Config{}, dev.NewStateScriptExecutor(&config), false); err == nil {
 
 		t.FailNow()
 	}
@@ -119,10 +119,10 @@ func Test_doManualUpdate_invalidHttpsClientConfig_updateFails(t *testing.T) {
 	defer os.Remove(deviceType)
 
 	config := conf.MenderConfig{}
-	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 	if err := DoStandaloneInstall(getTestDeviceManager(
 		dualRootfsDevice, &config, deviceType, dbdir),
-		imageFile, runOptions, nil,
+		imageFile, runOptions,
 		dev.NewStateScriptExecutor(&config), false); err == nil {
 
 		t.FailNow()
@@ -134,7 +134,7 @@ func Test_doManualUpdate_nonExistingFile_fail(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dbdir)
 
-	fakeDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	fakeDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 	imageFile := "non-existing"
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
@@ -142,7 +142,7 @@ func Test_doManualUpdate_nonExistingFile_fail(t *testing.T) {
 	config := conf.MenderConfig{}
 	if err := DoStandaloneInstall(getTestDeviceManager(
 		fakeDevice, &config, deviceType, dbdir),
-		imageFile, client.Config{}, nil,
+		imageFile, client.Config{},
 		dev.NewStateScriptExecutor(&config), false); err == nil {
 
 		t.FailNow()
@@ -154,14 +154,14 @@ func Test_doManualUpdate_networkUpdateNoClient_fail(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dbdir)
 
-	fakeDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	fakeDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 	imageFile := "http://non-existing"
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
 
 	config := conf.MenderConfig{}
 	if err := DoStandaloneInstall(getTestDeviceManager(fakeDevice, &config, deviceType, dbdir),
-		imageFile, client.Config{}, nil, dev.NewStateScriptExecutor(&config), false); err == nil {
+		imageFile, client.Config{}, dev.NewStateScriptExecutor(&config), false); err == nil {
 
 		t.FailNow()
 	}
@@ -172,7 +172,7 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dbdir)
 
-	fakeDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	fakeDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 	imageFile := "http://non-existing"
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
@@ -185,7 +185,7 @@ func Test_doManualUpdate_networkClientExistsNoServer_fail(t *testing.T) {
 	config := conf.MenderConfig{}
 	if err := DoStandaloneInstall(getTestDeviceManager(
 		fakeDevice, &config, deviceType, dbdir),
-		imageFile, fakeClientConfig, nil,
+		imageFile, fakeClientConfig,
 		dev.NewStateScriptExecutor(&config), false); err == nil {
 
 		t.FailNow()
@@ -229,7 +229,7 @@ func Test_doManualUpdate_existingFile_updateSuccess(t *testing.T) {
 	err = DoStandaloneInstall(getTestDeviceManager(
 		fakeDev, &config, deviceType, dbdir),
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.NoError(t, err)
 }
 
@@ -270,7 +270,7 @@ func Test_doManualUpdate_existingFile_updateSuccess_rebootExitCode(t *testing.T)
 	if err = DoStandaloneInstall(getTestDeviceManager(
 		fakeDev, &config, deviceType, dbdir),
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), true); err != ErrorManualRebootRequired {
+		dev.NewStateScriptExecutor(&config), true); err != ErrorManualRebootRequired {
 		t.FailNow()
 	}
 }
@@ -327,7 +327,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 	// one dependency at the time untill the artifact should be accepted.
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
 	// Try with existing, but null typeInfoProvides.
@@ -335,7 +335,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		datastore.ArtifactTypeInfoProvidesKey, []byte("null"))
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
 	// Try with artifact_name inserted.
@@ -343,7 +343,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		[]byte("OldArtifact"))
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
 	// Try with artifact_group inserted.
@@ -351,7 +351,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		[]byte("testGroup"))
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.Error(t, err)
 
 	// Try with typeInfoProvides inserted.
@@ -361,7 +361,7 @@ func TestDoManualUpdateArtifactV3Dependencies(t *testing.T) {
 		datastore.ArtifactTypeInfoProvidesKey, typeProvidesBuf)
 	err = DoStandaloneInstall(testDevMgr,
 		imageFileName, client.Config{},
-		nil, dev.NewStateScriptExecutor(&config), false)
+		dev.NewStateScriptExecutor(&config), false)
 	assert.NoError(t, err)
 
 }
@@ -991,7 +991,7 @@ func TestStandaloneModuleInstall(t *testing.T) {
 				tests.ArtifactAttributeOverrides{})
 
 			err = DoStandaloneInstall(device, artPath,
-				client.Config{}, nil, stateExec, false)
+				client.Config{}, stateExec, false)
 			if c.errInstall != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), c.errInstall)
@@ -1074,7 +1074,7 @@ func TestStandaloneStoreAndRestore(t *testing.T) {
 	deviceType := zeroLengthDeviceTypeFile(t)
 	defer os.Remove(deviceType)
 
-	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, installer.DualRootfsDeviceConfig{})
+	dualRootfsDevice := installer.NewDualRootfsDevice(nil, nil, conf.DualRootfsDeviceConfig{})
 
 	tmgr := getTestDeviceManager(dualRootfsDevice, &config, deviceType, dbdir)
 
@@ -1419,7 +1419,7 @@ func TestStandaloneInstallProvides(t *testing.T) {
 			}
 
 			err = DoStandaloneInstall(device, artPath,
-				client.Config{}, nil, stateExec, false)
+				client.Config{}, stateExec, false)
 			require.NoError(t, err)
 
 			err = DoStandaloneCommit(device, stateExec)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -112,7 +112,7 @@ func TestRunDaemon(t *testing.T) {
 	pieces := app.MenderPieces{
 		Store: store.NewMemStore(),
 		DualRootfsDevice: installer.NewDualRootfsDevice(
-			nil, nil, installer.DualRootfsDeviceConfig{}),
+			nil, nil, conf.DualRootfsDeviceConfig{}),
 	}
 
 	pieces.AuthManager = app.NewAuthManager(app.AuthManagerConfig{

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -246,9 +246,8 @@ func handleArtifactOperations(ctx *cli.Context, runOptions runOptionsType,
 		return PrintProvides(deviceManager)
 
 	case "install":
-		vKey := config.GetVerificationKey()
 		return app.DoStandaloneInstall(deviceManager, runOptions.imageFile,
-			runOptions.Config, vKey, stateExec, runOptions.rebootExitCode)
+			runOptions.Config, stateExec, runOptions.rebootExitCode)
 
 	case "commit":
 		return app.DoStandaloneCommit(deviceManager, stateExec)

--- a/device/device.go
+++ b/device/device.go
@@ -1,16 +1,16 @@
 // Copyright 2022 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package device
 
 import (
@@ -152,10 +152,6 @@ func (d *DeviceManager) GetDeviceType() (string, error) {
 	return GetDeviceType(d.DeviceTypeFile)
 }
 
-func (d *DeviceManager) GetArtifactVerifyKey() []byte {
-	return d.Config.GetVerificationKey()
-}
-
 func GetDeviceType(deviceTypeFile string) (string, error) {
 	return GetManifestData("device_type", deviceTypeFile)
 }
@@ -174,7 +170,7 @@ func (d *DeviceManager) ReadArtifactHeaders(from io.ReadCloser) (*installer.Inst
 	var i *installer.Installer
 	i, d.Installers, err = installer.ReadHeaders(from,
 		deviceType,
-		d.GetArtifactVerifyKey(),
+		&d.Config,
 		d.StateScriptPath,
 		&d.InstallerFactories)
 	return i, err

--- a/installer/dual_rootfs_device.go
+++ b/installer/dual_rootfs_device.go
@@ -1,16 +1,16 @@
 // Copyright 2022 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package installer
 
 import (
@@ -26,6 +26,7 @@ import (
 
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/system"
 )
 
@@ -36,11 +37,6 @@ const (
 	verifyRollbackRebootError = "Reboot to the old update failed. " +
 		"Expected \"upgrade_available\" flag to be false but it was true"
 )
-
-type DualRootfsDeviceConfig struct {
-	RootfsPartA string
-	RootfsPartB string
-}
 
 type dualRootfsDeviceImpl struct {
 	BootEnvReadWriter
@@ -60,7 +56,8 @@ type DualRootfsDevice interface {
 // checkMounted parses /proc/self/mounts to check
 // if device partition @part is a mounted fileststem.
 // return: The mount target if partition is mounted
-//         else an empty string is returned
+//
+//	else an empty string is returned
 func checkMounted(part string) string {
 	file, err := os.Open("/proc/self/mounts")
 	if err != nil {
@@ -81,7 +78,7 @@ func checkMounted(part string) string {
 func NewDualRootfsDevice(
 	env BootEnvReadWriter,
 	sc system.StatCommander,
-	config DualRootfsDeviceConfig,
+	config conf.DualRootfsDeviceConfig,
 ) DualRootfsDevice {
 	if config.RootfsPartA == "" || config.RootfsPartB == "" {
 		return nil

--- a/installer/dual_rootfs_device_test.go
+++ b/installer/dual_rootfs_device_test.go
@@ -1,16 +1,16 @@
 // Copyright 2021 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package installer
 
 import (
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mendersoftware/mender/conf"
 	stest "github.com/mendersoftware/mender/system/testing"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
@@ -258,7 +259,7 @@ func Test_Rollback_OK(t *testing.T) {
 }
 
 func TestDeviceVerifyReboot(t *testing.T) {
-	config := DualRootfsDeviceConfig{
+	config := conf.DualRootfsDeviceConfig{
 		"part1",
 		"part2",
 	}

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 	"github.com/mendersoftware/mender-artifact/areader"
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender/conf"
 	"github.com/mendersoftware/mender/statescript"
 )
 
@@ -83,10 +85,10 @@ var (
 	ErrorNothingToCommit = errors.New("There is nothing to commit")
 )
 
-func Install(art io.ReadCloser, dt string, key []byte, scrDir string,
+func Install(art io.ReadCloser, dt string, keySelector VerificationKeySelector, scrDir string,
 	inst *AllModules) ([]PayloadUpdatePerformer, error) {
 
-	installer, payloads, err := ReadHeaders(art, dt, key, scrDir, inst)
+	installer, payloads, err := ReadHeaders(art, dt, keySelector, scrDir, inst)
 	if err != nil {
 		return payloads, err
 	}
@@ -95,20 +97,18 @@ func Install(art io.ReadCloser, dt string, key []byte, scrDir string,
 	return payloads, err
 }
 
-func ReadHeaders(art io.ReadCloser, dt string, key []byte, scrDir string,
+type VerificationKeySelector interface {
+	SelectVerificationKeys(updateTypes ...string) []*conf.VerificationKey
+}
+
+func ReadHeaders(art io.ReadCloser, dt string, keySelector VerificationKeySelector, scrDir string,
 	inst *AllModules) (*Installer, []PayloadUpdatePerformer, error) {
 
-	var ar *areader.Reader
 	var installers []PayloadUpdatePerformer
 	var err error
 
 	// if there is a verification key artifact must be signed
-	if key != nil {
-		ar = areader.NewReaderSigned(art)
-	} else {
-		ar = areader.NewReader(art)
-		log.Info("No public key was provided for authenticating the artifact")
-	}
+	ar := areader.NewReader(art)
 
 	// Important for the client to forbid artifacts types we don't know.
 	ar.ForbidUnknownHandlers = true
@@ -133,6 +133,28 @@ func ReadHeaders(art io.ReadCloser, dt string, key []byte, scrDir string,
 			devices, dt)
 	}
 
+	var selectedKeys []*conf.VerificationKey
+	var shouldBeSigned bool
+	var selectKeysOnce sync.Once
+
+	ar.ShouldBeSignedCallback = func(hInfo artifact.HeaderInfoer) bool {
+		if hInfo == nil {
+			return false
+		}
+		if keySelector == nil {
+			return false
+		}
+		selectKeysOnce.Do(func() {
+			var updateTypes []string
+			for _, update := range hInfo.GetUpdates() {
+				updateTypes = append(updateTypes, *update.Type)
+			}
+			selectedKeys = keySelector.SelectVerificationKeys(updateTypes...)
+			shouldBeSigned = len(selectedKeys) > 0
+		})
+		return shouldBeSigned
+	}
+
 	// VerifySignatureCallback needs to be registered both for
 	// NewReader and NewReaderSigned to print a warning if artifact is signed
 	// but no verification key is provided.
@@ -140,23 +162,33 @@ func ReadHeaders(art io.ReadCloser, dt string, key []byte, scrDir string,
 		// MEN-1196 skip verification of the signature if there is no key
 		// provided. This means signed artifact will be installed on all
 		// devices having no key specified.
-		if key == nil {
+		if len(selectedKeys) == 0 {
 			log.Warn("Installer: Installing signed artifact without verification " +
 				"as verification key is missing")
 			return nil
 		}
 
-		// Do the verification only if the key is provided.
-		s, err := artifact.NewPKIVerifier(key)
-		if err != nil {
-			return err
-		}
-		err = s.Verify(message, sig)
-		if err == nil {
+		verified := false
+		for _, key := range selectedKeys {
+			// Do the verification only if the key is provided.
+			s, err := artifact.NewPKIVerifier(key.Data)
+			if err != nil {
+				log.Errorf("Installer: invalid PKI verification key %q: %v", key.Config.Path, err)
+				continue
+			}
+			if err := s.Verify(message, sig); err != nil {
+				log.Errorf("Installer: verifying with key %q: %v", key.Config.Path, err)
+				continue
+			}
 			// MEN-2152 Provide confirmation in log that digital signature was authenticated.
 			log.Info("Installer: authenticated digital signature of artifact")
+			verified = true
+			break
 		}
-		return err
+		if !verified {
+			return errors.New("failed to verify message with any of the provided verification keys")
+		}
+		return nil
 	}
 
 	scr := statescript.NewStore(scrDir)


### PR DESCRIPTION
https://hub.mender.io/t/multiple-artifactverifykeys/4309/6

Creates a new client config parameter called ArtifactVerifyKeys that is a list of paths to keys. Any matching key can be used to verify an artifact - e.g. if 5 verification keys are provided, only 1 needs to match to verify the artifact.

This also adds the ability to filter keys by update type - so some keys can be specified for use only for certain update types.

This enables a few key features:
- key rotation with a longer grace period by specifying multiple keys while rotating keys.
- separate verification keys for different update types.
- verifying artifacts signed for multiple environments/devices.

Changelog: Commit
Ticket: None

Signed-off-by: Michael Ho <callmemikeh@gmail.com>