### PR TITLE
fix(cmake): Avoid inheriting conflicting flags from static libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,28 +79,14 @@ else()
   set(MENDER_USE_BOOST_FS 0)
 endif()
 
+# Default for all components.
+add_compile_options(-std=c++11 -Werror -Wall)
 
-#---------------------------------------------------------------------------------------------------
-# When deciding which one(s) of these to include, the general rule is this:
-#
-# If it's a cross platform component, add this:
-#   target_link_libraries(<TARGET> PUBLIC crossplatform_compiler_flags)
-#
-# If it's a platform specific component, with a cross platform interface, add this:
-#   target_link_libraries(<TARGET> PRIVATE platform_compiler_flags)
-#   target_link_libraries(<TARGET> INTERFACE crossplatform_compiler_flags)
-
-add_library(crossplatform_compiler_flags INTERFACE)
-target_compile_features(crossplatform_compiler_flags INTERFACE cxx_std_11)
-target_compile_options(crossplatform_compiler_flags INTERFACE -std=c++11 -Werror -Wall)
-
-add_library(platform_compiler_flags INTERFACE)
-target_compile_features(platform_compiler_flags INTERFACE cxx_std_17)
-target_compile_options(platform_compiler_flags INTERFACE -std=c++17 -Werror -Wall)
-#---------------------------------------------------------------------------------------------------
+# Use this with target_compile_options for platform specific components that need it.
+set(PLATFORM_SPECIFIC_COMPILE_OPTIONS -std=c++17)
 
 add_executable(mender main.cpp lib.cpp)
-target_link_libraries(mender PUBLIC common_events crossplatform_compiler_flags)
+target_link_libraries(mender PUBLIC common_events)
 target_include_directories(mender PUBLIC ".")
 
 if($CACHE{COVERAGE})
@@ -151,7 +137,6 @@ include(GoogleTest)
 set(MENDER_TEST_FLAGS EXTRA_ARGS --gtest_output=xml:${CMAKE_SOURCE_DIR}/reports/)
 
 add_executable(main_test EXCLUDE_FROM_ALL main_test.cpp lib.cpp)
-target_link_libraries(main_test PUBLIC crossplatform_compiler_flags)
 target_link_libraries(main_test PRIVATE GTest::gtest_main)
 gtest_discover_tests(main_test ${MENDER_TEST_FLAGS})
 

--- a/artifact/sha/CMakeLists.txt
+++ b/artifact/sha/CMakeLists.txt
@@ -7,8 +7,7 @@ endif()
 add_library(sha STATIC platform/openssl/sha.cpp)
 target_link_libraries(sha PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 target_link_libraries(sha PUBLIC common_log common_error common_io)
-target_link_libraries(sha PRIVATE platform_compiler_flags)
-target_link_libraries(sha INTERFACE crossplatform_compiler_flags)
+target_compile_options(sha PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_include_directories(sha PUBLIC
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,13 +1,10 @@
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_library(common STATIC common.cpp)
-target_link_libraries(common PUBLIC crossplatform_compiler_flags)
 
 add_library(common_error STATIC error.cpp)
-target_link_libraries(common_error PUBLIC crossplatform_compiler_flags)
 
 add_library(common_io STATIC io.cpp)
-target_link_libraries(common_io PUBLIC crossplatform_compiler_flags)
 
 add_executable(io_test EXCLUDE_FROM_ALL io_test.cpp)
 target_link_libraries(io_test PUBLIC common_io common_error GTest::gtest_main gmock)
@@ -19,15 +16,13 @@ set(events_sources "$<$<STREQUAL:${PLATFORM},linux_x86>:boost/events.cpp>")
 set(procs_sources "$<$<EQUAL:${MENDER_USE_TINY_PROC_LIB},1>:tiny_process_library/tiny_process_library.cpp>")
 
 add_library(common_json STATIC json/json.cpp json/platform/${json_sources})
-target_link_libraries(common_json PRIVATE platform_compiler_flags)
-target_link_libraries(common_json INTERFACE crossplatform_compiler_flags)
+target_compile_options(common_json PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 if(${json_sources} MATCHES ".*nlohmann.*")
   target_include_directories(common_json PUBLIC ${CMAKE_SOURCE_DIR}/vendor/json/include/)
 endif()
 
 add_library(common_testing STATIC testing.cpp)
-target_link_libraries(common_testing INTERFACE crossplatform_compiler_flags)
-target_link_libraries(common_testing PRIVATE platform_compiler_flags)
+target_compile_options(common_testing PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 
 add_executable(json_test EXCLUDE_FROM_ALL json_test.cpp)
 target_link_libraries(json_test PUBLIC common_json GTest::gtest_main gmock)
@@ -38,8 +33,7 @@ add_library(common_key_value_database STATIC
   key_value_database.cpp
   key_value_database/in_memory/in_memory.cpp
 )
-target_link_libraries(common_key_value_database PRIVATE platform_compiler_flags)
-target_link_libraries(common_key_value_database INTERFACE crossplatform_compiler_flags)
+target_compile_options(common_key_value_database PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 if(MENDER_USE_LMDB)
   target_sources(common_key_value_database PRIVATE key_value_database/platform/lmdb/lmdb.cpp)
   target_include_directories(common_key_value_database PRIVATE ${CMAKE_SOURCE_DIR}/vendor/lmdbxx)
@@ -64,8 +58,7 @@ add_dependencies(check key_value_database_test)
 find_package(Boost 1.35 REQUIRED)
 add_library(common_events STATIC events/platform/${events_sources})
 target_include_directories(common_events PUBLIC ${Boost_INCLUDE_DIR})
-target_link_libraries(common_events PRIVATE platform_compiler_flags)
-target_link_libraries(common_events INTERFACE crossplatform_compiler_flags)
+target_compile_options(common_events PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_compile_definitions(common_events PUBLIC MENDER_EVENTS_USE_BOOST=1)
 
 add_executable(events_test EXCLUDE_FROM_ALL events_test.cpp)
@@ -75,9 +68,8 @@ add_dependencies(check events_test)
 
 add_library(common_http STATIC http/http.cpp http/platform/beast/http.cpp)
 target_include_directories(common_http PUBLIC ${Boost_INCLUDE_DIR})
-target_link_libraries(common_http PRIVATE platform_compiler_flags)
+target_compile_options(common_http PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_link_libraries(common_http PUBLIC common common_events common_error common_log)
-target_link_libraries(common_http INTERFACE crossplatform_compiler_flags)
 target_compile_definitions(common_http PUBLIC MENDER_EVENTS_USE_BOOST=1)
 
 # add_executable(http_test EXCLUDE_FROM_ALL http_test.cpp)
@@ -87,8 +79,7 @@ target_compile_definitions(common_http PUBLIC MENDER_EVENTS_USE_BOOST=1)
 
 add_library(common_log STATIC)
 # Accept the global compiler flags
-target_link_libraries(common_log PRIVATE platform_compiler_flags)
-target_link_libraries(common_log INTERFACE crossplatform_compiler_flags)
+target_compile_options(common_log PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 find_package(Boost 1.54 REQUIRED COMPONENTS log log_setup chrono regex thread filesystem atomic)
 target_sources(common_log PRIVATE log/platform/boost/boost_log.cpp)
 target_link_libraries(common_log PUBLIC ${Boost_LIBRARIES})
@@ -100,7 +91,6 @@ gtest_discover_tests(log_test)
 add_dependencies(check log_test)
 
 add_library(common_config_parser STATIC config_parser/config_parser.cpp)
-target_link_libraries(common_config_parser PUBLIC crossplatform_compiler_flags)
 target_link_libraries(common_config_parser PUBLIC common_json)
 if(${json_sources} MATCHES ".*nlohmann.*")
   target_include_directories(common_config_parser PUBLIC ${CMAKE_SOURCE_DIR}/vendor/json/include/)
@@ -109,14 +99,13 @@ endif()
 add_executable(config_parser_test EXCLUDE_FROM_ALL config_parser_test.cpp)
 target_link_libraries(config_parser_test PUBLIC common_config_parser GTest::gtest_main gmock)
 # The test uses some non-c++11 stuff, even though the implementation is c++11.
-target_link_libraries(common_config_parser PUBLIC platform_compiler_flags)
+target_compile_options(config_parser_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 gtest_discover_tests(config_parser_test)
 add_dependencies(check config_parser_test)
 
 
 add_library(common_processes STATIC processes/processes.cpp processes/platform/${procs_sources})
-target_link_libraries(common_processes PRIVATE platform_compiler_flags)
-target_link_libraries(common_processes INTERFACE crossplatform_compiler_flags)
+target_compile_options(common_processes PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_include_directories(common_processes PRIVATE ${CMAKE_SOURCE_DIR})
 if(${procs_sources} MATCHES ".*tiny_process_library.*")
   target_include_directories(common_processes PRIVATE ${CMAKE_SOURCE_DIR}/vendor/tiny-process-library)
@@ -131,7 +120,6 @@ add_dependencies(check processes_test)
 
 
 add_library(common_key_value_parser STATIC key_value_parser/key_value_parser.cpp)
-target_link_libraries(common_key_value_parser PUBLIC crossplatform_compiler_flags)
 target_link_libraries(common_key_value_parser PUBLIC common_error)
 target_include_directories(common_key_value_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
@@ -143,7 +131,6 @@ add_dependencies(check key_value_parser_test)
 
 
 add_library(common_identity_parser STATIC identity_parser/identity_parser.cpp)
-target_link_libraries(common_identity_parser PUBLIC crossplatform_compiler_flags)
 target_include_directories(common_identity_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes)
 
@@ -155,11 +142,10 @@ add_dependencies(check identity_parser_test)
 
 
 add_library(common_inventory_parser STATIC)
-target_link_libraries(common_inventory_parser INTERFACE crossplatform_compiler_flags)
 if(MENDER_USE_BOOST_FS)
   find_package(Boost 1.54 REQUIRED COMPONENTS filesystem)
   target_sources(common_inventory_parser PRIVATE inventory_parser/platform/boost_filesystem/inventory_parser.cpp)
-  target_link_libraries(common_inventory_parser PRIVATE platform_compiler_flags)
+  target_compile_options(common_inventory_parser PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
   target_include_directories(common_inventory_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${Boost_INCLUDEDIR})
   target_link_libraries(common_inventory_parser PUBLIC common_key_value_parser common_processes common_log ${Boost_libraries})
 endif()
@@ -172,12 +158,11 @@ add_dependencies(check inventory_parser_test)
 
 
 add_library(common_conf STATIC conf/conf.cpp)
-target_link_libraries(common_conf INTERFACE crossplatform_compiler_flags)
 if(MENDER_USE_BOOST_FS)
   find_package(Boost 1.54 REQUIRED COMPONENTS filesystem)
   target_sources(common_conf PRIVATE conf/platform/boost_filesystem/paths.cpp)
   target_include_directories(common_conf PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${Boost_INCLUDEDIR})
-  target_link_libraries(common_conf PRIVATE platform_compiler_flags)
+  target_compile_options(common_conf PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
   target_link_libraries(common_conf ${Boost_libraries})
 endif()
 

--- a/common/config_parser.hpp
+++ b/common/config_parser.hpp
@@ -20,7 +20,9 @@
 #ifndef MENDER_COMMON_CONFIG_PARSER_HPP
 #define MENDER_COMMON_CONFIG_PARSER_HPP
 
-namespace mender::common::config_parser {
+namespace mender {
+namespace common {
+namespace config_parser {
 
 using namespace std;
 
@@ -168,6 +170,8 @@ public:
 	ExpectedBool ValidateArtifactKeyCondition() const;
 };
 
-} // namespace mender::common::config_parser
+} // namespace config_parser
+} // namespace common
+} // namespace mender
 
 #endif // MENDER_COMMON_CONFIG_PARSER_HPP

--- a/common/config_parser/config_parser.cpp
+++ b/common/config_parser/config_parser.cpp
@@ -18,7 +18,9 @@
 #include <algorithm>
 #include <common/json.hpp>
 
-namespace mender::common::config_parser {
+namespace mender {
+namespace common {
+namespace config_parser {
 
 using namespace std;
 namespace json = mender::common::json;
@@ -472,4 +474,6 @@ ExpectedBool MenderConfigFromFile::ValidateConfig() {
 
 
 
-} // namespace mender::common::config_parser
+} // namespace config_parser
+} // namespace common
+} // namespace mender

--- a/common/json/json.cpp
+++ b/common/json/json.cpp
@@ -14,7 +14,9 @@
 
 #include <common/json.hpp>
 
-namespace mender::common::json {
+namespace mender {
+namespace common {
+namespace json {
 
 const JsonErrorCategoryClass JsonErrorCategory;
 
@@ -43,4 +45,6 @@ error::Error MakeError(JsonErrorCode code, const string &msg) {
 	return error::Error(error_condition(code, JsonErrorCategory), msg);
 }
 
-} // namespace mender::common::json
+} // namespace json
+} // namespace common
+} // namespace mender

--- a/common/key_value_database/in_memory/in_memory.cpp
+++ b/common/key_value_database/in_memory/in_memory.cpp
@@ -17,7 +17,9 @@
 
 #include <string>
 
-namespace mender::common::key_value_database {
+namespace mender {
+namespace common {
+namespace key_value_database {
 
 using namespace std;
 
@@ -98,4 +100,6 @@ Error KeyValueDatabaseInMemory::ReadTransaction(function<Error(Transaction &)> t
 	return txnFunc(txn);
 }
 
-} // namespace mender::common::key_value_database
+} // namespace key_value_database
+} // namespace common
+} // namespace mender

--- a/mender-auth/CMakeLists.txt
+++ b/mender-auth/CMakeLists.txt
@@ -2,7 +2,6 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(mender-auth main.cpp)
 target_link_libraries(mender-auth PRIVATE common_json common_log)
-target_link_libraries(mender-auth PUBLIC crossplatform_compiler_flags)
 install(TARGETS mender-auth
   DESTINATION bin
   COMPONENT mender-auth

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -2,7 +2,6 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(mender-update main.cpp)
 target_link_libraries(mender-update PRIVATE common_json common_log common_http common_conf)
-target_link_libraries(mender-update PUBLIC crossplatform_compiler_flags)
 install(TARGETS mender-update
   DESTINATION bin
   COMPONENT mender-update


### PR DESCRIPTION
Because flags are inherited from other libraries when you link to them, this does not work well for conflicting flags. Instead, introduce a default for all components, and then override using `target_compile_options`, which always puts the flags last.

Changelog: None
Ticket: None
