### PR TITLE
fix: systemd: Always try restarting the client if it exits.

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -9,7 +9,7 @@ Type=idle
 User=root
 Group=root
 ExecStart=/usr/bin/mender daemon
-Restart=on-abort
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The reason we didn't do this originally was to make the unit show up as "failed" when encountering permanent errors. "Permanent errors" are essentially "all regular exit codes", but not signals. However, because we handle most signals and return an exit code for those too, it does not always work well in certain scenarios, one of them being the OOM killer, which may try to use SIGTERM before SIGKILL. In this case the client would stay dead, even though we should try to relaunch it.

It appears that systemd does consider the unit failed if it restarts often enough, which will happen when there's a permanent error. Therefore we don't need to keep it dead at all, and can just restart it always, which is anyway a good safety net to have.

Changelog: Title
Ticket: ME-33

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>