### PR TITLE
chore: Revert "chore(tests/Dockerfile.daemon): Update base image to Ubuntu 22" 

### DIFF
--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -1,6 +1,6 @@
 # Creates a container which acts as a bare bones non-VM based Mender
 # installation, for use in tests.
-FROM ubuntu:22.04 AS build
+FROM ubuntu:20.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y make git build-essential golang liblzma-dev jq libssl-dev libglib2.0-dev curl
@@ -23,7 +23,7 @@ RUN mender-artifact write bootstrap-artifact \
         --provides "rootfs-image.version:original" \
         --output-path /bootstrap.mender
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN apt update && apt install -y openssh-server
 


### PR DESCRIPTION
This reverts commit 9e0a11aead94c6cee32a530ec34f7e7bcd9480ca.

Seems to be a problem in CI building this image. Revert the upgrade for now to unblock other work and follow-up independently.