### PR TITLE
Do not exit the client binary on proxy errors, and cancel the dials on stopping the server

### DIFF
--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -243,7 +243,7 @@ func (pc *proxyControllerInner) run(initDone chan struct{}) {
 		initDone <- struct{}{}
 		err := pc.server.Serve(l)
 		if err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Proxy Serve failed: %s\n", err)
+			log.Errorf("Proxy Serve failed: %s\n", err)
 		}
 	}(pc.conf.listener, initDone)
 
@@ -257,7 +257,7 @@ func (pc *proxyControllerInner) run(initDone chan struct{}) {
 	defer cancel()
 
 	if err := pc.server.Shutdown(ctx); err != nil {
-		log.Fatalf("Proxy Shutdown failed: %s\n", err)
+		log.Errorf("Proxy Shutdown failed: %s\n", err)
 	}
 
 	pc.quitResp <- struct{}{}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -224,6 +224,7 @@ func (pc *ProxyController) Stop() {
 	<-pc.quitResp
 	pc.isRunning = false
 
+	// Clear the finalizer associated with the proxyController
 	runtime.SetFinalizer(pc, nil)
 }
 

--- a/app/proxy/proxy_ws.go
+++ b/app/proxy/proxy_ws.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package proxy
 // Inspired by https://github.com/koding/websocketproxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +62,10 @@ func (pc *proxyControllerInner) wsAvailable() bool {
 	return len(pc.wsConnections) < maxWsConnections
 }
 
-func (pc *proxyControllerInner) DoWsUpgrade(w http.ResponseWriter, r *http.Request) {
+func (pc *proxyControllerInner) DoWsUpgrade(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request) {
 	// Convert server request to client request and override r.URL
 	r.RequestURI = ""
 	r.Host = ""
@@ -82,7 +86,7 @@ func (pc *proxyControllerInner) DoWsUpgrade(w http.ResponseWriter, r *http.Reque
 		Path:   ApiUrlDevicesConnect,
 	}
 
-	connBackend, resp, err := pc.wsDialer.Dial(wsUrl.String(), requestHeader)
+	connBackend, resp, err := pc.wsDialer.DialContext(ctx, wsUrl.String(), requestHeader)
 	if err != nil {
 		log.Errorf("couldn't dial to remote backend url %q, err: %s", wsUrl.String(), err.Error())
 		if resp != nil {


### PR DESCRIPTION
Previously we would do a log.Fatalf, resulting in an exit from the client upon proxy errors.

This does not play well with our on-abort systemd service policy, meaning that the client will never be restarted upon such exits.

The fix is simple: just log an error instead.

Ticket: ME-3
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
