### PR TITLE
fix: Tell curl to follow redirects when downloading .clang-format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ exceptions. To run automatic code style formatting on files you modify, use our
 template](https://github.com/mendersoftware/mendertesting/blob/master/.clang-format):
 
 ```bash
-curl -O https://github.com/mendersoftware/mendertesting/raw/master/.clang-format
+curl -L -O https://github.com/mendersoftware/mendertesting/raw/master/.clang-format
 clang-format -i --style=file:.clang-format <MODIFIED_FILES>
 ```
 


### PR DESCRIPTION
Otherwise it creates an empty file because the URL returns 302 and a different location. Feels like it is more future-proof to use -L here than the target URL directly.

Ticket: None
Changelog: None
Signed-off-by: Vratislav Podzimek <vratislav.podzimek@northern.tech>