### PR TITLE
Initial logging library implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 /compile
 /config.guess
 /config.h
-/config.h.in
 /config.log
 /config.status
 /config.sub

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ test:
   stage: test
   image: debian:11
   before_script:
-    - apt update && apt install -yyq g++ cmake git make lcov pkg-config liblmdb++-dev libboost-dev
+    - apt update && apt install -yyq g++ cmake git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev
   script:
     - cmake -D COVERAGE=ON .
     - make coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if (MENDER_DOWNLOAD_GTEST)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   ### END
 
-  set(BUILD_GMOCK OFF)
+  set(BUILD_GMOCK ON)
   set(INSTALL_GTEST OFF)
   FetchContent_MakeAvailable(googletest)
 
@@ -47,6 +47,10 @@ endif()
 
 # TODO: proper platform detection
 set(PLATFORM linux_x86)
+
+
+option(MENDER_LOG_BOOST "Use Boost as the underlying logging library provider (Default: ON)" ON)
+configure_file(config.h.in config.h)
 
 add_library(mender_compiler_flags INTERFACE)
 target_compile_features(mender_compiler_flags INTERFACE cxx_std_11)
@@ -67,7 +71,7 @@ endif()
 add_custom_target(coverage
   COMMAND lcov --capture --quiet --directory .
                --output-file coverage.lcov
-               --exclude '/usr/*' --exclude '*/googletest/*' --exclude '*_test.*'
+               --exclude '/usr/*' --exclude '*/googletest/*' --exclude '*_test.*' --exclude '*/googlemock/*'
   DEPENDS coverage_enabled check
 )
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -34,3 +34,19 @@ target_link_libraries(events_test PUBLIC common_events GTest::gtest_main)
 target_include_directories(events_test PRIVATE ../)
 gtest_discover_tests(events_test ${MENDER_TEST_FLAGS})
 add_dependencies(check events_test)
+
+add_library(common_log STATIC)
+target_include_directories(common_log PRIVATE ../)
+target_include_directories(common_log PUBLIC "${CMAKE_BINARY_DIR}")
+# Accept the global compiler flags
+target_link_libraries(common_log PUBLIC mender_compiler_flags)
+find_package(Boost 1.54 REQUIRED COMPONENTS log log_setup chrono regex thread filesystem atomic)
+target_sources(common_log PUBLIC log/platform/boost/boost_log.cpp)
+target_link_libraries(common_log PUBLIC ${Boost_LIBRARIES})
+
+# Test MenderLog
+add_executable(log_test EXCLUDE_FROM_ALL log_test.cpp)
+target_link_libraries(log_test PRIVATE common_log GTest::gtest_main gmock)
+target_include_directories(log_test PRIVATE ../)
+gtest_discover_tests(log_test)
+add_dependencies(check log_test)

--- a/common/log.hpp
+++ b/common/log.hpp
@@ -1,0 +1,158 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_LOG_HPP
+#define MENDER_LOG_HPP
+
+#include <config.h>
+
+#ifdef MENDER_LOG_BOOST
+#include <boost/log/common.hpp>
+#include <boost/log/sources/logger.hpp>
+#endif
+
+#include <string>
+#include <cassert>
+
+namespace mender::common::log {
+
+using namespace std;
+
+struct LogField {
+	LogField(const string &key, const string &value) :
+		key(key),
+		value(value) {
+	}
+
+	string key;
+	string value;
+};
+
+
+enum class LogLevel {
+	Fatal = 0,
+	Error = 1,
+	Warning = 2,
+	Info = 3,
+	Debug = 4,
+	Trace = 5,
+};
+
+inline string to_string_level(LogLevel lvl) {
+	switch (lvl) {
+	case LogLevel::Fatal:
+		return "fatal";
+	case LogLevel::Error:
+		return "error";
+	case LogLevel::Warning:
+		return "warning";
+	case LogLevel::Info:
+		return "info";
+	case LogLevel::Debug:
+		return "debug";
+	case LogLevel::Trace:
+		return "trace";
+	}
+	assert(false);
+}
+
+
+void Setup();
+
+class Logger {
+private:
+#ifdef MENDER_LOG_BOOST
+	boost::log::sources::severity_logger<LogLevel> logger;
+#endif
+
+	LogLevel level_ {LogLevel::Info};
+
+	string name_ {};
+
+	void AddField(const LogField &field);
+
+public:
+	explicit Logger(const string &name);
+	Logger(const string &name, LogLevel level);
+
+	void SetLevel(LogLevel level);
+
+	LogLevel Level();
+
+	template <typename... Fields>
+	Logger WithFields(const Fields &...fields) {
+		auto l = Logger(this->name_);
+		l.SetLevel(this->level_);
+		for (const auto f : {fields...}) {
+			l.AddField(f);
+		}
+		return l;
+	}
+
+	void Log(LogLevel level, const string &message);
+
+	void Fatal(const string &message) {
+		Log(LogLevel::Fatal, message);
+	}
+
+	void Error(const string &message) {
+		Log(LogLevel::Error, message);
+	}
+
+	void Warning(const string &message) {
+		Log(LogLevel::Warning, message);
+	}
+
+	void Info(const string &message) {
+		Log(LogLevel::Info, message);
+	}
+
+	void Debug(const string &message) {
+		Log(LogLevel::Debug, message);
+	}
+
+	void Trace(const string &message) {
+		Log(LogLevel::Trace, message);
+	}
+};
+
+
+} // namespace mender::common::log
+
+
+// Add a global logger to the namespace
+namespace mender::common::log {
+
+extern Logger global_logger_;
+
+void SetLevel(LogLevel level);
+
+LogLevel Level();
+
+template <typename... Fields>
+Logger WithFields(const Fields &...fields) {
+	return global_logger_.WithFields(fields...);
+}
+
+void Log(LogLevel level, const string &message);
+void Fatal(const string &message);
+void Error(const string &message);
+void Warning(const string &message);
+void Info(const string &message);
+void Debug(const string &message);
+void Trace(const string &message);
+
+} // namespace mender::common::log
+
+#endif // MENDER_LOG_HPP

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -1,0 +1,169 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/log.hpp>
+
+
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/core/null_deleter.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/log/common.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/attributes.hpp>
+#include <boost/log/sinks.hpp>
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/log/attributes/scoped_attribute.hpp>
+#include <boost/log/support/date_time.hpp>
+
+#include <string>
+
+namespace mender::common::log {
+
+namespace logging = boost::log;
+namespace expr = boost::log::expressions;
+namespace sinks = boost::log::sinks;
+namespace attrs = boost::log::attributes;
+namespace src = boost::log::sources;
+namespace keywords = boost::log::keywords;
+
+using namespace std;
+
+
+static void LogfmtFormatter(logging::record_view const &rec, logging::formatting_ostream &strm) {
+	strm << "record_id=" << logging::extract<unsigned int>("RecordID", rec) << " ";
+
+	auto level = logging::extract<LogLevel>("Severity", rec);
+	if (level) {
+		std::string lvl = to_string_level(level.get());
+		strm << "severity=" << lvl << " ";
+	}
+
+	auto val = logging::extract<boost::posix_time::ptime>("TimeStamp", rec);
+	if (val) {
+		strm << "time=\"" << val.get() << "\" ";
+	}
+
+	auto name = logging::extract<std::string>("Name", rec);
+	if (name) {
+		strm << "name=\"" << name.get() << "\" ";
+	}
+
+	for (auto f : rec.attribute_values()) {
+		auto field = logging::extract<LogField>(f.first.string(), rec);
+		if (field) {
+			strm << field.get().key << "=\"" << field.get().value << "\" ";
+		}
+	}
+
+	strm << "msg=\"" << rec[expr::smessage] << "\" ";
+}
+
+static void SetupLoggerSinks() {
+	typedef sinks::synchronous_sink<sinks::text_ostream_backend> text_sink;
+	boost::shared_ptr<text_sink> sink(new text_sink);
+
+	{
+		text_sink::locked_backend_ptr pBackend = sink->locked_backend();
+		boost::shared_ptr<std::ostream> pStream(&std::clog, boost::null_deleter());
+		pBackend->add_stream(pStream);
+	}
+
+	sink->set_formatter(&LogfmtFormatter);
+
+	logging::core::get()->add_sink(sink);
+}
+
+static void SetupLoggerAttributes() {
+	attrs::counter<unsigned int> RecordID(1);
+	logging::core::get()->add_global_attribute("RecordID", RecordID);
+
+	attrs::local_clock TimeStamp;
+	logging::core::get()->add_global_attribute("TimeStamp", TimeStamp);
+}
+
+Logger::Logger(const string &name) :
+	name_(name) {
+	src::severity_logger<LogLevel> slg;
+	slg.add_attribute("Name", attrs::constant<std::string>(name));
+	this->logger = slg;
+}
+
+Logger::Logger(const string &name, LogLevel level) :
+	name_(name),
+	level_(level) {
+	src::severity_logger<LogLevel> slg;
+	slg.add_attribute("Name", attrs::constant<std::string>(name));
+	this->logger = slg;
+}
+
+void Logger::Log(LogLevel level, const string &message) {
+	BOOST_LOG_SEV(this->logger, level) << message;
+}
+
+void Logger::SetLevel(LogLevel level) {
+	this->level_ = level;
+	boost::log::core::get()->set_filter(expr::attr<LogLevel>("Severity") <= level);
+}
+
+LogLevel Logger::Level() {
+	return this->level_;
+}
+
+void Logger::AddField(const LogField &field) {
+	this->logger.add_attribute(field.key, attrs::constant<LogField>(field));
+	return;
+}
+
+void Setup() {
+	SetupLoggerSinks();
+	SetupLoggerAttributes();
+	global_logger_.SetLevel(LogLevel::Info);
+}
+
+Logger global_logger_ = Logger("Global");
+
+void SetLevel(LogLevel level) {
+	global_logger_.SetLevel(level);
+}
+
+LogLevel Level() {
+	return global_logger_.Level();
+}
+
+void Log(LogLevel level, const string message) {
+	global_logger_.Log(level, message);
+}
+
+void Fatal(const string &message) {
+	return global_logger_.Log(LogLevel::Fatal, message);
+}
+void Error(const string &message) {
+	return global_logger_.Log(LogLevel::Error, message);
+}
+void Warning(const string &message) {
+	return global_logger_.Log(LogLevel::Warning, message);
+}
+void Info(const string &message) {
+	return global_logger_.Log(LogLevel::Info, message);
+}
+void Debug(const string &message) {
+	return global_logger_.Log(LogLevel::Debug, message);
+}
+void Trace(const string &message) {
+	return global_logger_.Log(LogLevel::Trace, message);
+}
+
+
+} // namespace mender::common::log

--- a/common/log_test.cpp
+++ b/common/log_test.cpp
@@ -1,0 +1,128 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/log.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <fstream>
+
+
+using namespace std;
+
+class LogTestEnv : public testing::Test {
+protected:
+	mender::common::log::Logger logger = mender::common::log::Logger("TestLogger");
+	static void SetUpTestSuite() {
+		// Only call log::Setup() once for the test suite
+		mender::common::log::Setup();
+	}
+
+	void SetUp() override {
+		namespace log = mender::common::log;
+		log::SetLevel(log::LogLevel::Info);
+	}
+};
+
+TEST_F(LogTestEnv, SetLogLevel) {
+	namespace log = mender::common::log;
+
+	auto logger = log::Logger("TestLogger");
+
+	EXPECT_EQ(log::LogLevel::Info, logger.Level())
+		<< "Unexpected standard LogLevel - should be Info";
+	logger.SetLevel(log::LogLevel::Warning);
+	EXPECT_EQ(log::LogLevel::Warning, logger.Level());
+}
+
+
+TEST_F(LogTestEnv, GlobalLoggerSetLogLevel) {
+	namespace log = mender::common::log;
+
+	EXPECT_EQ(log::LogLevel::Info, logger.Level())
+		<< "Unexpected standard LogLevel - should be Info";
+	log::SetLevel(log::LogLevel::Warning);
+	EXPECT_EQ(log::LogLevel::Warning, log::Level());
+
+	log::SetLevel(log::LogLevel::Info);
+}
+
+TEST_F(LogTestEnv, LogLevelFilter) {
+	namespace log = mender::common::log;
+	testing::internal::CaptureStderr();
+	auto logger = log::Logger("TestLogger");
+	ASSERT_EQ(log::Level(), log::LogLevel::Info);
+
+	// All log levels above and including Info
+	logger.Warning("Foobar");
+	logger.Error("Foobar");
+	logger.Info("Foobar");
+	string output = testing::internal::GetCapturedStderr();
+	EXPECT_GT(output.size(), 0) << "Captured output: " << output << std::endl;
+
+	// All log levels below Info
+	testing::internal::CaptureStderr();
+	logger.Trace("BarBaz");
+	logger.Debug("BarBaz");
+	output = testing::internal::GetCapturedStderr();
+	EXPECT_EQ(output.size(), 0) << "Output is: " << output;
+}
+
+TEST_F(LogTestEnv, GlobalLoggerLogLevelFilter) {
+	namespace log = mender::common::log;
+	testing::internal::CaptureStderr();
+	ASSERT_EQ(log::Level(), log::LogLevel::Info);
+
+	// All log levels above and including Info
+	log::Warning("Foobar");
+	log::Error("Foobar");
+	log::Info("Foobar");
+	string output = testing::internal::GetCapturedStderr();
+	EXPECT_GT(output.size(), 0) << "Captured output: " << output << std::endl;
+
+	// All log levels below Info
+	testing::internal::CaptureStderr();
+	log::Trace("BarBaz");
+	log::Debug("BarBaz");
+	output = testing::internal::GetCapturedStderr();
+	EXPECT_EQ(output.size(), 0) << "Output is: " << output;
+}
+
+TEST_F(LogTestEnv, StructuredLogging) {
+	namespace log = mender::common::log;
+	auto logger = log::Logger("TestLogger", log::LogLevel::Info);
+	ASSERT_EQ(log::Level(), log::LogLevel::Info);
+
+	testing::internal::CaptureStderr();
+	logger.WithFields(log::LogField("foo", "bar"), log::LogField {"test", "ing"}).Info("Foobar");
+	auto output = testing::internal::GetCapturedStderr();
+	EXPECT_GT(output.size(), 0) << "Output is: " << output;
+	EXPECT_THAT(output, testing::HasSubstr("foo=\"bar\""))
+		<< "LogLevel: " << to_string_level(log::Level());
+	EXPECT_THAT(output, testing::HasSubstr("test=\"ing\""));
+}
+
+TEST_F(LogTestEnv, GlobalLoggerStructuredLogging) {
+	namespace log = mender::common::log;
+	ASSERT_EQ(log::Level(), log::LogLevel::Info);
+
+	testing::internal::CaptureStderr();
+	log::WithFields(log::LogField("foo", "bar"), log::LogField {"test", "ing"}).Info("Foobar");
+	auto output = testing::internal::GetCapturedStderr();
+	EXPECT_GT(output.size(), 0) << "Output is: " << output;
+	EXPECT_THAT(output, testing::HasSubstr("foo=\"bar\""))
+		<< "LogLevel: " << to_string_level(log::Level());
+	EXPECT_THAT(output, testing::HasSubstr("test=\"ing\""));
+}

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine MENDER_LOG_BOOST

--- a/mender-auth/CMakeLists.txt
+++ b/mender-auth/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(mender-auth main.cpp)
-target_link_libraries(mender-auth PRIVATE common_json common_kv_db)
+target_link_libraries(mender-auth PRIVATE common_json common_kv_db common_log)
 target_link_libraries(mender-auth PUBLIC mender_compiler_flags)
 target_include_directories(mender-auth PUBLIC ../)
 install(TARGETS mender-auth DESTINATION bin)

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(mender-update main.cpp)
-target_link_libraries(mender-update PRIVATE common_json common_kv_db)
+target_link_libraries(mender-update PRIVATE common_json common_kv_db common_log)
 target_link_libraries(mender-update PUBLIC mender_compiler_flags)
 target_include_directories(mender-update PUBLIC ../)
 install(TARGETS mender-update DESTINATION bin)

--- a/mender-update/main.cpp
+++ b/mender-update/main.cpp
@@ -20,6 +20,7 @@ using namespace std;
 #include <common/json.hpp>
 #include <common/kv_db.hpp>
 #include <common/expected.hpp>
+#include <common/log.hpp>
 
 enum ExampleErrorCode {
 	NoError = 0,
@@ -31,11 +32,45 @@ void hello_world(std::shared_ptr<json::Json> j, std::shared_ptr<kv_db::KeyValueD
 	db->hello_world();
 }
 
+void log_poc() {
+	namespace log = mender::common::log;
+
+	log::Setup();
+
+	auto logger = log::Logger("NamedLogger");
+
+	logger.Log(log::LogLevel::Info, "Test log");
+
+	auto sub_logger = logger.WithFields(log::LogField("foo", "bar"), log::LogField("bar", "baz"));
+
+	sub_logger.Log(log::LogLevel::Error, "Some error");
+
+	logger.Info("Some info message");
+
+	logger.SetLevel(log::LogLevel::Warning);
+
+	logger.Info("I should never show up");
+
+	logger.SetLevel(log::LogLevel::Debug);
+
+	logger.Log(log::LogLevel::Trace, "I should not show");
+	logger.Log(log::LogLevel::Debug, "I should show test");
+
+	// Global logger
+
+	log::SetLevel(log::LogLevel::Info);
+
+	log::WithFields(log::LogField("test", "ing")).Info("Bugs bunny");
+	log::Info("Foobar");
+	log::Warning("Hur-dur");
+}
+
 int main() {
 	shared_ptr<json::Json> j = make_shared<json::Json>();
 	shared_ptr<kv_db::KeyValueDB> db = make_shared<kv_db::KeyValueDB>();
 
 	hello_world(j, db);
+	log_poc();
 
 	using ExampleError = mender::common::error::Error<ExampleErrorCode>;
 	using ExpectedExampleString = mender::common::expected::Expected<string, ExampleError>;

--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y cmake make git build-essential jq curl pkg-config liblmdb++-dev libboost-dev
+RUN apt update && apt install -y cmake make git build-essential jq curl pkg-config liblmdb++-dev libboost-dev libboost-log-dev
 
 WORKDIR /cpp/src/github.com/mendersoftware/mender
 COPY ./ .


### PR DESCRIPTION
This is my initial attempt at the structured logger interface.

I know it is probably rough, but at least it's in a working state now. Example output:

```console
record_id=1 severity=info time="2023-Jan-10 15:02:23.770474" name="Test" msg="Test log"
record_id=2 severity=error time="2023-Jan-10 15:02:23.771073" name="Foo" foo="bar" bar="baz" msg="Some error"
record_id=3 severity=info time="2023-Jan-10 15:02:23.771282" name="Test" msg="Some info message"
record_id=4 severity=debug time="2023-Jan-10 15:02:23.771475" name="Test" msg="I should show test"
```

Obviously rough, and can/should be changed, but I think you get the jist of it.

Currently in order to add fields to your log record you need to call the `withFields` method. The reason for this is that in boost attributes have to be added to a logger, and not to records directly (at least as far as I found - feel free to prove me wrong.). So it is this, or creating a logger per record, in the case we want:

```
log.info("foobarbaz", log::LogField{"test", "field"});
```

I personally feel this is good enough to move on, but then again - shoot me down at will.

