### PR TITLE
ME-5 and MEN-6009: http-proxy fixes

### DIFF
--- a/app/proxy/proxy_ws_test.go
+++ b/app/proxy/proxy_ws_test.go
@@ -434,3 +434,27 @@ func TestProxyWsConnectMutualTLS(t *testing.T) {
 
 	runTestSendReceiveWs(t, srv, proxyController)
 }
+
+func TestProxyWsConnectCustomCertWithReverseProxy(t *testing.T) {
+	httpProxy, err := cltest.NewTestHttpProxy(1, false)
+	require.NoError(t, err)
+	defer func() {
+		err := httpProxy.Stop()
+		require.NoError(t, err)
+	}()
+	t.Setenv("HTTPS_PROXY", httpProxy.GetUrl())
+
+	TestProxyWsConnectCustomCert(t)
+}
+
+func TestProxyWsConnectMutualTLSWithReverseProxy(t *testing.T) {
+	httpProxy, err := cltest.NewTestHttpProxy(1, true)
+	require.NoError(t, err)
+	defer func() {
+		err := httpProxy.Stop()
+		require.NoError(t, err)
+	}()
+	t.Setenv("HTTPS_PROXY", httpProxy.GetUrl())
+
+	TestProxyWsConnectMutualTLS(t)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -14,7 +14,9 @@
 package client
 
 import (
+	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -484,14 +486,35 @@ func loadClientTrust(ctx *openssl.Ctx, conf *Config) (*openssl.Ctx, error) {
 	return ctx, nil
 }
 
-func dialOpenSSL(ctx *openssl.Ctx, conf *Config, _ string, addr string) (net.Conn, error) {
+func establishSSLConnection(
+	addr string,
+	proxyURL *url.URL,
+	ctx *openssl.Ctx,
+	flags openssl.DialFlags,
+) (*openssl.Conn, error) {
+	if proxyURL != nil {
+		proxyConn, err := dialProxy("tcp", addr, proxyURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to connect to proxy")
+		}
+		return openssl.DialUpgrade(addr, proxyConn, ctx, flags)
+	}
+	return openssl.Dial("tcp", addr, ctx, flags)
+}
+
+func dialOpenSSL(
+	ctx *openssl.Ctx,
+	conf *Config,
+	_, addr string,
+	proxyURL *url.URL,
+) (net.Conn, error) {
 	flags := openssl.DialFlags(0)
 
 	if conf.NoVerify {
 		flags = openssl.InsecureSkipHostVerification
 	}
 
-	conn, err := openssl.Dial("tcp", addr, ctx, flags)
+	conn, err := establishSSLConnection(addr, proxyURL, ctx, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -565,7 +588,7 @@ func newHttpsClient(conf Config) (*http.Client, error) {
 		IdleConnTimeout:   time.Duration(idleConnTimeoutSeconds) * time.Second,
 		Proxy:             http.ProxyFromEnvironment,
 		DialTLS: func(network string, addr string) (net.Conn, error) {
-			return dialOpenSSL(ctx, &conf, network, addr)
+			return dialOpenSSL(ctx, &conf, network, addr, nil)
 		},
 	}
 
@@ -717,11 +740,101 @@ func newWebsocketDialerTLS(conf Config) (*websocket.Dialer, error) {
 
 	dialer := websocket.Dialer{
 		NetDialTLSContext: func(_ context.Context, network string, addr string) (net.Conn, error) {
-			return dialOpenSSL(ctx, &conf, network, addr)
+			proxyURL, err := ProxyURLFromHostPortGetter(addr)
+			if err != nil {
+				return nil, errors.Wrapf(err,
+					"Failed to get http-proxy configurations during websocket dial")
+			}
+			return dialOpenSSL(ctx, &conf, network, addr, proxyURL)
 		},
 	}
 
 	return &dialer, nil
+}
+
+// http.ProxyFromEnvironment returns nil if parameter req.URL is localhost.
+// This function variable is public so it can be overriden in tests.
+var ProxyURLFromHostPortGetter = func(addr string) (*url.URL, error) {
+	u, err := url.Parse("https://" + addr)
+	if err != nil {
+		return u, err
+	}
+	return http.ProxyFromEnvironment(&http.Request{URL: u})
+}
+
+func getHostPort(u *url.URL) (hostPort string) {
+	hostPort = u.Host
+	if i := strings.LastIndex(u.Host, ":"); i > strings.LastIndex(u.Host, "]") {
+		return u.Host
+	} else {
+		switch u.Scheme {
+		case "https":
+			hostPort += ":443"
+		default:
+			hostPort += ":80"
+		}
+	}
+	return hostPort
+}
+
+func dialProxy(network string, addr string, proxyURL *url.URL) (net.Conn, error) {
+	var (
+		resp *http.Response
+		err  error
+	)
+	hostPort := getHostPort(proxyURL)
+	conn, err := net.Dial(network, hostPort)
+	if err != nil {
+		return nil, err
+	}
+
+	connectHeader := make(http.Header)
+	if user := proxyURL.User; user != nil {
+		proxyUser := user.Username()
+		if proxyPassword, passwordSet := user.Password(); passwordSet {
+			credential := base64.StdEncoding.EncodeToString([]byte(proxyUser + ":" + proxyPassword))
+			connectHeader.Set("Proxy-Authorization", "Basic "+credential)
+		}
+	}
+
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: addr},
+		Host:   addr,
+		Header: connectHeader,
+	}
+	connectCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	didReadResponse := make(chan struct{})
+
+	go func() {
+		defer close(didReadResponse)
+		if err := connectReq.Write(conn); err != nil {
+			return
+		}
+		br := bufio.NewReader(conn)
+		resp, err = http.ReadResponse(br, connectReq) //nolint:bodyclose
+	}()
+	select {
+	case <-connectCtx.Done():
+		conn.Close()
+		<-didReadResponse
+		return nil, connectCtx.Err()
+	case <-didReadResponse:
+	}
+
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		conn.Close()
+		return nil, errors.Errorf("Response line received from proxy: %s", resp.Status)
+	}
+	return conn, nil
 }
 
 func NewWebsocketDialer(conf Config) (*websocket.Dialer, error) {

--- a/client/test/http_proxy.go
+++ b/client/test/http_proxy.go
@@ -1,0 +1,269 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package test
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/mendersoftware/mender/client"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	client.ProxyURLFromHostPortGetter = func(addr string) (*url.URL, error) {
+		p := os.Getenv("HTTPS_PROXY")
+		if p == "" {
+			return nil, nil
+		}
+		return url.Parse(p)
+	}
+}
+
+const (
+	inetAddrLoopback = "127.0.0.1:0"
+	username         = "user"
+	password         = "password"
+)
+
+type connection struct {
+	clientConn net.Conn
+	serverConn net.Conn
+	wg         *sync.WaitGroup
+}
+
+type TestHttpProxy struct {
+	isRunning          bool
+	listener           net.Listener
+	quit               chan interface{}
+	wg                 *sync.WaitGroup
+	errors             []error
+	connections        map[*connection]bool
+	mut                *sync.Mutex
+	requireAuth        bool
+	numRequiredConns   int
+	numSuccessfulConns int
+}
+
+func NewTestHttpProxy(
+	numRequiredConns int,
+	requireAuth bool,
+) (*TestHttpProxy, error) {
+	listener, err := net.Listen("tcp", inetAddrLoopback)
+	if err != nil {
+		return nil, err
+	}
+	p := &TestHttpProxy{
+		isRunning:        true,
+		listener:         listener,
+		quit:             make(chan interface{}),
+		wg:               new(sync.WaitGroup),
+		errors:           make([]error, 0),
+		connections:      make(map[*connection]bool),
+		mut:              &sync.Mutex{},
+		requireAuth:      requireAuth,
+		numRequiredConns: numRequiredConns,
+	}
+	p.wg.Add(1)
+	go p.serve()
+	return p, nil
+}
+
+func (p *TestHttpProxy) GetUrl() string {
+	if !p.requireAuth {
+		return "http://" + p.listener.Addr().String()
+	}
+	return "http://" + username + ":" + password + "@" + p.listener.Addr().String()
+}
+
+func (p *TestHttpProxy) Stop() error {
+	if p == nil {
+		return nil
+	}
+	close(p.quit)
+	p.listener.Close()
+	p.mut.Lock()
+	p.isRunning = false
+	for c := range p.connections {
+		c.clientConn.Close()
+		c.serverConn.Close()
+	}
+	p.mut.Unlock()
+	p.wg.Wait()
+
+	if len(p.errors) > 0 {
+		return p.errors[0]
+	}
+
+	if p.numRequiredConns >= 0 && p.numRequiredConns != p.numSuccessfulConns {
+		return errors.Errorf(
+			"number of successful connections %d "+
+				"was not equal to required amount of %d",
+			p.numSuccessfulConns,
+			p.numRequiredConns)
+	}
+
+	return nil
+}
+
+func (p *TestHttpProxy) serve() {
+	defer p.wg.Done()
+
+	for {
+		conn, err := p.listener.Accept()
+		if err != nil {
+			select {
+			case <-p.quit:
+				return
+			default:
+				p.appendError(errors.Wrap(err, "failed to accept connection"))
+				return
+			}
+		} else {
+			p.wg.Add(1)
+			go func() {
+				defer p.wg.Done()
+				p.handleConnection(conn)
+			}()
+		}
+	}
+}
+
+func (p *TestHttpProxy) handleConnection(conn net.Conn) {
+	defer conn.Close()
+	br := bufio.NewReader(conn)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		p.appendError(errors.Wrap(err, "failed to read http request"))
+		return
+	}
+
+	if req.Method != http.MethodConnect {
+		if err := sendResponse(conn, http.StatusBadRequest); err != nil {
+			p.appendError(err)
+		}
+		p.appendError(errors.New("initial http request method was not CONNECT"))
+		return
+	}
+
+	if err = p.handleAuth(req); err != nil {
+		if sendErr := sendResponse(conn,
+			http.StatusProxyAuthRequired); sendErr != nil {
+			p.appendError(sendErr)
+		}
+		p.appendError(err)
+		return
+	}
+
+	forwardConn, err := net.Dial("tcp", req.Host)
+	if err != nil {
+		p.appendError(errors.New("failed to dial forwarding target"))
+		return
+	}
+	defer forwardConn.Close()
+
+	if err := sendResponse(conn, http.StatusOK); err != nil {
+		p.appendError(err)
+		return
+	}
+
+	c := &connection{
+		clientConn: conn,
+		serverConn: forwardConn,
+		wg:         new(sync.WaitGroup),
+	}
+
+	p.mut.Lock()
+	p.numSuccessfulConns++
+	if !p.isRunning {
+		p.mut.Unlock()
+		return
+	}
+	p.connections[c] = true
+	p.mut.Unlock()
+
+	c.wg.Add(2)
+	go forwardConnection(c.wg, c.clientConn, c.serverConn)
+	go forwardConnection(c.wg, c.serverConn, c.clientConn)
+	c.wg.Wait()
+
+	p.mut.Lock()
+	delete(p.connections, c)
+	p.mut.Unlock()
+}
+func (p *TestHttpProxy) handleAuth(req *http.Request) error {
+	if !p.requireAuth {
+		return nil
+	}
+	if h := req.Header["Proxy-Authorization"]; h != nil {
+		h = strings.Split(h[0], " ")
+		if len(h) != 2 {
+			return errors.New("received auth header with bad format")
+		}
+		if t := h[0]; t != "Basic" {
+			return errors.Errorf("received auth header with non-Basic type '%s'", t)
+		}
+		bytes, err := base64.StdEncoding.DecodeString(h[1])
+		if err != nil {
+			return errors.New("failed to base64 decode credentials")
+		}
+		creds := strings.Split(string(bytes), ":")
+		if len(creds) != 2 {
+			return errors.New("received credentials in bad format")
+		}
+		if creds[0] != username || creds[1] != password {
+			return errors.New("username or password did not match")
+		}
+	} else {
+		return errors.New("required auth header absent from connect request")
+	}
+	return nil
+}
+
+func (p *TestHttpProxy) appendError(err error) {
+	p.mut.Lock()
+	p.errors = append(p.errors, err)
+	p.mut.Unlock()
+}
+
+func sendResponse(conn net.Conn, statusCode int) error {
+	if err := (&http.Response{
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		StatusCode: statusCode,
+	}).Write(conn); err != nil {
+		return errors.Wrap(err,
+			fmt.Sprintf("failed to write '%d: %s; back to client",
+				statusCode,
+				http.StatusText(statusCode)))
+	}
+	return nil
+}
+
+func forwardConnection(wg *sync.WaitGroup, src net.Conn, dst net.Conn) {
+	_, _ = io.Copy(dst, src)
+	src.Close()
+	dst.Close()
+	wg.Done()
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/godbus/dbus v4.1.0+incompatible
 	github.com/gorilla/websocket v1.4.3-0.20220104015952-9111bb834a68
 	github.com/mendersoftware/mender-artifact v0.0.0-20220913084855-9ed8ad0d53d0
-	github.com/mendersoftware/openssl v0.0.0-20220610125625-9fe59ddd6ba4
+	github.com/mendersoftware/openssl v1.1.1-0.20221101131127-8797d18baf1a
 	github.com/mendersoftware/progressbar v0.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,9 @@ github.com/mendersoftware/cli/v2 v2.1.1-minimal h1:NWX83kF8Eobfb3oBWeUmw9Ef2H9Zq
 github.com/mendersoftware/cli/v2 v2.1.1-minimal/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/mendersoftware/mender-artifact v0.0.0-20220913084855-9ed8ad0d53d0 h1:ZHMmgWD6G1b4MywhXs11MWqdoFU4AsSjMTaG2LTjfGo=
 github.com/mendersoftware/mender-artifact v0.0.0-20220913084855-9ed8ad0d53d0/go.mod h1:eQHxeBLK2D2OltPBY77ZiVuTEx8YRAJrkD1l4FwTfsA=
-github.com/mendersoftware/openssl v0.0.0-20220610125625-9fe59ddd6ba4 h1:RNC/c9KxP541F5MdM8ejzSIIRyvF2l74mj6PvvwDdvE=
 github.com/mendersoftware/openssl v0.0.0-20220610125625-9fe59ddd6ba4/go.mod h1:tikEC94q+Y0TU6r19L6mHzwruoTNYPEkrQPvsHEcQyU=
+github.com/mendersoftware/openssl v1.1.1-0.20221101131127-8797d18baf1a h1:7Jnq9cHfBkvBTggigPyJRWW1wZ8WUbIfddg8L2wjMSM=
+github.com/mendersoftware/openssl v1.1.1-0.20221101131127-8797d18baf1a/go.mod h1:tikEC94q+Y0TU6r19L6mHzwruoTNYPEkrQPvsHEcQyU=
 github.com/mendersoftware/progressbar v0.0.3 h1:AUdBGPvXO0l9i39rmXKZbEAPet2FzBeiG8b30D5/2Vc=
 github.com/mendersoftware/progressbar v0.0.3/go.mod h1:NYaLNLhy3UXkRweGjhR3We3Q1ngmUmOWjC3+m8EzwjE=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=

--- a/vendor/github.com/mendersoftware/openssl/net.go
+++ b/vendor/github.com/mendersoftware/openssl/net.go
@@ -149,3 +149,53 @@ func DialSession(network, addr string, ctx *Ctx, flags DialFlags,
 	}
 	return conn, nil
 }
+
+// DialUpgrade upgrades the tcpConn connection to an OpenSSL client connection
+// using context ctx.
+// If flags includes InsecureSkipHostVerification, the server certificate's
+// hostname will not be checked to match the hostname in addr. Otherwise, flags
+// should be 0.
+//
+// DialUgrade probably won't work for you unless you set a verify location or
+// add some certs to the certificate store of the client context you're using.
+// This library is not nice enough to use the system certificate store by
+// default for you yet.
+func DialUpgrade(addr string, tcpConn net.Conn, ctx *Ctx, flags DialFlags) (*Conn, error) {
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		var err error
+		ctx, err = NewCtx()
+		if err != nil {
+			return nil, err
+		}
+	}
+	conn, err := Client(tcpConn, ctx)
+	if err != nil {
+		tcpConn.Close()
+		return nil, err
+	}
+	if flags&DisableSNI == 0 {
+		err = conn.SetTlsExtHostName(host)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	err = conn.Handshake()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if flags&InsecureSkipHostVerification == 0 {
+		err = conn.VerifyHostname(host)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	return conn, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/mendersoftware/mender-artifact/artifact/stage
 github.com/mendersoftware/mender-artifact/awriter
 github.com/mendersoftware/mender-artifact/handlers
 github.com/mendersoftware/mender-artifact/utils
-# github.com/mendersoftware/openssl v0.0.0-20220610125625-9fe59ddd6ba4
+# github.com/mendersoftware/openssl v1.1.1-0.20221101131127-8797d18baf1a
 ## explicit
 github.com/mendersoftware/openssl
 github.com/mendersoftware/openssl/utils


### PR DESCRIPTION
Two commits:

fix: websocket connectivity through http-proxy if configured

Enables websocket connections to be established through an http-proxy configurable by setting the `HTTPS_PROXY` environment variable. This renders services that relies on websocket connections, such as `mender-connect`, compatible with http-proxying.

Changelog: All
Ticket: ME-5
Signed-off-by: Mikael Torp-Holte <mikael.torp-holte@northern.tech>

`---`

fix: client not to skip custom TLS if an http-proxy is configured

Previously, Mender client supported http-proxying but ignored custom TLS client configuration if present. This change renders any custom TLS configurations, such as Mutual TLS, compatible with http-proxying.


Changelog: All
Ticket: MEN-6009
Signed-off-by: Mikael Torp-Holte <mikael.torp-holte@northern.tech>