### PR TITLE
Add the manifest parser implementation

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(sha)
-add_subdirectory(v3/version)
 add_subdirectory(tar)
+
+add_subdirectory(v3/version)
+add_subdirectory(v3/manifest)

--- a/artifact/error.cpp
+++ b/artifact/error.cpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/error.hpp>
+
+#include <cassert>
+#include <string>
+
+namespace mender {
+namespace artifact {
+namespace parser_error {
+
+using namespace std;
+
+namespace error = mender::common::error;
+
+const ErrorCategoryClass ErrorCategory;
+
+const char *ErrorCategoryClass::name() const noexcept {
+	return "ParserErrorCategory";
+}
+
+string ErrorCategoryClass::message(int code) const {
+	switch (code) {
+	case NoError:
+		return "Success";
+	case ParseError:
+		return "Parse error";
+	case TypeError:
+		return "Type error";
+	case EOFError:
+		return "EOF error";
+	}
+	assert(false);
+}
+
+error::Error MakeError(Code code, const string &msg) {
+	return error::Error(error_condition(code, ErrorCategory), msg);
+}
+} // namespace parser_error
+} // namespace artifact
+} // namespace mender

--- a/artifact/error.hpp
+++ b/artifact/error.hpp
@@ -1,0 +1,50 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_PARSER_ERROR_HPP
+#define MENDER_PARSER_ERROR_HPP
+
+#include <string>
+
+#include <common/error.hpp>
+
+namespace mender {
+namespace artifact {
+namespace parser_error {
+
+using namespace std;
+
+namespace error = mender::common::error;
+
+enum Code {
+	NoError = 0,
+	ParseError,
+	TypeError,
+	EOFError,
+};
+
+class ErrorCategoryClass : public std::error_category {
+public:
+	const char *name() const noexcept override;
+	string message(int code) const override;
+};
+extern const ErrorCategoryClass ErrorCategory;
+
+error::Error MakeError(Code code, const string &msg);
+} // namespace parser_error
+} // namespace artifact
+} // namespace mender
+
+
+#endif // MENDER_PARSER_ERROR_HPP

--- a/artifact/v3/manifest/CMakeLists.txt
+++ b/artifact/v3/manifest/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+# Test the parser
+add_executable(artifact_manifest_parser_test EXCLUDE_FROM_ALL
+  manifest.cpp
+  ${CMAKE_SOURCE_DIR}/artifact/error.cpp
+  manifest_test.cpp
+)
+target_link_libraries(artifact_manifest_parser_test PRIVATE
+  common_log
+  common_io
+  common_error
+  GTest::gtest_main
+  gmock
+)
+target_include_directories(artifact_manifest_parser_test PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+)
+gtest_discover_tests(artifact_manifest_parser_test)
+add_dependencies(check artifact_manifest_parser_test)

--- a/artifact/v3/manifest/manifest.cpp
+++ b/artifact/v3/manifest/manifest.cpp
@@ -1,0 +1,95 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/manifest/manifest.hpp>
+
+#include <cctype>
+#include <iterator>
+#include <string>
+#include <sstream>
+#include <regex>
+
+#include <common/error.hpp>
+
+#include <artifact/error.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace manifest {
+
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+
+struct ManifestLine {
+	const string shasum;
+	const string entry_name;
+};
+
+using ExpectedManifestLine = expected::expected<ManifestLine, error::Error>;
+
+const size_t expected_shasum_length {64};
+const size_t expected_whitespace {2};
+const string manifest_line_regex_string {
+	"^([0-9a-z]{" + to_string(expected_shasum_length) + "})[[:space:]]{"
+	+ to_string(expected_whitespace) + "}([/.[:alnum:]]+)$"};
+
+namespace {
+ExpectedManifestLine Tokenize(const string &line) {
+	const std::regex manifest_line_regex(
+		manifest_line_regex_string, std::regex_constants::ECMAScript);
+	std::smatch base_match;
+	std::regex_match(line, base_match, manifest_line_regex);
+
+	if (base_match.size() != 3) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::ParseError,
+			"Line (" + line
+				+ ") is not in the expected manifest format: " + manifest_line_regex_string));
+	}
+
+	return ManifestLine {.shasum = base_match[1], .entry_name = base_match[2]};
+}
+} // namespace
+
+ExpectedManifest Parse(mender::common::io::Reader &reader) {
+	Manifest m {};
+
+	stringstream ss {};
+
+	io::StreamWriter sw {ss};
+
+	auto err = io::Copy(sw, reader);
+	if (err) {
+		return expected::unexpected(err);
+	}
+
+	string line {};
+
+	while (getline(ss, line, '\n')) {
+		auto manifest_line = Tokenize(line);
+		if (!manifest_line) {
+			return expected::unexpected(manifest_line.error());
+		}
+
+		m.map_[manifest_line->entry_name] = manifest_line->shasum;
+	}
+
+	return m;
+}
+
+} // namespace manifest
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/artifact/v3/manifest/manifest.hpp
+++ b/artifact/v3/manifest/manifest.hpp
@@ -1,0 +1,57 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_V3_MANIFEST_PARSER_HPP
+#define MENDER_ARTIFACT_V3_MANIFEST_PARSER_HPP
+
+#include <string>
+#include <unordered_map>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace manifest {
+
+using namespace std;
+
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+
+class Manifest {
+public:
+	string Get(const string &key) {
+		auto value = map_.find(key);
+		if (value != map_.end()) {
+			return value->second;
+		}
+		return "";
+	}
+
+	unordered_map<string, string> map_;
+};
+
+using ExpectedManifest = expected::expected<Manifest, error::Error>;
+
+ExpectedManifest Parse(io::Reader &reader);
+
+} // namespace manifest
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+#endif // MENDER_ARTIFACT_V3_MANIFEST_PARSER_HPP

--- a/artifact/v3/manifest/manifest_test.cpp
+++ b/artifact/v3/manifest/manifest_test.cpp
@@ -1,0 +1,147 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/manifest/manifest.hpp>
+
+#include <string>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace std;
+
+TEST(ParserTest, TestParseManifest) {
+	std::string manifest_data =
+		R"(aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f  data/0000.tar
+9f65db081a46f7832b9767c56afcc7bfe784f0a62cc2950b6375b2b6390e6e50  header.tar
+96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b  version
+)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	ASSERT_TRUE(manifest) << "error message: " << manifest.error().message;
+
+	auto manifest_unwrapped = manifest.value();
+
+	ASSERT_EQ(
+		manifest_unwrapped.Get("version"),
+		"96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b")
+		<< "ONE";
+	EXPECT_EQ(
+		manifest_unwrapped.Get("header.tar"),
+		"9f65db081a46f7832b9767c56afcc7bfe784f0a62cc2950b6375b2b6390e6e50")
+		<< "TWO";
+	EXPECT_EQ(
+		manifest_unwrapped.Get("data/0000.tar"),
+		"aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f")
+		<< "THREE";
+	EXPECT_EQ(manifest_unwrapped.Get("IDoNotExist"), "");
+}
+
+TEST(ParserTest, TestParseManifestFormatErrorShasumLength) {
+	/* Two characters missing from the shasum */
+	std::string manifest_data =
+		R"(aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb001  data/0000.tar
+)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	EXPECT_FALSE(manifest) << manifest.error().message;
+
+	EXPECT_EQ(
+		manifest.error().message,
+		"Line (aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb001  data/0000.tar) is not in the expected manifest format: ^([0-9a-z]{64})[[:space:]]{2}([/.[:alnum:]]+)$");
+}
+
+TEST(ParserTest, TestParseManifestFormatErrorMissingName) {
+	std::string manifest_data =
+		R"(96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b
+)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	EXPECT_FALSE(manifest) << manifest.error().message;
+
+	EXPECT_EQ(
+		manifest.error().message,
+		"Line (96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b) is not in the expected manifest format: ^([0-9a-z]{64})[[:space:]]{2}([/.[:alnum:]]+)$");
+}
+
+
+TEST(ParserTest, TestParseManifestFormatErrorWrongNumberOfWhitespaceSeparators) {
+	/* 3 instead of two spaces in between the sha and the name */
+	std::string manifest_data =
+		R"(96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b   version
+)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	EXPECT_FALSE(manifest);
+
+	EXPECT_EQ(
+		manifest.error().message,
+		"Line (96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b   version) is not in the expected manifest format: ^([0-9a-z]{64})[[:space:]]{2}([/.[:alnum:]]+)$");
+}
+
+TEST(ParserTest, TestParseManifestFormatErrorAllOnOneLine) {
+	std::string manifest_data =
+		R"(aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f  data/00 00.tar
+9f65db081a46f7832b9767c56afcc7bfe784f0a62cc2950b6375b2b6390e6e50  header.tar
+96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b  version)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	EXPECT_FALSE(manifest);
+
+	EXPECT_EQ(
+		manifest.error().message,
+		"Line (aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f  data/00 00.tar) is not in the expected manifest format: ^([0-9a-z]{64})[[:space:]]{2}([/.[:alnum:]]+)$");
+}
+
+TEST(ParserTest, TestParseManifestFormatErrorNewlineSeparators) {
+	std::string manifest_data =
+		R"(aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f data/0000.tar 9f65db081a46f7832b9767c56afcc7bfe784f0a62cc2950b6375b2b6390e6e50 header.tar 96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b version)";
+
+	std::stringstream ss {manifest_data};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto manifest = mender::artifact::v3::manifest::Parse(sr);
+
+	EXPECT_FALSE(manifest) << manifest.error().message << std::endl;
+
+	EXPECT_EQ(
+		manifest.error().message,
+		"Line (aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f data/0000.tar 9f65db081a46f7832b9767c56afcc7bfe784f0a62cc2950b6375b2b6390e6e50 header.tar 96bcd965947569404798bcbdb614f103db5a004eb6e364cfc162c146890ea35b version) is not in the expected manifest format: ^([0-9a-z]{64})[[:space:]]{2}([/.[:alnum:]]+)$");
+}

--- a/common/io.cpp
+++ b/common/io.cpp
@@ -64,6 +64,15 @@ ExpectedSize ByteWriter::Write(
 	return bytes_to_write;
 }
 
+ExpectedSize StreamWriter::Write(
+	vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+	os_.write(reinterpret_cast<const char *>(&*start), end - start);
+	if (!os_) {
+		return expected::unexpected(Error(make_error_condition(errc::io_error), ""));
+	}
+	return end - start;
+}
+
 } // namespace io
 } // namespace common
 } // namespace mender

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -27,6 +27,8 @@
 #include <sstream>
 #include <string>
 #include <algorithm>
+#include <ostream>
+#include <iostream>
 
 namespace mender {
 namespace common {
@@ -137,6 +139,21 @@ public:
 		receiver_ {receiver} {
 	}
 
+	ExpectedSize Write(
+		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) override;
+};
+
+class StreamWriter : virtual public Writer {
+private:
+	std::ostream &os_;
+
+public:
+	StreamWriter(std::ostream &stream) :
+		os_ {stream} {
+	}
+	StreamWriter(std::ostream &&stream) :
+		os_ {stream} {
+	}
 	ExpectedSize Write(
 		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) override;
 };


### PR DESCRIPTION
This adds the initial manifest parser implementation for the Mender-artifact format parser.