### PR TITLE
feat: Basic DB keys and vacuuming

### DIFF
--- a/common/context.hpp
+++ b/common/context.hpp
@@ -15,6 +15,8 @@
 #ifndef MENDER_COMMON_CONTEXT_HPP
 #define MENDER_COMMON_CONTEXT_HPP
 
+#include <string>
+
 #include <common/conf.hpp>
 #include <common/error.hpp>
 #include <common/key_value_database.hpp>
@@ -33,10 +35,55 @@ namespace conf = mender::common::conf;
 namespace error = mender::common::error;
 namespace kv_db = mender::common::key_value_database;
 
+using namespace std;
+
 class MenderContext {
 public:
 	error::Error Initialize(const conf::MenderConfig &config);
 	kv_db::KeyValueDatabase &GetMenderStoreDB();
+
+	// Name of artifact currently installed. Introduced in Mender 2.0.0.
+	const string ArtifactNameKey {"artifact-name"};
+
+	// Name of the group the currently installed artifact belongs to. For
+	// artifact version >= 3, this is held in the header-info artifact-
+	// provides field
+	const string ArtifactGroupKey {"artifact-group"};
+
+	// Holds the current artifact provides from the type-info header of
+	// artifact version >= 3.
+	// NOTE: These provides are held in a separate key due to the header-
+	// info provides overlap with previous versions of mender artifact.
+	const string ArtifactProvidesKey {"artifact-provides"};
+
+	// The key used by the standalone installer to track artifacts that have
+	// been started, but not committed. We don't want to use the
+	// StateDataKey for this, because it contains a lot less information.
+	const string StandaloneStateKey {"standalone-state"};
+
+	// Name of key that state data is stored under across reboots. Uses the
+	// StateData structure, marshalled to JSON.
+	const string StateDataKey {"state"};
+
+	// Added together with update modules in v2.0.0. This key is invoked if,
+	// and only if, a client loads data using the StateDataKey, and
+	// discovers that it is a different version than what it currently
+	// supports. In that case it switches to using the
+	// StateDataKeyUncommitted until the commit stage, where it switches
+	// back to StateDataKey. This is intended to ensure that upgrading the
+	// client to a new database schema doesn't overwrite the existing
+	// schema, in case it is rolled back and the old client needs the
+	// original schema again.
+	const string StateDataKeyUncommitted {"state-uncommitted"};
+
+	// Added in Mender v2.7.0. Updated every time a control map is updated
+	// in memory.
+	const string UpdateControlMaps {"update-control-maps"};
+
+	// ---------------------- NOT IN USE ANYMORE --------------------------
+	// Key used to store the auth token.
+	const string AuthTokenName {"authtoken"};
+	const string AuthTokenCacheInvalidatorName {"auth-token-cache-invalidator"};
 
 private:
 #if MENDER_USE_LMDB

--- a/common/context/context.cpp
+++ b/common/context/context.cpp
@@ -28,7 +28,22 @@ namespace error = mender::common::error;
 error::Error MenderContext::Initialize(const conf::MenderConfig &config) {
 #if MENDER_USE_LMDB
 	auto err = mender_store_.Open(conf::paths::Join(config.data_store_dir, "mender-store"));
-	return err;
+	if (err) {
+		return err;
+	}
+	err = mender_store_.Remove(AuthTokenName);
+	if (err) {
+		// key not existing in the DB is not treated as an error so this must be
+		// a real error
+		return err;
+	}
+	err = mender_store_.Remove(AuthTokenCacheInvalidatorName);
+	if (err) {
+		// same as above -- a real error
+		return err;
+	}
+
+	return error::NoError;
 #else
 	return error::NoError;
 #endif


### PR DESCRIPTION
Adding basic set of DB keys as constants into the MenderContext class and cleanup of unused keys from the DB as part of MenderContext::Initialize().

Ticket: MEN-6308
Changelog: none
