### PR TITLE
feat(vendor): Add an optional library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendor/expected"]
 	path = vendor/expected
 	url = https://github.com/TartanLlama/expected.git
+[submodule "vendor/optional-lite"]
+	path = vendor/optional-lite
+	url = https://github.com/martinmoene/optional-lite.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ endif()
 add_subdirectory(vendor/expected)
 include_directories(${CMAKE_SOURCE_DIR}/vendor/expected/include)
 
+add_subdirectory(vendor/optional-lite)
+include_directories(${CMAKE_SOURCE_DIR}/vendor/optional-lite/include)
+
 if (${PLATFORM} STREQUAL linux_x86)
   set(MENDER_USE_BOOST_BEAST 1)
 else()

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -11,3 +11,6 @@
 #
 # CC0 1.0 Universal
 a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499  vendor/expected/COPYING
+#
+# Boost Software License
+c9bff75738922193e67fa726fa225535870d2aa1059f91452c411736284ad566  vendor/optional-lite/LICENSE.txt


### PR DESCRIPTION
This adds an optional library to vendor. The library is fully compatible with C++17's optional implementation, when built under C++11, which should suit us well.

Added a simple example to the auth binary, to examplify it's use.

Ticket: None
Changelog: None
