### PR TITLE
I/O utilities

### DIFF
--- a/common/io.hpp
+++ b/common/io.hpp
@@ -79,6 +79,13 @@ public:
 	}
 };
 
+/* Discards all data written to it */
+class Discard : virtual public Writer {
+	ExpectedSize Write(const vector<uint8_t> &dst) override {
+		return dst.size();
+	}
+};
+
 } // namespace io
 } // namespace common
 } // namespace mender

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -22,6 +22,8 @@
 #include <system_error>
 #include <vector>
 #include <istream>
+#include <sstream>
+#include <string>
 
 namespace mender {
 namespace common {
@@ -83,6 +85,26 @@ public:
 class Discard : virtual public Writer {
 	ExpectedSize Write(const vector<uint8_t> &dst) override {
 		return dst.size();
+	}
+};
+
+class StringReader : virtual public Reader {
+private:
+	StreamReader reader_;
+	std::stringstream s_;
+
+public:
+	StringReader(string &str) :
+		s_ {str},
+		reader_ {s_} {
+	}
+	StringReader(string &&str) :
+		s_ {str},
+		reader_ {s_} {
+	}
+
+	ExpectedSize Read(vector<uint8_t> &dst) override {
+		return reader_.Read(dst);
 	}
 };
 

--- a/common/io_test.cpp
+++ b/common/io_test.cpp
@@ -154,3 +154,14 @@ TEST(IO, Copy) {
 	ASSERT_TRUE(error);
 	ASSERT_EQ(error.code, std::errc::io_error);
 }
+
+
+TEST(IO, TestStringReader) {
+	auto string_reader = io::StringReader("foobar");
+
+	auto discard_writer = io::Discard {};
+
+	auto err = Copy(discard_writer, string_reader);
+
+	EXPECT_FALSE(err);
+}


### PR DESCRIPTION
This adds to new utilities to the `io` library.

1. A `StringReader` to easily wrap a string in a `Reader` interface.
2. A `Discard` writer. Pretty much a `/dev/null` for io Read/Writers.