### PR TITLE
(artifact-parser): Add the Version header parser

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(sha)
+add_subdirectory(v3/version)

--- a/artifact/v3/version/CMakeLists.txt
+++ b/artifact/v3/version/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+# Test the parser
+add_executable(artifact_version_parser_test EXCLUDE_FROM_ALL
+  version.cpp
+  version_test.cpp
+)
+target_link_libraries(artifact_version_parser_test PRIVATE
+  GTest::gtest_main
+  gmock
+  common_io
+  common_error
+  common_json
+)
+target_include_directories(artifact_version_parser_test PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+)
+gtest_discover_tests(artifact_version_parser_test)
+add_dependencies(check artifact_version_parser_test)

--- a/artifact/v3/version/version.cpp
+++ b/artifact/v3/version/version.cpp
@@ -1,0 +1,117 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/version/version.hpp>
+
+#include <string>
+#include <vector>
+
+#include <common/common.hpp>
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/json.hpp>
+
+
+namespace artifact {
+namespace v3 {
+namespace version {
+
+namespace io = mender::common::io;
+namespace expected = mender::common::expected;
+namespace error = mender::common::error;
+namespace json = mender::common::json;
+
+const int supported_parser_version {3};
+const string supported_parser_format {"mender"};
+
+const ErrorCategoryClass ErrorCategory {};
+
+const char *ErrorCategoryClass::name() const noexcept {
+	return "VersionParserErrorCategory";
+}
+
+string ErrorCategoryClass::message(int code) const {
+	switch (code) {
+	case NoError:
+		return "Success";
+	case ParseError:
+		return "Parse error";
+	case VersionError:
+		return "Wrong Artifact version";
+	case FormatError:
+		return "Wrong Artifact format";
+	default:
+		return "Unknown";
+	}
+}
+
+error::Error MakeError(ErrorCode code, const string &msg) {
+	return error::Error(error_condition(code, ErrorCategory), msg);
+}
+
+
+ExpectedVersion Parse(io::Reader &reader) {
+	// Read in all the bytes into a tmp buffer
+	std::vector<uint8_t> buf(1024);
+	io::ByteWriter bw {buf};
+
+	auto err = io::Copy(bw, reader);
+	if (err) {
+		return expected::unexpected(err);
+	}
+
+	auto expected_json = json::LoadFromString(mender::common::StringFromByteVector(buf));
+
+	if (!expected_json) {
+		return expected::unexpected(MakeError(
+			ParseError,
+			"Failed to parse the version header JSON: " + expected_json.error().message));
+	}
+
+	const json::Json version_json = expected_json.value();
+
+	auto version =
+		version_json.Get("version").and_then([](const json::Json &j) { return j.GetInt(); });
+
+	if (!version) {
+		return expected::unexpected(MakeError(VersionError, version.error().message));
+	}
+
+	if (version.value() != supported_parser_version) {
+		return expected::unexpected(MakeError(
+			FormatError,
+			"Only version " + std::to_string(supported_parser_version)
+				+ " is supported, received version " + std::to_string(version.value())));
+	}
+
+	auto format =
+		version_json.Get("format").and_then([](const json::Json &j) { return j.GetString(); });
+
+	if (!format) {
+		return expected::unexpected(MakeError(FormatError, format.error().message));
+	}
+
+	if (format != supported_parser_format) {
+		return expected::unexpected(MakeError(
+			FormatError,
+			"The client only understands the 'mender' Artifact type. Got format: "
+				+ format.value()));
+	}
+
+	return Version {.version = supported_parser_version, .format = supported_parser_format};
+}
+
+} // namespace version
+} // namespace v3
+} // namespace artifact

--- a/artifact/v3/version/version.hpp
+++ b/artifact/v3/version/version.hpp
@@ -1,0 +1,65 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_VERSION_PARSER_HPP
+#define MENDER_ARTIFACT_VERSION_PARSER_HPP
+
+#include <string>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+
+namespace artifact {
+namespace v3 {
+namespace version {
+
+using namespace std;
+
+namespace io = mender::common::io;
+namespace expected = mender::common::expected;
+namespace error = mender::common::error;
+
+
+enum ErrorCode {
+	NoError = 0,
+	ParseError,
+	VersionError,
+	FormatError,
+};
+
+class ErrorCategoryClass : public std::error_category {
+public:
+	const char *name() const noexcept override;
+	string message(int code) const override;
+};
+
+extern const ErrorCategoryClass ErrorCategory;
+
+error::Error MakeError(ErrorCode code, const string &msg);
+
+struct Version {
+	const int version;
+	const string format;
+};
+
+using ExpectedVersion = expected::expected<Version, error::Error>;
+
+ExpectedVersion Parse(io::Reader &reader);
+
+} // namespace version
+} // namespace v3
+} // namespace artifact
+
+#endif // MENDER_ARTIFACT_VERSION_PARSER_HPP

--- a/artifact/v3/version/version_test.cpp
+++ b/artifact/v3/version/version_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/version/version.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <fstream>
+
+
+using namespace std;
+
+
+TEST(ParserTest, TestParseVersion) {
+	std::string json_data = R"(
+  {
+    "version": 3,
+		"format" : "mender"
+  }
+)";
+
+	std::stringstream ss {json_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto version = artifact::v3::version::Parse(sr);
+
+	ASSERT_TRUE(version) << version.error().message << std::endl;
+
+	auto version_unwrapped = version.value();
+
+	EXPECT_EQ(version_unwrapped.version, 3);
+	EXPECT_EQ(version_unwrapped.format, "mender");
+}
+
+TEST(ParserTest, TestParseWrongVersion) {
+	// We don't support version 2
+	std::string json_data = R"(
+  {
+    "version": 2,
+		"format" : "mender"
+  }
+)";
+
+	std::stringstream ss {json_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto version = artifact::v3::version::Parse(sr);
+
+	ASSERT_FALSE(version) << version.error().message << std::endl;
+
+	auto expected_error_message = "Only version 3 is supported, received version 2";
+
+	EXPECT_EQ(version.error().message, expected_error_message);
+}
+
+
+TEST(ParserTest, TestParseWrongFormat) {
+	// We don't support other formats than mender atm
+	std::string json_data = R"(
+  {
+    "version": 3,
+		"format" : "foobar"
+  }
+)";
+
+	std::stringstream ss {json_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto version = artifact::v3::version::Parse(sr);
+
+	ASSERT_FALSE(version) << version.error().message << std::endl;
+
+	auto expected_error_message =
+		"The client only understands the 'mender' Artifact type. Got format: foobar";
+
+	EXPECT_EQ(version.error().message, expected_error_message);
+}
+
+TEST(ParserTest, TestParseMumboJumbo) {
+	std::string json_data = R"(
+foobarbaz
+)";
+
+	std::stringstream ss {json_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto version = artifact::v3::version::Parse(sr);
+
+	ASSERT_FALSE(version) << version.error().message << std::endl;
+
+	auto expected_error_message = "Failed to parse the version header JSON";
+
+	EXPECT_THAT(version.error().message, testing::StartsWith(expected_error_message));
+}
+
+
+TEST(ParserTest, TestParseMalformedInput) {
+	// Missing ending {
+	std::string json_data = R"(
+  {
+    "version": 3,
+		"format" : "mender"
+)";
+
+	std::stringstream ss {json_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto version = artifact::v3::version::Parse(sr);
+
+	ASSERT_FALSE(version) << version.error().message << std::endl;
+
+	auto expected_error_message = "Failed to parse the version header JSON";
+
+	EXPECT_THAT(version.error().message, testing::StartsWith(expected_error_message));
+}


### PR DESCRIPTION
This adds a simple parser for the Mender-Artifact v3 version header.

As well as a small utility ByteWriter class to io.

I do have to admit that I feel this turned out needlessly complicated, so all open for advice on how to improve this!