### PR TITLE
chore(artifact): Add the version parser to the mender namespace

### DIFF
--- a/artifact/v3/version/version.cpp
+++ b/artifact/v3/version/version.cpp
@@ -23,6 +23,7 @@
 #include <common/json.hpp>
 
 
+namespace mender {
 namespace artifact {
 namespace v3 {
 namespace version {
@@ -115,3 +116,4 @@ ExpectedVersion Parse(io::Reader &reader) {
 } // namespace version
 } // namespace v3
 } // namespace artifact
+} // namespace mender

--- a/artifact/v3/version/version.hpp
+++ b/artifact/v3/version/version.hpp
@@ -21,6 +21,7 @@
 #include <common/error.hpp>
 #include <common/io.hpp>
 
+namespace mender {
 namespace artifact {
 namespace v3 {
 namespace version {
@@ -61,5 +62,6 @@ ExpectedVersion Parse(io::Reader &reader);
 } // namespace version
 } // namespace v3
 } // namespace artifact
+} // namespace mender
 
 #endif // MENDER_ARTIFACT_VERSION_PARSER_HPP

--- a/artifact/v3/version/version_test.cpp
+++ b/artifact/v3/version/version_test.cpp
@@ -22,6 +22,8 @@
 
 using namespace std;
 
+using namespace mender;
+
 
 TEST(ParserTest, TestParseVersion) {
 	std::string json_data = R"(


### PR DESCRIPTION
This was missed during the initial implementation and review.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>