### PR TITLE
3.3.x: fix: do not ignore software versioning opts in the module artifact gens

### DIFF
--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -96,7 +96,7 @@ while (( "$#" )); do
       ;;
     --)
       shift
-      passthrough_args="$@"
+      passthrough_args="$passthrough_args $@"
       break
       ;;
     -*)

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -96,7 +96,7 @@ while (( "$#" )); do
       ;;
     --)
       shift
-      passthrough_args="$@"
+      passthrough_args="$passthrough_args $@"
       break
       ;;
     -*)

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -94,7 +94,7 @@ while [ -n "$1" ]; do
       ;;
     --)
       shift
-      passthrough_args="$@"
+      passthrough_args="$passthrough_args $@"
       break
       ;;
     -*)


### PR DESCRIPTION
Propagate the software versioning opts to the mender-artifact command. Before this commit, the options were swallowed and ignored.

Ticket: MEN-6026
Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit cbefdcc1b6c9322149f4741179568bcc469359db)