### PR TITLE
fix: add missing d-bus path documentation

### DIFF
--- a/Documentation/io.mender.Authentication1.xml
+++ b/Documentation/io.mender.Authentication1.xml
@@ -9,7 +9,10 @@
     This interface lets applications authenticate with the Mender server. The
     Mender client will handle the authentication and provide the user with a
     JSON Web Token (JWT) and the server URL, which the user can use to do API
-    calls to the Mender server on his own.
+    calls to the Mender server on his own. It is exposed at
+
+    * connection: `io.mender.AuthenticationManager`
+    * object: `/io/mender/AuthenticationManager`
   -->
   <interface name="io.mender.Authentication1">
 

--- a/Documentation/io.mender.Update1.xml
+++ b/Documentation/io.mender.Update1.xml
@@ -6,7 +6,10 @@
     io.mender.Update1:
     @short_description: Mender Update Management API v1
 
-    This interface lets applications interact with the update flow.
+    This interface lets applications interact with the update flow. It is exposed at
+
+    * connection: `io.mender.UpdateManager`
+    * object: `/io/mender/UpdateManager`
   -->
   <interface name="io.mender.Update1">
 


### PR DESCRIPTION
In order to access the D-Bus API, the already documented interface path is not sufficient. Add the missing pieces of information:
- connection name
- object name

Changelog: None
Ticket: None

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
