### PR TITLE
feat(logger): Add a thread: <proxy> field to the proxy logger

### DIFF
--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -27,10 +27,12 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/mendersoftware/mender/client"
 )
+
+var log = logrus.WithFields(logrus.Fields{"thread": "proxy"})
 
 const (
 	ProxyHost        = "127.0.0.1"

--- a/app/proxy/proxy_ws.go
+++ b/app/proxy/proxy_ws.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
-	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
Now the proxy logger stands out in the logs more, and can thus be filtered
easier with tools parsing structured logs. This means that a log line from the
`proxy` thread goes from looking like:

```
Oct 05 08:50:06 qemux86-64 mender[259]: time="2022-10-05T08:50:06Z" level=error msg="error forwarding from client to backend: websocket: close 1006 (abnormal closure): unexpected EOF"
```

To:

```
Oct 05 08:50:06 qemux86-64 mender[259]: time="2022-10-05T08:50:06Z" level=error thread="proxy" msg="error forwarding from client to backend: websocket: close 1006 (abnormal closure): unexpected EOF"
```

Changelog: Commit
Ticket: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>