### PR TITLE
test: fix the race-condition in the DaemonRun unit test

### DIFF
--- a/app/daemon_test.go
+++ b/app/daemon_test.go
@@ -245,7 +245,7 @@ func TestDaemonRun(t *testing.T) {
 
 		t.Logf("poke count: %v", dtc.updateCheckCount)
 		assert.GreaterOrEqual(t, dtc.updateCheckCount, (timespolled - 1))
-		assert.Less(t, dtc.updateCheckCount, (timespolled + 1))
+		assert.LessOrEqual(t, dtc.updateCheckCount, (timespolled + 1))
 
 	})
 	t.Run("testing state machine interrupt functionality - updateCheck state", func(t *testing.T) {


### PR DESCRIPTION
This fixes the race-condition in the DaemonRun test through allowing the
UpdateCheckCount to be one higher than currently allowed.

The reason for adding this is that the update check is actually really close to
being triggered 6 times. If you look at the timeline below:

0  1  2  3  4  5
|--|--|--|--|--|-
u1 u2 u3 u4 u5 u6
i1 i2 i3 i4 i5 i6

Here you can see that the update should really be sent 6-times, if the client is
fast, and the tests are a little bit slow.

In fact, it is really easy to trigger locally, by making the test-thread a
little bit slower with the added sleep:

```
		time.Sleep(time.Duration(timespolled)*pollInterval + time.Duration(10)*time.Millisecond)
```

Then, you will get 6 update check attempts every time locally.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 7d45ee8cba272fd4cbd6f6762166cafd82f4695a)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>