### PR TITLE
feat: Add io stream reader

### DIFF
--- a/common/io.hpp
+++ b/common/io.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <system_error>
 #include <vector>
+#include <istream>
 
 namespace mender {
 namespace common {
@@ -60,6 +61,23 @@ Error Copy(Writer &dst, Reader &src);
  * intermediate. The block size will be the size of `buffer`.
  */
 Error Copy(Writer &dst, Reader &src, vector<uint8_t> &buffer);
+
+class StreamReader : virtual public Reader {
+private:
+	std::istream &is_;
+
+public:
+	StreamReader(std::istream &stream) :
+		is_ {stream} {
+	}
+	StreamReader(std::istream &&stream) :
+		is_ {stream} {
+	}
+	ExpectedSize Read(vector<uint8_t> &dst) override {
+		is_.read(reinterpret_cast<char *>(&dst[0]), dst.size());
+		return is_.gcount();
+	}
+};
 
 } // namespace io
 } // namespace common


### PR DESCRIPTION
This adds an io::Reader utility to wrap regular cpp streams, as seen in the PR: https://github.com/mendersoftware/mender/pull/1141