### PR TITLE
feat: support overriding default folders using environment variables

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,7 +50,12 @@ const (
 		"(see list of COMMANDS below).\n\n" +
 		"Global flag remarks:\n" +
 		"  - Supported log levels incudes: 'debug', 'info', " +
-		"'warning', 'error', 'panic' and 'fatal'.\n"
+		"'warning', 'error', 'panic' and 'fatal'.\n\n" +
+		"Environment variables:\n" +
+		"  - MENDER_CONF_DIR - configuration (default: /etc/mender).\n" +
+		"  - MENDER_DATA_DIR - identity, inventory and update modules " +
+		"(default: /usr/share/mender).\n" +
+		"  - MENDER_DATASTORE_DIR - runtime datastore (default: /var/lib/mender).\n"
 	snapshotDescription = "Creates a snapshot of the currently running " +
 		"rootfs. The snapshots can be passed as a rootfs-image to the " +
 		"mender-artifact tool to create an update based on THIS " +

--- a/conf/paths.go
+++ b/conf/paths.go
@@ -18,6 +18,7 @@
 package conf
 
 import (
+	"os"
 	"path"
 )
 
@@ -25,10 +26,19 @@ const (
 	BrokenArtifactSuffix = "_INCONSISTENT"
 )
 
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
 var (
-	// needed so that we can override it when testing
-	DefaultPathDataDir = "/usr/share/mender"
-	DefaultDataStore   = "/var/lib/mender"
+	// needed so that we can override it when testing or deploying on partially read-only systems
+	DefaultPathConfDir = getenv("MENDER_CONF_DIR", "/etc/mender")
+	DefaultPathDataDir = getenv("MENDER_DATA_DIR", "/usr/share/mender")
+	DefaultDataStore   = getenv("MENDER_DATASTORE_DIR", "/var/lib/mender")
 	DefaultKeyFile     = "mender-agent.pem"
 
 	DefaultConfFile         = path.Join(GetConfDirPath(), "mender.conf")
@@ -57,5 +67,5 @@ func GetStateDirPath() string {
 }
 
 func GetConfDirPath() string {
-	return "/etc/mender"
+	return DefaultPathConfDir
 }


### PR DESCRIPTION
needed when deploying on partially read-only systems

Changelog: The default folders (/etc/mender, /data/mender, /usr/share/mender) can now be overridden through the environment variables: `MENDER_CONF_DIR`, `MENDER_DATA_DIR`, `MENDER_DATASTORE_DIR`.

Ticket: None
Signed-off-by: Uri Ishon <uishon@gmail.com>