### PR TITLE
feat: Introduce Json::GetChildren()

### DIFF
--- a/common/json.hpp
+++ b/common/json.hpp
@@ -18,6 +18,7 @@
 #include <config.h>
 
 #include <string>
+#include <map>
 
 #include <common/error.hpp>
 #include <common/expected.hpp>
@@ -59,6 +60,8 @@ using ExpectedSize = mender::common::expected::ExpectedSize;
 class Json {
 public:
 	using ExpectedJson = expected::expected<Json, error::Error>;
+	using ChildrenMap = map<string, Json>;
+	using ExpectedChildrenMap = expected::expected<ChildrenMap, error::Error>;
 
 	Json() = default;
 
@@ -78,6 +81,8 @@ public:
 	ExpectedJson operator[](const size_t idx) const {
 		return this->Get(idx);
 	}
+
+	ExpectedChildrenMap GetChildren() const;
 
 	bool IsObject() const;
 	bool IsArray() const;
@@ -104,6 +109,8 @@ private:
 };
 
 using ExpectedJson = expected::expected<Json, error::Error>;
+using ChildrenMap = map<string, Json>;
+using ExpectedChildrenMap = expected::expected<ChildrenMap, error::Error>;
 
 ExpectedJson LoadFromFile(string file_path);
 ExpectedJson LoadFromString(string json_str);

--- a/common/json/platform/nlohmann/nlohmann_json.cpp
+++ b/common/json/platform/nlohmann/nlohmann_json.cpp
@@ -15,7 +15,9 @@
 #include <common/json.hpp>
 
 #include <fstream>
+#include <map>
 #include <string>
+
 #include <nlohmann/json.hpp>
 
 using njson = nlohmann::json;
@@ -98,6 +100,19 @@ ExpectedJson Json::Get(const size_t idx) const {
 
 	njson n_json = this->n_json[idx];
 	return Json(n_json);
+}
+
+ExpectedChildrenMap Json::GetChildren() const {
+	if (!this->IsObject()) {
+		auto err = MakeError(JsonErrorCode::TypeError, "Invalid JSON type to get children from");
+		return expected::unexpected(err);
+	}
+
+	ChildrenMap ret {};
+	for (const auto &item : this->n_json.items()) {
+		ret[item.key()] = Json(item.value());
+	}
+	return ExpectedChildrenMap(ret);
 }
 
 bool Json::IsObject() const {

--- a/common/json_test.cpp
+++ b/common/json_test.cpp
@@ -277,3 +277,27 @@ TEST(JsonDataTests, GetDataValues) {
 	EXPECT_EQ(esize.error().code, json::MakeError(json::JsonErrorCode::TypeError, "").code);
 	EXPECT_EQ(esize.error().message, "Not a JSON array");
 }
+
+TEST(JsonDataTests, GetChildren) {
+	json::ExpectedJson ej = json::LoadFromString(json_example_str);
+	ASSERT_TRUE(ej);
+
+	json::Json j = ej.value();
+	ASSERT_TRUE(j.IsObject());
+
+	json::ExpectedChildrenMap e_map = j.GetChildren();
+	ASSERT_TRUE(e_map);
+
+	json::ChildrenMap ch_map = e_map.value();
+	EXPECT_EQ(ch_map.size(), 7);
+	EXPECT_EQ(ch_map["string"].GetString().value_or(""), "string value");
+
+	j = ch_map["child"];
+	EXPECT_TRUE(j.IsObject());
+
+	e_map = j.GetChildren();
+	ASSERT_TRUE(e_map);
+
+	ch_map = e_map.value();
+	EXPECT_EQ(ch_map.size(), 1);
+}


### PR DESCRIPTION
An elementary function allowing iteration over JSON object's children, other functions can be easily built on top of this one.

Ticket: none
Changelog: none