### PR TITLE
ci: Add a gcc-4.9 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,16 @@ test:
     paths:
       - coverage.lcov
 
+test:gcc:4.9:
+  stage: test
+  image: gcc:4.9
+  before_script:
+    - apt update && apt install -q -y g++ cmake git make pkg-config liblmdb++-dev libboost-dev libboost-log-dev
+  script:
+    - cmake --build .
+  tags:
+    - mender-qa-worker-generic
+
 test:modules-artifact-gen:
   stage: test
   image: python:3.10


### PR DESCRIPTION
This is done to make sure we are supporting the lowest GCC we know we will have
to support.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>