### PR TITLE
chore: egrep is obsolescent; use grep -E

### DIFF
--- a/support/mender-inventory-os
+++ b/support/mender-inventory-os
@@ -9,7 +9,7 @@ for file in /etc/os-release /usr/lib/os-release; do
         continue
     fi
 
-    eval "$(egrep '^(PRETTY_NAME|NAME|VERSION)=("[^"]*"|[^" ]*)' $file)"
+    eval "$(grep -E '^(PRETTY_NAME|NAME|VERSION)=("[^"]*"|[^" ]*)' $file)"
     if [ -n "$PRETTY_NAME" ]; then
         echo "os=$PRETTY_NAME"
         exit 0

--- a/tests/rootfs-image-v2
+++ b/tests/rootfs-image-v2
@@ -7,8 +7,8 @@ set -ue
 # - MENDER_ROOTFS_PART_B
 . /etc/mender/rootfs-image-v2.conf
 
-MENDER_ROOTFS_PART_A_NUMBER="$(echo "$MENDER_ROOTFS_PART_A" | egrep -o '[0-9]+$')"
-MENDER_ROOTFS_PART_B_NUMBER="$(echo "$MENDER_ROOTFS_PART_B" | egrep -o '[0-9]+$')"
+MENDER_ROOTFS_PART_A_NUMBER="$(echo "$MENDER_ROOTFS_PART_A" | grep -Eo '[0-9]+$')"
+MENDER_ROOTFS_PART_B_NUMBER="$(echo "$MENDER_ROOTFS_PART_B" | grep -Eo '[0-9]+$')"
 
 if command -v grub-mender-grubenv-print > /dev/null; then
     PRINTENV=grub-mender-grubenv-print


### PR DESCRIPTION
Changelog: Replace obsolescent `egrep` with `grep -E` in inventory script
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>
(cherry picked from commit 75b0acb07c972f5ba4f40b4b221f4a0f1b342b09)
