### PR TITLE
feat: Add default paths and environment handling

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -133,7 +133,7 @@ add_dependencies(check processes_test)
 add_library(common_key_value_parser STATIC key_value_parser/key_value_parser.cpp)
 target_link_libraries(common_key_value_parser PUBLIC crossplatform_compiler_flags)
 target_link_libraries(common_key_value_parser PUBLIC common_error)
-target_include_directories(common_key_value_parser PRIVATE ../ ${CMAKE_BINARY_DIR})
+target_include_directories(common_key_value_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(key_value_parser_test EXCLUDE_FROM_ALL key_value_parser_test.cpp)
 target_link_libraries(key_value_parser_test PUBLIC common_key_value_parser GTest::gtest_main gmock)
@@ -144,7 +144,7 @@ add_dependencies(check key_value_parser_test)
 
 add_library(common_identity_parser STATIC identity_parser/identity_parser.cpp)
 target_link_libraries(common_identity_parser PUBLIC crossplatform_compiler_flags)
-target_include_directories(common_identity_parser PRIVATE ../ ${CMAKE_BINARY_DIR})
+target_include_directories(common_identity_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes)
 
 add_executable(identity_parser_test EXCLUDE_FROM_ALL identity_parser_test.cpp)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -169,3 +169,20 @@ target_link_libraries(inventory_parser_test PUBLIC common_inventory_parser commo
 target_include_directories(inventory_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(inventory_parser_test)
 add_dependencies(check inventory_parser_test)
+
+
+add_library(common_conf STATIC conf/conf.cpp)
+target_link_libraries(common_conf INTERFACE crossplatform_compiler_flags)
+if(MENDER_USE_BOOST_FS)
+  find_package(Boost 1.54 REQUIRED COMPONENTS filesystem)
+  target_sources(common_conf PRIVATE conf/platform/boost_filesystem/paths.cpp)
+  target_include_directories(common_conf PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${Boost_INCLUDEDIR})
+  target_link_libraries(common_conf PRIVATE platform_compiler_flags)
+  target_link_libraries(common_conf ${Boost_libraries})
+endif()
+
+add_executable(conf_test EXCLUDE_FROM_ALL conf_test.cpp)
+target_link_libraries(conf_test PUBLIC common_conf GTest::gtest_main gmock)
+target_include_directories(conf_test PRIVATE ${CMAKE_SOURCE_DIR})
+gtest_discover_tests(conf_test)
+add_dependencies(check conf_test)

--- a/common/conf.hpp
+++ b/common/conf.hpp
@@ -1,0 +1,32 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_CONF_HPP
+#define MENDER_COMMON_CONF_HPP
+
+#include <string>
+
+namespace mender {
+namespace common {
+namespace conf {
+
+using namespace std;
+
+string GetEnv(const string &var_name, const string &default_value);
+
+} // namespace conf
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_CONF_HPP

--- a/common/conf/conf.cpp
+++ b/common/conf/conf.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/conf.hpp>
+
+#include <string>
+#include <cstdlib>
+
+namespace mender {
+namespace common {
+namespace conf {
+
+using namespace std;
+
+string GetEnv(const string &var_name, const string &default_value) {
+	const char *value = getenv(var_name.c_str());
+	if (value == nullptr) {
+		return string(default_value);
+	} else {
+		return string(value);
+	}
+}
+
+} // namespace conf
+} // namespace common
+} // namespace mender

--- a/common/conf/paths.hpp
+++ b/common/conf/paths.hpp
@@ -1,0 +1,47 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_CONF_PATHS_HPP
+#define MENDER_COMMON_CONF_PATHS_HPP
+
+#include <string>
+
+namespace mender {
+namespace common {
+namespace conf {
+namespace paths {
+
+using namespace std;
+
+extern const string DefaultPathConfDir;
+extern const string DefaultPathDataDir;
+extern const string DefaultDataStore;
+extern const string DefaultKeyFile;
+
+extern const string DefaultConfFile;
+extern const string DefaultFallbackConfFile;
+
+// device specific paths
+extern const string DefaultArtScriptsPath;
+extern const string DefaultRootfsScriptsPath;
+extern const string DefaultModulesPath;
+extern const string DefaultModulesWorkPath;
+extern const string DefaultBootstrapArtifactFile;
+
+} // namespace paths
+} // namespace conf
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_CONF_PATHS_HPP

--- a/common/conf/platform/boost_filesystem/paths.cpp
+++ b/common/conf/platform/boost_filesystem/paths.cpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/conf/paths.hpp>
+
+#include <string>
+
+#include <common/conf.hpp>
+#include <boost/filesystem.hpp>
+
+namespace mender {
+namespace common {
+namespace conf {
+namespace paths {
+
+using namespace std;
+namespace conf = mender::common::conf;
+namespace fs = boost::filesystem;
+
+const string DefaultPathConfDir =
+	conf::GetEnv("MENDER_CONF_DIR", (fs::path("/etc") / "mender").string());
+const string DefaultPathDataDir =
+	conf::GetEnv("MENDER_DATA_DIR", (fs::path("/usr/share") / "mender").string());
+const string DefaultDataStore =
+	conf::GetEnv("MENDER_DATASTORE_DIR", (fs::path("/var/lib") / "mender").string());
+const string DefaultKeyFile = "mender-agent.pem";
+
+const string DefaultConfFile = (fs::path(DefaultPathConfDir) / "mender.conf").string();
+const string DefaultFallbackConfFile = (fs::path(DefaultDataStore) / "mender.conf").string();
+
+// device specific paths
+const string DefaultArtScriptsPath = (fs::path(DefaultDataStore) / "scripts").string();
+const string DefaultRootfsScriptsPath = (fs::path(DefaultPathConfDir) / "scripts").string();
+const string DefaultModulesPath = (fs::path(DefaultPathDataDir) / "modules" / "v3").string();
+const string DefaultModulesWorkPath = (fs::path(DefaultDataStore) / "modules" / "v3").string();
+const string DefaultBootstrapArtifactFile =
+	(fs::path(DefaultDataStore) / "bootstrap.mender").string();
+
+} // namespace paths
+} // namespace conf
+} // namespace common
+} // namespace mender

--- a/common/conf_test.cpp
+++ b/common/conf_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/conf.hpp>
+
+#include <vector>
+#include <string>
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+namespace conf = mender::common::conf;
+
+using namespace std;
+
+TEST(ConfTests, GetEnvTest) {
+	auto value = conf::GetEnv("MENDER_CONF_TEST_VAR", "default_value");
+	EXPECT_EQ(value, "default_value");
+
+	char var[] = "MENDER_CONF_TEST_VAR=mender_conf_test_value";
+	int ret = putenv(var);
+	ASSERT_EQ(ret, 0);
+
+	value = conf::GetEnv("MENDER_CONF_TEST_VAR", "default_value");
+	EXPECT_EQ(value, "mender_conf_test_value");
+}

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(mender-update main.cpp)
-target_link_libraries(mender-update PRIVATE common_json common_log common_http)
+target_link_libraries(mender-update PRIVATE common_json common_log common_http common_conf)
 target_link_libraries(mender-update PUBLIC crossplatform_compiler_flags)
 install(TARGETS mender-update
   DESTINATION bin

--- a/mender-update/main.cpp
+++ b/mender-update/main.cpp
@@ -22,6 +22,7 @@ using namespace std;
 #include <common/http.hpp>
 #include <common/json.hpp>
 #include <common/log.hpp>
+#include <common/conf/paths.hpp>
 
 using namespace mender::common;
 
@@ -124,5 +125,7 @@ int main() {
 
 	loop.Run();
 
+	std::cout << "Default conf dir is: " << mender::common::conf::paths::DefaultConfFile
+			  << std::endl;
 	return 0;
 }


### PR DESCRIPTION
Default paths in mender::common::conf::paths and
mender::common::conf:GetEnv() for getting values of environment variables with a fallback (default) value.

Ticket: MEN-6313
Changelog: None
