### PR TITLE
expected lib alignments with the standard library

### DIFF
--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -33,6 +33,8 @@ public:
 	Expected(Expected &&e);
 
 	Expected(ExpectedType &&ex);
+	Expected &operator=(Expected &&ex);
+
 	~Expected();
 
 	bool has_value() const {
@@ -141,6 +143,25 @@ Expected<ExpectedType, ErrorType> &Expected<ExpectedType, ErrorType>::operator=(
 	} else {
 		this->has_val_ = false;
 		new (&this->err_) ErrorType(e.error());
+	}
+	return *this;
+}
+
+template <typename ExpectedType, typename ErrorType>
+Expected<ExpectedType, ErrorType> &Expected<ExpectedType, ErrorType>::operator=(Expected &&e) {
+	if (this->has_val_) {
+		this->ex_.~ExpectedType();
+	} else {
+		this->err_.~ErrorType();
+	}
+
+	this->has_val_ = e.has_val_;
+	if (e.has_val_) {
+		this->has_val_ = true;
+		new (&this->ex_) ExpectedType(std::move(e.value()));
+	} else {
+		this->has_val_ = false;
+		new (&this->err_) ErrorType(std::move(e.error()));
 	}
 	return *this;
 }

--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -31,6 +31,8 @@ public:
 	Expected(const ErrorType &err);
 	Expected(const Expected &e);
 	Expected(Expected &&e);
+
+	Expected(ExpectedType &&ex);
 	~Expected();
 
 	bool has_value() const {
@@ -85,6 +87,11 @@ template <typename ExpectedType, typename ErrorType>
 Expected<ExpectedType, ErrorType>::Expected(const ExpectedType &ex) :
 	has_val_(true),
 	ex_(ex) {};
+
+template <typename ExpectedType, typename ErrorType>
+Expected<ExpectedType, ErrorType>::Expected(ExpectedType &&ex) :
+	has_val_(true),
+	ex_(std::move(ex)) {};
 
 template <typename ExpectedType, typename ErrorType>
 Expected<ExpectedType, ErrorType>::Expected(const ErrorType &err) :

--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -38,7 +38,8 @@ public:
 	bool has_value() const {
 		return has_val_;
 	};
-	ExpectedType value() const;
+	ExpectedType &value();
+	const ExpectedType &value() const;
 	ErrorType error() const;
 
 	Expected &operator=(const Expected &);
@@ -108,7 +109,13 @@ Expected<ExpectedType, ErrorType>::~Expected() {
 };
 
 template <typename ExpectedType, typename ErrorType>
-ExpectedType Expected<ExpectedType, ErrorType>::value() const {
+ExpectedType &Expected<ExpectedType, ErrorType>::value() {
+	assert(this->has_val_);
+	return this->ex_;
+};
+
+template <typename ExpectedType, typename ErrorType>
+const ExpectedType &Expected<ExpectedType, ErrorType>::value() const {
 	assert(this->has_val_);
 	return this->ex_;
 };

--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -30,6 +30,7 @@ public:
 	Expected(const ExpectedType &ex);
 	Expected(const ErrorType &err);
 	Expected(const Expected &e);
+	Expected(Expected &&e);
 	~Expected();
 
 	bool has_value() const {
@@ -62,6 +63,18 @@ Expected<ExpectedType, ErrorType>::Expected(const Expected &e) {
 	if (e.has_val_) {
 		this->has_val_ = true;
 		new (&this->ex_) ExpectedType(e.value());
+	} else {
+		this->has_val_ = false;
+		new (&this->err_) ErrorType(e.error());
+	}
+}
+
+
+template <typename ExpectedType, typename ErrorType>
+Expected<ExpectedType, ErrorType>::Expected(Expected &&e) {
+	if (e.has_val_) {
+		this->has_val_ = true;
+		new (&this->ex_) ExpectedType(std::move(e.value()));
 	} else {
 		this->has_val_ = false;
 		new (&this->err_) ErrorType(e.error());


### PR DESCRIPTION
This adds a few methods to align our `mender::expected` library to align closer with the standard librarys `expected` implementation.

The commits should contain most the information needed.