### PR TITLE
Replace the internal expected implementation with an existing lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/tiny-process-library"]
 	path = vendor/tiny-process-library
 	url = https://gitlab.com/eidheim/tiny-process-library.git
+[submodule "vendor/expected"]
+	path = vendor/expected
+	url = https://github.com/TartanLlama/expected.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ else()
   set(MENDER_USE_BOOST_ASIO 0)
 endif()
 
+add_subdirectory(vendor/expected)
+include_directories(${CMAKE_SOURCE_DIR}/vendor/expected/include)
+
 if (${PLATFORM} STREQUAL linux_x86)
   set(MENDER_USE_BOOST_BEAST 1)
 else()

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -8,3 +8,6 @@
 #
 # UNLICENSE
 7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c  vendor/lmdbxx/UNLICENSE
+#
+# CC0 1.0 Universal
+a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499  vendor/expected/COPYING

--- a/common/config_parser.hpp
+++ b/common/config_parser.hpp
@@ -26,6 +26,8 @@ namespace config_parser {
 
 using namespace std;
 
+using mender::common::expected::ExpectedBool;
+
 namespace error = mender::common::error;
 
 /** HttpsClient holds the configuration for the client side mTLS
@@ -61,8 +63,6 @@ public:
 	string message(int code) const override;
 };
 extern const ConfigParserErrorCategoryClass ConfigParserErrorCategory;
-
-using ExpectedBool = mender::common::expected::Expected<bool, error::Error>;
 
 error::Error MakeError(ConfigParserErrorCode code, const string &msg);
 

--- a/common/config_parser/config_parser.cpp
+++ b/common/config_parser/config_parser.cpp
@@ -52,7 +52,7 @@ ExpectedBool MenderConfigFromFile::ValidateArtifactKeyCondition() const {
 			auto err = MakeError(
 				ConfigParserErrorCode::ParseError,
 				"Both 'ArtifactVerifyKey' and 'ArtifactVerifyKeys' are set");
-			return ExpectedBool(err);
+			return expected::unexpected(err);
 		}
 	}
 	return ExpectedBool(true);
@@ -63,7 +63,7 @@ ExpectedBool MenderConfigFromFile::ValidateServerConfig() const {
 		auto err = MakeError(
 			ConfigParserErrorCode::ParseError,
 			"Both 'Servers' AND 'ServerURL given in the configuration. Please set only one of these fields");
-		return err;
+		return expected::unexpected(err);
 	}
 
 	if (servers.size() == 0) {
@@ -80,7 +80,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		auto err = MakeError(
 			ConfigParserErrorCode::ParseError,
 			"Failed to parse '" + path + "': " + e_cfg_json.error().message);
-		return err;
+		return expected::unexpected(err);
 	}
 
 	bool applied = false;

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -152,7 +152,7 @@ using TransactionPtr = shared_ptr<Transaction>;
 using RequestPtr = shared_ptr<Request>;
 using ResponsePtr = shared_ptr<Response>;
 
-using ExpectedResponsePtr = expected::Expected<ResponsePtr, error::Error>;
+using ExpectedResponsePtr = expected::expected<ResponsePtr, error::Error>;
 
 using ResponseHandler = function<void(ExpectedResponsePtr)>;
 

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -74,7 +74,7 @@ Request::Request(Method method) :
 
 expected::ExpectedString Transaction::GetHeader(const string &name) const {
 	if (headers_.find(name) == headers_.end()) {
-		return MakeError(NoSuchHeaderError, "No such header: " + name);
+		return expected::unexpected(MakeError(NoSuchHeaderError, "No such header: " + name));
 	}
 	return headers_.at(name);
 }

--- a/common/http/platform/beast/http.cpp
+++ b/common/http/platform/beast/http.cpp
@@ -96,14 +96,14 @@ error::Error Session::AsyncCall(
 
 void Session::CallErrorHandler(
 	const error_code &err, const RequestPtr &req, ResponseHandler handler) {
-	handler(error::Error(
-		err.default_error_condition(), MethodToString(req->method_) + " " + req->orig_address_));
+	handler(expected::unexpected(error::Error(
+		err.default_error_condition(), MethodToString(req->method_) + " " + req->orig_address_)));
 }
 
 void Session::CallErrorHandler(
 	const error::Error &err, const RequestPtr &req, ResponseHandler handler) {
-	handler(error::Error(
-		err.code, err.message + ": " + MethodToString(req->method_) + " " + req->orig_address_));
+	handler(expected::unexpected(error::Error(
+		err.code, err.message + ": " + MethodToString(req->method_) + " " + req->orig_address_)));
 }
 
 void Session::ResolveHandler(error_code err, const asio::ip::tcp::resolver::results_type &results) {

--- a/common/inventory_parser/platform/boost_filesystem/inventory_parser.cpp
+++ b/common/inventory_parser/platform/boost_filesystem/inventory_parser.cpp
@@ -83,7 +83,7 @@ kvp::ExpectedKeyValuesMap GetInventoryData(const string &generators_dir) {
 		err::Error error = MakeError(
 			kvp::KeyValueParserErrorCode::NoDataError,
 			"No data successfully read from inventory scripts in '" + generators_dir + "'");
-		return kvp::ExpectedKeyValuesMap(error);
+		return expected::unexpected(error);
 	}
 }
 

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -31,11 +31,12 @@ namespace io {
 
 using namespace std;
 
+namespace expected = mender::common::expected;
+
 using mender::common::error::Error;
 using mender::common::error::NoError;
-using mender::common::expected::Expected;
 
-using ExpectedSize = Expected<size_t, Error>;
+using mender::common::expected::ExpectedSize;
 
 class Reader {
 public:
@@ -44,7 +45,7 @@ public:
 	virtual ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) = 0;
 };
 using ReaderPtr = shared_ptr<Reader>;
-using ExpectedReaderPtr = Expected<ReaderPtr, Error>;
+using ExpectedReaderPtr = expected::expected<ReaderPtr, Error>;
 
 class Writer {
 public:
@@ -54,11 +55,11 @@ public:
 		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) = 0;
 };
 using WriterPtr = shared_ptr<Writer>;
-using ExpectedWriterPtr = Expected<WriterPtr, Error>;
+using ExpectedWriterPtr = expected::expected<WriterPtr, Error>;
 
 class ReadWriter : virtual public Reader, virtual public Writer {};
 using ReadWriterPtr = shared_ptr<ReadWriter>;
-using ExpectedReadWriterPtr = Expected<ReadWriterPtr, Error>;
+using ExpectedReadWriterPtr = expected::expected<ReadWriterPtr, Error>;
 
 /**
  * Stream the data from `src` to `dst` until encountering EOF or an error.

--- a/common/json.hpp
+++ b/common/json.hpp
@@ -55,7 +55,7 @@ using ExpectedSize = mender::common::expected::ExpectedSize;
 
 class Json {
 public:
-	using ExpectedJson = mender::common::expected::Expected<Json, error::Error>;
+	using ExpectedJson = expected::expected<Json, error::Error>;
 
 	Json() = default;
 
@@ -100,7 +100,7 @@ private:
 #endif
 };
 
-using ExpectedJson = mender::common::expected::Expected<Json, error::Error>;
+using ExpectedJson = expected::expected<Json, error::Error>;
 
 ExpectedJson LoadFromFile(string file_path);
 ExpectedJson LoadFromString(string json_str);

--- a/common/json/platform/nlohmann/nlohmann_json.cpp
+++ b/common/json/platform/nlohmann/nlohmann_json.cpp
@@ -32,7 +32,7 @@ ExpectedJson LoadFromFile(string file_path) {
 	} catch (njson::parse_error &e) {
 		auto err = MakeError(
 			JsonErrorCode::ParseError, "Failed to parse '" + file_path + "': " + e.what());
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 }
 
@@ -44,7 +44,7 @@ ExpectedJson LoadFromString(string json_str) {
 	} catch (njson::parse_error &e) {
 		auto err = MakeError(
 			JsonErrorCode::ParseError, "Failed to parse '''" + json_str + "''': " + e.what());
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 }
 
@@ -56,19 +56,19 @@ ExpectedJson Json::Get(const char *child_key) const {
 	if (!this->n_json.is_object()) {
 		auto err = MakeError(
 			JsonErrorCode::TypeError, "Invalid JSON type to get '" + string(child_key) + "' from");
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 
 	bool contains = this->n_json.contains(child_key);
 	if (!contains) {
 		auto err =
 			MakeError(JsonErrorCode::KeyError, "Key '" + string(child_key) + "' doesn't exist");
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 
 	njson n_json = this->n_json[child_key];
 	Json j = Json(n_json);
-	return ExpectedJson(j);
+	return j;
 }
 
 ExpectedJson Json::Get(const size_t idx) const {
@@ -76,18 +76,17 @@ ExpectedJson Json::Get(const size_t idx) const {
 		auto err = MakeError(
 			JsonErrorCode::TypeError,
 			"Invalid JSON type to get item at index " + to_string(idx) + " from");
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 
 	if (this->n_json.size() <= idx) {
 		auto err =
 			MakeError(JsonErrorCode::IndexError, "Index " + to_string(idx) + " out of range");
-		return ExpectedJson(err);
+		return expected::unexpected(err);
 	}
 
 	njson n_json = this->n_json[idx];
-	Json j = Json(n_json);
-	return ExpectedJson(j);
+	return Json(n_json);
 }
 
 bool Json::IsObject() const {
@@ -117,39 +116,39 @@ bool Json::IsNull() const {
 ExpectedString Json::GetString() const {
 	try {
 		string s = this->n_json.get<string>();
-		return ExpectedString(s);
+		return s;
 	} catch (njson::type_error &e) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting string");
-		return ExpectedString(err);
+		return expected::unexpected(err);
 	}
 }
 
 ExpectedInt Json::GetInt() const {
 	try {
 		int s = this->n_json.get<int>();
-		return ExpectedInt(s);
+		return s;
 	} catch (njson::type_error &e) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting int");
-		return ExpectedInt(err);
+		return expected::unexpected(err);
 	}
 }
 
 ExpectedBool Json::GetBool() const {
 	try {
 		bool s = this->n_json.get<bool>();
-		return ExpectedBool(s);
+		return s;
 	} catch (njson::type_error &e) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting bool");
-		return ExpectedBool(err);
+		return expected::unexpected(err);
 	}
 }
 
 ExpectedSize Json::GetArraySize() const {
 	if (!this->n_json.is_array()) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Not a JSON array");
-		return ExpectedSize(err);
+		return expected::unexpected(err);
 	} else {
-		return ExpectedSize(this->n_json.size());
+		return this->n_json.size();
 	}
 }
 

--- a/common/key_value_database/in_memory/in_memory.cpp
+++ b/common/key_value_database/in_memory/in_memory.cpp
@@ -23,6 +23,8 @@ namespace key_value_database {
 
 using namespace std;
 
+namespace expected = mender::common::expected;
+
 class InMemoryTransaction : public Transaction {
 public:
 	InMemoryTransaction(KeyValueDatabaseInMemory &db, bool read_only);
@@ -46,7 +48,8 @@ ExpectedBytes InMemoryTransaction::Read(const string &key) {
 	if (value != db_.map_.end()) {
 		return ExpectedBytes(value->second);
 	} else {
-		return ExpectedBytes(MakeError(KeyError, "Key " + key + " not found in memory database"));
+		return expected::unexpected(
+			MakeError(KeyError, "Key " + key + " not found in memory database"));
 	}
 }
 
@@ -69,7 +72,7 @@ ExpectedBytes KeyValueDatabaseInMemory::Read(const string &key) {
 		return error::NoError;
 	});
 	if (err) {
-		return err;
+		return expected::unexpected(err);
 	} else {
 		return ret;
 	}

--- a/common/key_value_database/platform/lmdb/lmdb.cpp
+++ b/common/key_value_database/platform/lmdb/lmdb.cpp
@@ -44,12 +44,13 @@ expected::ExpectedBytes LmdbTransaction::Read(const string &key) {
 		std::string_view value;
 		bool exists = dbi_.get(txn_, key, value);
 		if (!exists) {
-			return MakeError(KeyError, "Key " + key + " not found in database");
+			return expected::unexpected(
+				MakeError(KeyError, "Key " + key + " not found in database"));
 		}
 
 		return common::ByteVectorFromString(value);
 	} catch (std::runtime_error &e) {
-		return MakeError(LmdbError, e.what());
+		return expected::unexpected(MakeError(LmdbError, e.what()));
 	}
 }
 
@@ -120,7 +121,7 @@ expected::ExpectedBytes KeyValueDatabaseLmdb::Read(const string &key) {
 		}
 	});
 	if (err) {
-		return err;
+		return expected::unexpected(err);
 	} else {
 		return ret;
 	}

--- a/common/key_value_parser.hpp
+++ b/common/key_value_parser.hpp
@@ -28,6 +28,7 @@ namespace key_value_parser {
 using namespace std;
 
 namespace error = mender::common::error;
+namespace expected = mender::common::expected;
 
 enum KeyValueParserErrorCode {
 	NoError = 0,
@@ -45,7 +46,7 @@ extern const KeyValueParserErrorCategoryClass KeyValueParserErrorCategory;
 error::Error MakeError(KeyValueParserErrorCode code, const string &msg);
 
 using KeyValuesMap = unordered_map<string, vector<string>>;
-using ExpectedKeyValuesMap = mender::common::expected::Expected<KeyValuesMap, error::Error>;
+using ExpectedKeyValuesMap = expected::expected<KeyValuesMap, error::Error>;
 
 ExpectedKeyValuesMap ParseKeyValues(const vector<string> &items, char delimiter = '=');
 error::Error AddParseKeyValues(

--- a/common/key_value_parser/key_value_parser.cpp
+++ b/common/key_value_parser/key_value_parser.cpp
@@ -53,7 +53,7 @@ ExpectedKeyValuesMap ParseKeyValues(const vector<string> &items, char delimiter)
 	KeyValuesMap ret;
 	error::Error err = AddParseKeyValues(ret, items, delimiter);
 	if (err) {
-		return ExpectedKeyValuesMap(err);
+		return expected::unexpected(err);
 	} else {
 		return ExpectedKeyValuesMap(ret);
 	}

--- a/common/processes.hpp
+++ b/common/processes.hpp
@@ -27,6 +27,7 @@ namespace processes {
 using namespace std;
 
 namespace error = mender::common::error;
+namespace expected = mender::common::expected;
 
 enum ProcessesErrorCode {
 	NoError = 0,
@@ -43,7 +44,7 @@ extern const ProcessesErrorCategoryClass ProcessesErrorCategory;
 error::Error MakeError(ProcessesErrorCode code, const string &msg);
 
 using LineData = vector<string>;
-using ExpectedLineData = mender::common::expected::Expected<LineData, error::Error>;
+using ExpectedLineData = expected::expected<LineData, error::Error>;
 
 class Process {
 public:

--- a/mender-update/main.cpp
+++ b/mender-update/main.cpp
@@ -65,12 +65,12 @@ int main() {
 	log_poc();
 
 	namespace ExampleErrorType = mender::common::json;
-	using ExpectedExampleString = mender::common::expected::Expected<string, error::Error>;
+	using ExpectedExampleString = expected::expected<string, error::Error>;
 
 	ExpectedExampleString ex_s = ExpectedExampleString("Hello, world!");
 
 	auto err = ExampleErrorType::MakeError(json::KeyError, "Something wrong happened");
-	ExpectedExampleString ex_s_err = ExpectedExampleString(err);
+	ExpectedExampleString ex_s_err = expected::unexpected(err);
 
 	if (ex_s) {
 		std::cout << "Got expected string value: '" << ex_s.value() << "'" << std::endl;

--- a/mender-update/main.cpp
+++ b/mender-update/main.cpp
@@ -12,8 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include <memory>
+#include <cstddef>
 #include <iostream>
+#include <memory>
+#include <string>
 
 using namespace std;
 
@@ -27,9 +29,6 @@ using namespace std;
 using namespace mender::common;
 
 
-#include <iostream>
-#include <cstddef>
-#include <bitset>
 
 void log_poc() {
 	namespace log = mender::common::log;


### PR DESCRIPTION
This PR replaces our internal std::expected implementation with an existing project. More closely:

```
https://github.com/TartanLlama/expected
```

This fully replaces our implementation, while giving us access to the modern monadic extensions, which can help reduce the overhead surrounding our expactation handling.

See the link for more information.