### PR TITLE
test(docker-client): Do not write to the syslog

### DIFF
--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -23,4 +23,4 @@ if [ -n "$TENANT_TOKEN" ]; then
 fi
 
 /etc/init.d/ssh start
-mender daemon
+mender --no-syslog daemon


### PR DESCRIPTION
The docker-client has no syslog to write to as there is no daemon listening.

Simply disable writing it.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

