### PR TITLE
fix: duplicate journald log entries in some systemd configurations

### DIFF
--- a/support/mender-client.service
+++ b/support/mender-client.service
@@ -8,7 +8,7 @@ Conflicts=mender.service
 Type=idle
 User=root
 Group=root
-ExecStart=/usr/bin/mender daemon
+ExecStart=/usr/bin/mender --no-syslog daemon
 Restart=always
 
 [Install]


### PR DESCRIPTION
Since systemd v213, `journald` symlinks `/dev/log` to point to itself. The syslogger in mender-client is configured by default to forward log messages to `/dev/log`. `journald` will receive duplicate log messages; one from `/dev/log` and one from `stdout`.

Changelog: Add `--no-syslog` to the service file to ensure no duplicate log messages in the journal.

Ticket: MEN-6070
Signed-off-by: Mikael Torp-Holte <mikael.torp-holte@northern.tech>