### PR TITLE
feat(artifact): Add the top-level parser structure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,11 @@ test:
   stage: test
   image: debian:11
   before_script:
-    - apt update && apt install -yyq g++ cmake git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev
+    - apt update && apt install -yyq g++ cmake git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev curl
+    # mender-artifact install
+    - curl https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
+      -o /usr/local/bin/mender-artifact
+    - chmod +x /usr/local/bin/mender-artifact
   script:
     - cmake -D COVERAGE=ON .
     - make coverage
@@ -41,7 +45,23 @@ test:
   stage: test
   image: ubuntu:22.04
   before_script:
-    - apt update && apt install -yyq clang cmake git make pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev
+    - apt update && apt install -yyq clang cmake git make pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev curl
+    # mender-artifact
+    - curl https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
+      -o /bin/mender-artifact
+    - chmod +x /bin/mender-artifact
+    # mender-artifact install
+    - apt-get install --assume-yes
+        apt-transport-https
+        ca-certificates
+        curl
+        gnupg-agent
+        software-properties-common
+    - curl -fsSL https://downloads.mender.io/repos/debian/gpg >> /etc/apt/trusted.gpg.d/mender.asc
+    - echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/jammy/stable main"
+      > /etc/apt/sources.list.d/mender.list
+    - apt-get update
+    - apt install mender-artifact
     - export CC=$(which clang)
     - export CXX=$(which clang++)
   script:

--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -1,5 +1,34 @@
+
 add_subdirectory(sha)
 add_subdirectory(tar)
 add_subdirectory(v3/version)
 add_subdirectory(v3/manifest)
 add_subdirectory(v3/payload)
+
+set(parser_sources
+  parser.cpp
+  error.cpp
+  v3/version/version.cpp
+  v3/manifest/manifest.cpp
+  v3/payload/payload.cpp
+)
+
+add_library(artifact_parser STATIC ${parser_sources})
+target_link_libraries(artifact_parser PUBLIC common_json common_log common_tar common_error sha common_io)
+target_compile_options(common_json PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
+target_include_directories(artifact_parser PUBLIC ${CMAKE_SOURCE_DIR})
+
+# Test the parser
+add_executable(artifact_parser_test EXCLUDE_FROM_ALL parser_test.cpp)
+target_link_libraries(artifact_parser_test PRIVATE
+  artifact_parser
+  GTest::gtest_main
+  gmock
+  common_testing
+  common_io
+  common_processes
+)
+target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR}/artifact)
+gtest_discover_tests(artifact_parser_test)
+add_dependencies(check artifact_parser_test)

--- a/artifact/lexer.hpp
+++ b/artifact/lexer.hpp
@@ -1,0 +1,70 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_LEXER_HPP
+#define MENDER_ARTIFACT_LEXER_HPP
+
+#include <cstdint>
+#include <unordered_map>
+
+#include <system_error>
+
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/expected.hpp>
+#include <artifact/tar/tar.hpp>
+
+#include <artifact/sha/sha.hpp>
+
+#include <artifact/token.hpp>
+
+
+namespace mender {
+namespace artifact {
+namespace lexer {
+
+using namespace std;
+
+namespace log = mender::common::log;
+
+class Lexer {
+private:
+	std::shared_ptr<mender::tar::Reader> tar_reader_;
+
+public:
+	token::Token current;
+
+	Lexer(std::shared_ptr<mender::tar::Reader> tr) :
+		tar_reader_ {tr},
+		current {} {
+	}
+
+	token::Token &Next() {
+		auto entry = tar_reader_->Next();
+		if (!entry) {
+			log::Error("Error reading the next tar entry: " + entry.error().message);
+			this->current = token::Token {token::Type::Unrecognized};
+			return this->current;
+		}
+		log::Trace("Entry name: " + entry.value().Name());
+		this->current = token::Token {entry.value().Name(), entry.value()};
+		return current;
+	}
+};
+
+} // namespace lexer
+} // namespace artifact
+} // namespace mender
+
+#endif // MENDER_ARTIFACT_LEXER_HPP

--- a/artifact/parser.cpp
+++ b/artifact/parser.cpp
@@ -1,0 +1,137 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/parser.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <system_error>
+#include <unordered_map>
+
+#include <common/json.hpp>
+#include <common/log.hpp>
+#include <artifact/tar/tar.hpp>
+#include <common/common.hpp>
+
+#include <artifact/lexer.hpp>
+#include <artifact/tar/tar.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+Header Parse() {
+	return Header {};
+}
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+
+
+namespace mender {
+namespace artifact {
+namespace parser {
+
+using namespace std;
+
+namespace lexer = artifact::lexer;
+namespace log = mender::common::log;
+namespace io = mender::common::io;
+namespace tar = mender::tar;
+namespace expected = mender::common::expected;
+namespace error = mender::common::error;
+
+namespace version = mender::artifact::v3::version;
+namespace manifest = mender::artifact::v3::manifest;
+namespace payload = mender::artifact::v3::payload;
+
+ExpectedArtifact Parse(io::Reader &reader) {
+	std::shared_ptr<tar::Reader> tar_reader {make_shared<tar::Reader>(reader)};
+
+	lexer::Lexer lexer = lexer::Lexer {tar_reader};
+
+	token::Token tok = lexer.Next();
+
+	log::Trace("Parsing Version");
+	if (tok.type != token::Type::Version) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Got unexpected token : '" + tok.TypeToString() + "' expected 'version'"));
+	}
+
+	auto expected_version = version::Parse(*tok.value);
+
+	if (!expected_version) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the version: " + expected_version.error().message));
+	}
+
+	auto version = expected_version.value();
+
+	log::Trace("Parsing the Manifest");
+	tok = lexer.Next();
+	if (tok.type != token::Type::Manifest) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Got unexpected token " + tok.TypeToString() + " expected 'manifest'"));
+	}
+	auto expected_manifest = manifest::Parse(*tok.value);
+	if (!expected_manifest) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the manifest: " + expected_manifest.error().message));
+	}
+	auto manifest = expected_manifest.value();
+
+	tok = lexer.Next();
+	if (tok.type == token::Type::ManifestSignature) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError, "Signed Artifacts are unsupported"));
+	}
+
+	log::Trace("Parsing the Header");
+	if (tok.type != token::Type::Header) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Got unexpected token " + tok.TypeToString() + " expected 'Header'"));
+	}
+	// auto header = v3::header::Parse(); // TODO (MEN-6178): Enable
+
+	log::Trace("Parsing the payload");
+	tok = lexer.Next();
+	if (tok.type != token::Type::Payload) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Got unexpected token " + tok.TypeToString() + "expected 'data/0000.tar"));
+	}
+
+	return Artifact {version, manifest, lexer}; // TODO (MEN-6178): Add the header
+};
+
+
+ExpectedPayloadReader Artifact::Next() {
+	// Currently only one payload supported
+	if (payload_index_ != 0) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::EOFError, "Reached the end of the Artifact"));
+	}
+	payload_index_++;
+	return payload::Verify(*(this->lexer_.current.value), this->manifest.Get("data/0000.tar"));
+}
+
+} // namespace parser
+} // namespace artifact
+} // namespace mender

--- a/artifact/parser.hpp
+++ b/artifact/parser.hpp
@@ -1,0 +1,103 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_PARSER_HPP
+#define MENDER_ARTIFACT_PARSER_HPP
+
+#include <memory>
+#include <unordered_map>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/log.hpp>
+#include <common/io.hpp>
+#include <artifact/tar/tar.hpp>
+
+#include <artifact/sha/sha.hpp>
+
+#include <artifact/v3/version/version.hpp>
+#include <artifact/v3/manifest/manifest.hpp>
+#include <artifact/v3/payload/payload.hpp>
+
+#include <artifact/lexer.hpp>
+
+#include <artifact/error.hpp>
+
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+
+namespace header {
+struct Header {};
+} // namespace header
+namespace payload {} // namespace payload
+
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+
+
+namespace mender {
+namespace artifact {
+namespace parser {
+
+using namespace std;
+
+namespace expected = mender::common::expected;
+namespace error = mender::common::error;
+namespace io = mender::common::io;
+
+namespace payload = mender::artifact::v3::payload;
+
+namespace tar = mender::tar;
+
+using Version = mender::artifact::v3::version::Version;
+using Manifest = mender::artifact::v3::manifest::Manifest;
+using Header = mender::artifact::v3::header::Header;
+
+namespace payload = mender::artifact::v3::payload;
+
+using ExpectedPayloadReader = expected::expected<payload::Reader, error::Error>;
+
+// Structure to hold the contents of a Mender artifact file.
+class Artifact {
+private:
+	lexer::Lexer lexer_;
+	unsigned int payload_index_ {0};
+
+public:
+	Version version;
+	Manifest manifest;
+	// manifest::sig::ManifestSignature manifest_sig {}; // Unused
+	Header header {}; // Unused
+
+	ExpectedPayloadReader Next();
+
+	Artifact(Version &version, Manifest &manifest, lexer::Lexer lexer) :
+		lexer_ {lexer},
+		version {version},
+		manifest {manifest} {
+	}
+};
+
+using ExpectedArtifact = expected::expected<Artifact, error::Error>;
+
+ExpectedArtifact Parse(io::Reader &reader);
+
+} // namespace parser
+} // namespace artifact
+
+} // namespace mender
+#endif // MENDER_ARTIFACT_PARSER_HPP

--- a/artifact/parser_test.cpp
+++ b/artifact/parser_test.cpp
@@ -1,0 +1,135 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/parser.hpp>
+#include <artifact/lexer.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <common/processes.hpp>
+
+#include <common/testing.hpp>
+
+#include <fstream>
+
+
+using namespace std;
+
+namespace io = mender::common::io;
+
+namespace tar = mender::tar;
+
+namespace processes = mender::common::processes;
+
+namespace mendertesting = mender::common::testing;
+
+class ParserTestEnv : public testing::Test {
+public:
+protected:
+	static void SetUpTestSuite() {
+		string script = R"(#! /bin/sh
+
+    DIRNAME=$(dirname $0)
+
+		# Create small tar file
+		echo foobar > ${DIRNAME}/testdata
+		mender-artifact --compression none write rootfs-image --no-progress -t test-device -n test-artifact -f ${DIRNAME}/testdata -o ${DIRNAME}/test-artifact-no-compression.mender || exit 1
+
+		mender-artifact --compression gzip write rootfs-image --no-progress -t test-device -n test-artifact -f ${DIRNAME}/testdata -o ${DIRNAME}/test-artifact-gzip.mender || exit 1
+
+		mender-artifact --compression lzma write rootfs-image --no-progress -t test-device -n test-artifact -f ${DIRNAME}/testdata -o ${DIRNAME}/test-artifact-lzma.mender || exit 1
+
+		mender-artifact --compression zstd_better write rootfs-image --no-progress -t test-device -n test-artifact -f ${DIRNAME}/testdata -o ${DIRNAME}/test-artifact-zstd.mender || exit 1
+
+		exit 0
+		)";
+
+		const string script_fname = tmpdir->Path() + "/test-script.sh";
+
+		std::ofstream os(script_fname.c_str(), std::ios::out);
+		os << script;
+		os.close();
+
+		int ret = chmod(script_fname.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+		ASSERT_EQ(ret, 0);
+
+
+		processes::Process proc({script_fname});
+		auto ex_line_data = proc.GenerateLineData();
+		ASSERT_TRUE(ex_line_data);
+		EXPECT_EQ(proc.GetExitStatus(), 0) << "error message: " + ex_line_data.error().message;
+	}
+
+	static void TearDownTestSuite() {
+		tmpdir.reset();
+	}
+
+	static unique_ptr<mendertesting::TemporaryDirectory> tmpdir;
+};
+
+unique_ptr<mendertesting::TemporaryDirectory> ParserTestEnv::tmpdir =
+	unique_ptr<mendertesting::TemporaryDirectory>(new mendertesting::TemporaryDirectory());
+;
+
+TEST_F(ParserTestEnv, TestParseTopLevelNoCompression) {
+	std::fstream fs {tmpdir->Path() + "/test-artifact-no-compression.mender"};
+
+	io::StreamReader sr {fs};
+
+	auto artifact = mender::artifact::parser::Parse(sr);
+
+	ASSERT_TRUE(artifact) << artifact.error().message << std::endl;
+}
+
+TEST_F(ParserTestEnv, TestParseTopLevelGzip) {
+	std::fstream fs {tmpdir->Path() + "/test-artifact-gzip.mender"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	auto artifact = mender::artifact::parser::Parse(sr);
+
+	ASSERT_TRUE(artifact) << artifact.error().message << std::endl;
+}
+
+TEST_F(ParserTestEnv, TestParseTopLevelLZMA) {
+	std::fstream fs {tmpdir->Path() + "/test-artifact-lzma.mender"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	auto artifact = mender::artifact::parser::Parse(sr);
+
+	ASSERT_TRUE(artifact) << artifact.error().message << std::endl;
+}
+
+TEST_F(ParserTestEnv, TestParseTopLevelZstd) {
+	std::fstream fs {tmpdir->Path() + "/test-artifact-zstd.mender"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	auto artifact = mender::artifact::parser::Parse(sr);
+
+	ASSERT_TRUE(artifact) << artifact.error().message << std::endl;
+}
+
+TEST(ParserTest, TestParseMumboJumbo) {
+	std::stringstream ss {"foobar"};
+
+	mender::common::io::StreamReader sr {ss};
+
+	auto artifact = mender::artifact::parser::Parse(sr);
+
+	ASSERT_FALSE(artifact) << artifact.error().message << std::endl;
+	ASSERT_EQ(artifact.error().message, "Got unexpected token : 'Unrecognized' expected 'version'");
+}

--- a/artifact/token.hpp
+++ b/artifact/token.hpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_TOKEN_HPP
+#define MENDER_ARTIFACT_TOKEN_HPP
+
+#include <unordered_map>
+#include <string>
+
+#include <common/log.hpp>
+#include <common/expected.hpp>
+
+namespace mender {
+namespace artifact {
+namespace token {
+
+using namespace std;
+
+namespace tar = mender::tar;
+
+namespace log = mender::common::log;
+namespace error = mender::common::error;
+namespace expected = mender::common::expected;
+
+enum class Type {
+	Uninitialized = 0,
+	Unrecognized,
+	Version,
+	Manifest,
+	ManifestSignature,
+	ManifestAugment,
+	Header,
+	HeaderAugment,
+	Payload,
+};
+
+const unordered_map<const Type, const string> type_map {
+	{Type::Uninitialized, "Uninitialized"},
+	{Type::Unrecognized, "Unrecognized"},
+	{Type::Version, "version"},
+	{Type::Manifest, "manifest"},
+	{Type::ManifestAugment, "manifest-augment"},
+	{Type::ManifestSignature, "manifest.sig"},
+	{Type::Header, "header"},
+	{Type::HeaderAugment, "header-augment"},
+	{Type::Payload, "data"},
+};
+
+class Token {
+public:
+	Type type;
+	// Poor mans optional
+	shared_ptr<tar::Entry> value;
+
+public:
+	Token() :
+		type {Type::Uninitialized} {
+	}
+	Token(Type t) :
+		type {t} {
+	}
+	Token(const string &type_name, tar::Entry &entry) :
+		type {StringToType(type_name)},
+		value {make_shared<tar::Entry>(entry)} {
+	}
+
+	const string TypeToString() const {
+		return type_map.at(type);
+	}
+
+private:
+	Type StringToType(const string &type_name) {
+		if (type_name == "version") {
+			return Type::Version;
+		}
+		if (type_name == "manifest") {
+			return Type::Manifest;
+		}
+		if (type_name.find("header.tar") == 0) {
+			return Type::Header;
+		}
+		if (type_name.find("data/0000.tar") == 0) {
+			return Type::Payload;
+		}
+		log::Error("Unrecognized token: " + type_name);
+		return Type::Unrecognized;
+	}
+};
+} // namespace token
+} // namespace artifact
+} // namespace mender
+
+#endif // MENDER_ARTIFACT_TOKEN_HPP


### PR DESCRIPTION
Adds the top-level Artifact parser structure.

Usage:

```
a = artifact::Parse(io::Reader &reader)
a.version
a.x
.
.
.
payload = a.Next()
```

Ticket: MEN-6200
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>