### PR TITLE
feat: Extend the coverage support a little bit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ DBUS_POLICY_FILES = \
 
 build: mender
 
-mender:
-	g++ -o mender main.cpp $(CXXFLAGS) $(LDFLAGS)
+mender: main.cpp lib.cpp
+	g++ -o mender main.cpp lib.cpp $(CXXFLAGS) $(LDFLAGS)
 
 install: install-bin \
 	install-conf \
@@ -181,14 +181,16 @@ coverage: Makefile
 		--directory . \
 		--output-file coverage.lcov \
 		--exclude '/usr/*' \
-		--exclude '*/googletest/*'
+		--exclude '*/googletest/*' \
+		--exclude '*_test.*'
 
 vendor/googletest/lib/libgtest.a:
 	( cd vendor/googletest && cmake . && make )
 
-main_test: main_test.cpp Makefile vendor/googletest/lib/libgtest.a
+main_test: main_test.cpp lib.cpp Makefile vendor/googletest/lib/libgtest.a
 	g++ \
 		-o main_test \
+		lib.cpp \
 		main_test.cpp \
 		-pthread \
 		vendor/googletest/lib/libgtest.a \

--- a/lib.cpp
+++ b/lib.cpp
@@ -12,10 +12,15 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include <gtest/gtest.h>
+#include <unistd.h>
 
-int GetTheAnswerToLifeTheUniverseAndEverything();
+#include <iostream>
 
-TEST(Main, Main) {
-	EXPECT_EQ(GetTheAnswerToLifeTheUniverseAndEverything(), 42) << "Printed if test fails";
+using namespace std;
+
+int GetTheAnswerToLifeTheUniverseAndEverything() {
+	if (getpid() == 1) {
+		cout << "Branch we will never hit\n";
+	}
+	return 42;
 }


### PR DESCRIPTION
* Introduce "fake" missed coverage. The resulting number (75%) is closer to what we actually have in the client.

* Omit "_test.*" files from coverage report.

* Test something which is in a "production" source file.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
