### PR TITLE
Iterators

### DIFF
--- a/artifact/sha/sha.hpp
+++ b/artifact/sha/sha.hpp
@@ -64,7 +64,6 @@ private:
 	std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX *)> sha_handle_;
 #endif
 	io::Reader &wrapped_reader_;
-	vector<uint8_t> buffer_;
 	std::string expected_sha_ {};
 	bool initialized_ {false};
 
@@ -72,7 +71,8 @@ public:
 	Reader(io::Reader &reader);
 	Reader(io::Reader &reader, const std::string &expected_sha);
 
-	expected::ExpectedSize Read(vector<uint8_t> &dst) override;
+	expected::ExpectedSize Read(
+		vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override;
 
 	expected::ExpectedString ShaSum();
 };

--- a/artifact/sha/sha_test.cpp
+++ b/artifact/sha/sha_test.cpp
@@ -34,9 +34,9 @@ TEST(ShasummerTest, TestShaSum) {
 
 	vector<uint8_t> actual(4096);
 
-	auto bytes_read = r.Read(actual);
+	auto bytes_read = r.Read(actual.begin(), actual.end());
 
-	EXPECT_TRUE(bytes_read);
+	ASSERT_TRUE(bytes_read);
 
 	// EOF read and get the proper shasum
 	ASSERT_GT(bytes_read.value(), 0);

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -41,14 +41,15 @@ class Reader {
 public:
 	virtual ~Reader() {};
 
-	virtual ExpectedSize Read(vector<uint8_t> &dst) = 0;
+	virtual ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) = 0;
 };
 
 class Writer {
 public:
 	virtual ~Writer() {};
 
-	virtual ExpectedSize Write(const vector<uint8_t> &dst) = 0;
+	virtual ExpectedSize Write(
+		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) = 0;
 };
 
 class ReadWriter : virtual public Reader, virtual public Writer {};
@@ -75,8 +76,8 @@ public:
 	StreamReader(std::istream &&stream) :
 		is_ {stream} {
 	}
-	ExpectedSize Read(vector<uint8_t> &dst) override {
-		is_.read(reinterpret_cast<char *>(&dst[0]), dst.size());
+	ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override {
+		is_.read(reinterpret_cast<char *>(&*start), end - start);
 		if (is_.bad()) {
 			int int_error = errno;
 			return Error(
@@ -88,8 +89,9 @@ public:
 
 /* Discards all data written to it */
 class Discard : virtual public Writer {
-	ExpectedSize Write(const vector<uint8_t> &dst) override {
-		return dst.size();
+	ExpectedSize Write(
+		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) override {
+		return end - start;
 	}
 };
 
@@ -108,8 +110,8 @@ public:
 		reader_ {s_} {
 	}
 
-	ExpectedSize Read(vector<uint8_t> &dst) override {
-		return reader_.Read(dst);
+	ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override {
+		return reader_.Read(start, end);
 	}
 };
 

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -77,6 +77,11 @@ public:
 	}
 	ExpectedSize Read(vector<uint8_t> &dst) override {
 		is_.read(reinterpret_cast<char *>(&dst[0]), dst.size());
+		if (is_.bad()) {
+			int int_error = errno;
+			return Error(
+				std::error_code(int_error, std::system_category()).default_error_condition(), "");
+		}
 		return is_.gcount();
 	}
 };

--- a/common/io_test.cpp
+++ b/common/io_test.cpp
@@ -25,11 +25,19 @@ namespace error = mender::common::error;
 TEST(IO, Copy) {
 	class TestReader : public io::Reader {
 	public:
-		MOCK_METHOD(io::ExpectedSize, Read, (vector<uint8_t> & buffer), (override));
+		MOCK_METHOD(
+			io::ExpectedSize,
+			Read,
+			(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end),
+			(override));
 	};
 	class TestWriter : public io::Writer {
 	public:
-		MOCK_METHOD(io::ExpectedSize, Write, (const vector<uint8_t> &buffer), (override));
+		MOCK_METHOD(
+			io::ExpectedSize,
+			Write,
+			(vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end),
+			(override));
 	};
 
 	testing::StrictMock<TestReader> r;
@@ -46,56 +54,87 @@ TEST(IO, Copy) {
 	// Random data.
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(2))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			buffer[2] = uint8_t('c');
-			return 3;
-		}))
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				*(start++) = uint8_t('c');
+				return 3;
+			}))
 		.WillRepeatedly(testing::Return(io::ExpectedSize(0)));
 	vector<uint8_t> expected {uint8_t('a'), uint8_t('b'), uint8_t('c')};
-	EXPECT_CALL(w, Write(expected))
+	EXPECT_CALL(w, Write)
 		.Times(testing::Exactly(1))
-		.WillOnce(testing::Return(io::ExpectedSize(3)));
+		.WillOnce(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.cbegin()));
+				}),
+			testing::Return(io::ExpectedSize(3))));
 	error = Copy(w, r);
 	ASSERT_FALSE(error);
 
 	// Short read (should re-read and succeed).
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(3))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			return 2;
-		}))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('c');
-			return 1;
-		}))
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				return 2;
+			}))
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('c');
+				return 1;
+			}))
 		.WillRepeatedly(testing::Return(io::ExpectedSize(0)));
-	EXPECT_CALL(w, Write).Times(testing::Exactly(2));
 	expected = vector<uint8_t> {uint8_t('a'), uint8_t('b')};
-	ON_CALL(w, Write(expected)).WillByDefault(testing::Return(io::ExpectedSize(expected.size())));
-	expected = vector<uint8_t> {uint8_t('c')};
-	ON_CALL(w, Write(expected)).WillByDefault(testing::Return(io::ExpectedSize(expected.size())));
+	auto expected2 = vector<uint8_t> {uint8_t('c')};
+	EXPECT_CALL(w, Write)
+		.Times(testing::Exactly(2))
+		.WillOnce(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.begin()));
+				}),
+			testing::Return(io::ExpectedSize(expected.cend() - expected.cbegin()))))
+		.WillRepeatedly(testing::DoAll(
+			testing::Invoke(
+				[&expected2](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected2.begin()));
+				}),
+			testing::Return(io::ExpectedSize(expected2.cend() - expected2.cbegin()))));
 	error = Copy(w, r);
 	ASSERT_FALSE(error);
 
 	// Error on second read.
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(2))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			return 2;
-		}))
-		.WillRepeatedly(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('c');
-			return error::Error(std::errc::io_error, "Error");
-		}));
-	EXPECT_CALL(w, Write).Times(testing::Exactly(1));
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				return 2;
+			}))
+		.WillRepeatedly(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('c');
+				return error::Error(std::errc::io_error, "Error");
+			}));
 	expected = vector<uint8_t> {uint8_t('a'), uint8_t('b')};
-	ON_CALL(w, Write(expected)).WillByDefault(testing::Return(io::ExpectedSize(expected.size())));
+	EXPECT_CALL(w, Write)
+		.Times(testing::Exactly(1))
+		.WillOnce(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.begin()));
+				}),
+			testing::Return(io::ExpectedSize(expected.cend() - expected.cbegin()))));
 	error = Copy(w, r);
 	ASSERT_TRUE(error);
 	ASSERT_EQ(error.code, std::errc::io_error);
@@ -103,22 +142,35 @@ TEST(IO, Copy) {
 	// Error on write.
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(2))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			return 2;
-		}))
-		.WillRepeatedly(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('c');
-			return 1;
-		}));
-	EXPECT_CALL(w, Write).Times(testing::Exactly(2));
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				return 2;
+			}))
+		.WillRepeatedly(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('c');
+				return 1;
+			}));
 	expected = vector<uint8_t> {uint8_t('a'), uint8_t('b')};
-	ON_CALL(w, Write(expected)).WillByDefault(testing::Return(io::ExpectedSize(expected.size())));
-	expected = vector<uint8_t> {uint8_t('c')};
-	ON_CALL(w, Write(expected))
-		.WillByDefault(
-			testing::Return(io::ExpectedSize(error::Error(std::errc::invalid_argument, "Error"))));
+	expected2 = vector<uint8_t> {uint8_t('c')};
+	EXPECT_CALL(w, Write)
+		.Times(testing::Exactly(2))
+		.WillOnce(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.begin()));
+				}),
+			testing::Return(io::ExpectedSize(expected.cend() - expected.cbegin()))))
+		.WillRepeatedly(testing::DoAll(
+			testing::Invoke(
+				[&expected2](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected2.begin()));
+				}),
+			testing::Return(io::ExpectedSize(error::Error(std::errc::invalid_argument, "Error")))));
 	error = Copy(w, r);
 	ASSERT_TRUE(error);
 	ASSERT_EQ(error.code, std::errc::invalid_argument);
@@ -126,15 +178,22 @@ TEST(IO, Copy) {
 	// Short write.
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(1))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			return 2;
-		}));
-	EXPECT_CALL(w, Write).Times(testing::Exactly(1));
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				return 2;
+			}));
 	expected = vector<uint8_t> {uint8_t('a'), uint8_t('b')};
-	ON_CALL(w, Write(expected))
-		.WillByDefault(testing::Return(io::ExpectedSize(expected.size() - 1)));
+	EXPECT_CALL(w, Write)
+		.Times(testing::Exactly(1))
+		.WillRepeatedly(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.begin()));
+				}),
+			testing::Return(io::ExpectedSize(expected.cend() - expected.cbegin() - 1))));
 	error = Copy(w, r);
 	ASSERT_TRUE(error);
 	ASSERT_EQ(error.code, std::errc::io_error);
@@ -142,14 +201,22 @@ TEST(IO, Copy) {
 	// No write.
 	EXPECT_CALL(r, Read)
 		.Times(testing::Exactly(1))
-		.WillOnce(testing::Invoke([](vector<uint8_t> &buffer) -> io::ExpectedSize {
-			buffer[0] = uint8_t('a');
-			buffer[1] = uint8_t('b');
-			return 2;
-		}));
-	EXPECT_CALL(w, Write).Times(testing::Exactly(1));
+		.WillOnce(testing::Invoke(
+			[](vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) -> io::ExpectedSize {
+				*(start++) = uint8_t('a');
+				*(start++) = uint8_t('b');
+				return 2;
+			}));
 	expected = vector<uint8_t> {uint8_t('a'), uint8_t('b')};
-	ON_CALL(w, Write(expected)).WillByDefault(testing::Return(io::ExpectedSize(0)));
+	EXPECT_CALL(w, Write)
+		.Times(testing::Exactly(1))
+		.WillRepeatedly(testing::DoAll(
+			testing::Invoke(
+				[&expected](
+					vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+					ASSERT_TRUE(equal(start, end, expected.begin()));
+				}),
+			testing::Return(io::ExpectedSize(0))));
 	error = Copy(w, r);
 	ASSERT_TRUE(error);
 	ASSERT_EQ(error.code, std::errc::io_error);


### PR DESCRIPTION
```
commit 11ee57d9727333709539538bf37e116685b159f5
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Feb 24 12:02:38 2023

    fix: Handle errors in `StreamReader::Read`.
    
    Changelog: None
    Ticket: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 761937834c98522dfc1f7ef7fd11227764de651c
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Feb 24 16:08:24 2023

    chore: Switch Reader/Writer interfaces to use iterators.
    
    This is more in line with how the std interfaces work, and saves us
    from having to resize containers before and after passing them into
    the Read and Write functions. The resulting code reduction can be
    clearly seen.
    
    The tests are a bit more complicated because they do deep comparisons,
    and comparing ranges of iterators is harder than just two values. We
    cannot just match arguments one by one anymore, but we need to use a
    custom function where we call `std::equal`. This is limited to the
    io_test though, and I don't think it affects production code.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```