### PR TITLE
Artifact Payload parser implementation

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(sha)
 add_subdirectory(tar)
-
 add_subdirectory(v3/version)
 add_subdirectory(v3/manifest)
+add_subdirectory(v3/payload)

--- a/artifact/v3/payload/CMakeLists.txt
+++ b/artifact/v3/payload/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Test the parser
+add_executable(artifact_payload_parser_test EXCLUDE_FROM_ALL
+  payload.cpp
+  payload_test.cpp
+)
+target_link_libraries(artifact_payload_parser_test PRIVATE
+  GTest::gtest_main
+  gmock
+  common_io
+  common_error
+  common_log
+  common_tar
+  common_testing
+  common_processes
+  sha
+)
+target_include_directories(artifact_payload_parser_test PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+)
+gtest_discover_tests(artifact_payload_parser_test)
+add_dependencies(check artifact_payload_parser_test)

--- a/artifact/v3/payload/payload.cpp
+++ b/artifact/v3/payload/payload.cpp
@@ -1,0 +1,35 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/payload/payload.hpp>
+
+#include <vector>
+
+#include <common/io.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace payload {
+
+using namespace std;
+
+Reader Verify(io::Reader &reader, const string &expected_shasum) {
+	return sha::Reader {reader, expected_shasum};
+}
+
+} // namespace payload
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/artifact/v3/payload/payload.hpp
+++ b/artifact/v3/payload/payload.hpp
@@ -1,0 +1,47 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_PAYLOAD_PARSER_HPP
+#define MENDER_ARTIFACT_PAYLOAD_PARSER_HPP
+
+#include <vector>
+
+#include <common/io.hpp>
+#include <common/expected.hpp>
+
+#include <artifact/sha/sha.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace payload {
+
+using namespace std;
+
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+namespace sha = mender::sha;
+
+using mender::common::expected::ExpectedSize;
+
+typedef sha::Reader Reader;
+
+Reader Verify(io::Reader &reader, const string &expected_shasum);
+
+} // namespace payload
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+
+#endif // MENDER_ARTIFACT_PAYLOAD_PARSER_HPP

--- a/artifact/v3/payload/payload_test.cpp
+++ b/artifact/v3/payload/payload_test.cpp
@@ -1,0 +1,119 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/payload/payload.hpp>
+
+#include <string>
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <artifact/tar/tar.hpp>
+
+#include <common/processes.hpp>
+#include <common/testing.hpp>
+
+using namespace std;
+
+namespace io = mender::common::io;
+namespace tar = mender::tar;
+namespace processes = mender::common::processes;
+namespace mendertesting = mender::common::testing;
+namespace payload = mender::artifact::v3::payload;
+
+class PayloadTestEnv : public testing::Test {
+public:
+protected:
+	static void SetUpTestSuite() {
+		string script = R"(#! /bin/sh
+
+    DIRNAME=$(dirname $0)
+
+		# Create small tar payload file
+		echo foobar > ${DIRNAME}/testdata
+		tar cvf ${DIRNAME}/test.tar ${DIRNAME}/testdata
+
+		exit 0
+		)";
+
+		const string script_fname = tmpdir->Path() + "/test-script.sh";
+
+		std::ofstream os(script_fname.c_str(), std::ios::out);
+		os << script;
+		os.close();
+
+		int ret = chmod(script_fname.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+		ASSERT_EQ(ret, 0);
+
+
+		processes::Process proc({script_fname});
+		auto ex_line_data = proc.GenerateLineData();
+		ASSERT_TRUE(ex_line_data);
+		EXPECT_EQ(proc.GetExitStatus(), 0) << "error message: " + ex_line_data.error().message;
+	}
+
+	static void TearDownTestSuite() {
+		tmpdir.reset();
+	}
+
+	static unique_ptr<mendertesting::TemporaryDirectory> tmpdir;
+};
+
+unique_ptr<mendertesting::TemporaryDirectory> PayloadTestEnv::tmpdir =
+	unique_ptr<mendertesting::TemporaryDirectory>(new mendertesting::TemporaryDirectory());
+
+TEST_F(PayloadTestEnv, TestPayloadSuccess) {
+	std::fstream fs {tmpdir->Path() + "/test.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	mender::tar::Reader tar_reader {sr};
+
+	mender::tar::Entry tar_entry = tar_reader.Next().value();
+
+	ASSERT_THAT(tar_entry.Name(), testing::EndsWith("testdata"));
+
+	payload::Reader p = payload::Verify(
+		tar_entry, "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f");
+
+	auto discard_writer = io::Discard {};
+
+	auto err = io::Copy(discard_writer, p);
+
+	EXPECT_FALSE(err) << "Got unexpected error: " << err.message;
+}
+
+TEST_F(PayloadTestEnv, TestPayloadFailure) {
+	std::fstream fs {tmpdir->Path() + "/test.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	mender::tar::Reader tar_reader {sr};
+
+	mender::tar::Entry tar_entry = tar_reader.Next().value();
+
+	ASSERT_THAT(tar_entry.Name(), testing::EndsWith("testdata"));
+
+	payload::Reader p = payload::Verify(
+		tar_entry,
+		// Ends with (e) not (f)
+		"aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019e");
+
+	auto discard_writer = io::Discard {};
+
+	auto err = io::Copy(discard_writer, p);
+
+	EXPECT_TRUE(err);
+}


### PR DESCRIPTION
This adds the payload parser implementation.

Interface:

```
payload::Verify(io::Reader) -> Reader
```

The payload is itself offering a Reader, and will automatically verify the
payload checksum upon write, and if the checksum does not match, will throw an
error at the end of the write.

Interface:

```
p = Payload.Next()
.Read() -> expectedSize
```

Ticket: MEN-6205
Changelog: None