### PR TITLE
Fix logger levels

### DIFF
--- a/common/log.hpp
+++ b/common/log.hpp
@@ -81,6 +81,8 @@ private:
 
 	void AddField(const LogField &field);
 
+	void Log_(LogLevel level, const string &message);
+
 public:
 	explicit Logger(const string &name);
 	Logger(const string &name, LogLevel level);
@@ -99,7 +101,11 @@ public:
 		return l;
 	}
 
-	void Log(LogLevel level, const string &message);
+	void Log(LogLevel level, const string &message) {
+		if (level <= this->level_) {
+			Log_(level, message);
+		}
+	}
 
 	void Fatal(const string &message) {
 		Log(LogLevel::Fatal, message);

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -109,13 +109,12 @@ Logger::Logger(const string &name, LogLevel level) :
 	this->logger = slg;
 }
 
-void Logger::Log(LogLevel level, const string &message) {
+void Logger::Log_(LogLevel level, const string &message) {
 	BOOST_LOG_SEV(this->logger, level) << message;
 }
 
 void Logger::SetLevel(LogLevel level) {
 	this->level_ = level;
-	boost::log::core::get()->set_filter(expr::attr<LogLevel>("Severity") <= level);
 }
 
 LogLevel Logger::Level() {
@@ -145,7 +144,7 @@ LogLevel Level() {
 	return global_logger_.Level();
 }
 
-void Log(LogLevel level, const string message) {
+void Log_(LogLevel level, const string message) {
 	global_logger_.Log(level, message);
 }
 

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -129,9 +129,7 @@ void Logger::AddField(const LogField &field) {
 Logger Setup() {
 	SetupLoggerSinks();
 	SetupLoggerAttributes();
-	auto logger = Logger("Global");
-	logger.SetLevel(LogLevel::Info);
-	return logger;
+	return Logger("Global");
 }
 
 Logger global_logger_ = Setup();

--- a/common/log_test.cpp
+++ b/common/log_test.cpp
@@ -122,3 +122,24 @@ TEST_F(LogTestEnv, GlobalLoggerStructuredLogging) {
 		<< "LogLevel: " << to_string_level(log::Level());
 	EXPECT_THAT(output, testing::HasSubstr("test=\"ing\""));
 }
+
+TEST_F(LogTestEnv, LoggerLevelFilters) {
+	namespace log = mender::common::log;
+	ASSERT_EQ(log::Level(), log::LogLevel::Info);
+
+	auto sublogger = log::WithFields(log::LogField("foo", "bar"), log::LogField {"test", "ing"});
+	sublogger.SetLevel(log::LogLevel::Error);
+
+	log::SetLevel(log::LogLevel::Debug);
+
+	testing::internal::CaptureStderr();
+	log::Info("Foobar");
+	sublogger.Info("BarBaz");
+	auto output = testing::internal::GetCapturedStderr();
+	EXPECT_GT(output.size(), 0) << "Output is: " << output;
+	EXPECT_THAT(output, testing::Not(testing::HasSubstr("foo=\"bar\"")))
+		<< "LogLevel: " << to_string_level(log::Level());
+	EXPECT_THAT(output, testing::Not(testing::HasSubstr("test=\"ing\"")));
+	EXPECT_THAT(output, testing::Not(testing::HasSubstr("BarBaz")));
+	EXPECT_THAT(output, testing::HasSubstr("Foobar"));
+}


### PR DESCRIPTION

Leftover fix from the logger, and one cleanup

* Now loggers no longer interfere with eachothers log-levels, as the filtering is done in each logger.
* Chore: Removed the standard log-level setting in Setup, as this is already done when constructing the class.
