### PR TITLE
Header parser impl

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(sha)
 add_subdirectory(tar)
 add_subdirectory(v3/version)
 add_subdirectory(v3/manifest)
+add_subdirectory(v3/header)
 add_subdirectory(v3/payload)
 
 set(parser_sources
@@ -10,6 +11,9 @@ set(parser_sources
   error.cpp
   v3/version/version.cpp
   v3/manifest/manifest.cpp
+  v3/header/header.cpp
+  v3/header/header_info.cpp
+  v3/header/type_info.cpp
   v3/payload/payload.cpp
 )
 
@@ -27,6 +31,8 @@ target_link_libraries(artifact_parser_test PRIVATE
   common_testing
   common_io
   common_processes
+  sha
+  common_conf
 )
 target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR}/artifact)

--- a/artifact/config.hpp
+++ b/artifact/config.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_CONFIG_HPP
+#define MENDER_ARTIFACT_CONFIG_HPP
+
+#include <string>
+
+namespace mender {
+namespace artifact {
+namespace parser {
+namespace config {
+
+using namespace std;
+
+struct ParserConfig {
+	string artifact_scripts_filesystem_path {};
+};
+
+} // namespace config
+} // namespace parser
+} // namespace artifact
+} // namespace mender
+
+#endif // MENDER_ARTIFACT_CONFIG_HPP

--- a/artifact/lexer.hpp
+++ b/artifact/lexer.hpp
@@ -27,8 +27,6 @@
 
 #include <artifact/sha/sha.hpp>
 
-#include <artifact/token.hpp>
-
 
 namespace mender {
 namespace artifact {
@@ -38,27 +36,28 @@ using namespace std;
 
 namespace log = mender::common::log;
 
+template <typename Token, typename Type>
 class Lexer {
 private:
 	std::shared_ptr<mender::tar::Reader> tar_reader_;
 
 public:
-	token::Token current;
+	Token current;
 
 	Lexer(std::shared_ptr<mender::tar::Reader> tr) :
 		tar_reader_ {tr},
 		current {} {
 	}
 
-	token::Token &Next() {
+	Token &Next() {
 		auto entry = tar_reader_->Next();
 		if (!entry) {
-			log::Error("Error reading the next tar entry: " + entry.error().message);
-			this->current = token::Token {token::Type::Unrecognized};
+			log::Trace("Error reading the next tar entry: " + entry.error().message);
+			this->current = Token {Type::EOFToken};
 			return this->current;
 		}
 		log::Trace("Entry name: " + entry.value().Name());
-		this->current = token::Token {entry.value().Name(), entry.value()};
+		this->current = Token {entry.value().Name(), entry.value()};
 		return current;
 	}
 };

--- a/artifact/parser.cpp
+++ b/artifact/parser.cpp
@@ -60,7 +60,7 @@ namespace payload = mender::artifact::v3::payload;
 ExpectedArtifact Parse(io::Reader &reader) {
 	std::shared_ptr<tar::Reader> tar_reader {make_shared<tar::Reader>(reader)};
 
-	lexer::Lexer lexer = lexer::Lexer {tar_reader};
+	auto lexer = lexer::Lexer<token::Token, token::Type> {tar_reader};
 
 	token::Token tok = lexer.Next();
 

--- a/artifact/parser.hpp
+++ b/artifact/parser.hpp
@@ -28,27 +28,14 @@
 
 #include <artifact/v3/version/version.hpp>
 #include <artifact/v3/manifest/manifest.hpp>
+#include <artifact/v3/header/header.hpp>
 #include <artifact/v3/payload/payload.hpp>
 
 #include <artifact/lexer.hpp>
 #include <artifact/token.hpp>
+#include <artifact/config.hpp>
 
 #include <artifact/error.hpp>
-
-
-namespace mender {
-namespace artifact {
-namespace v3 {
-
-namespace header {
-struct Header {};
-} // namespace header
-namespace payload {} // namespace payload
-
-} // namespace v3
-} // namespace artifact
-} // namespace mender
-
 
 namespace mender {
 namespace artifact {
@@ -82,20 +69,25 @@ public:
 	Version version;
 	Manifest manifest;
 	// manifest::sig::ManifestSignature manifest_sig {}; // Unused
-	Header header {}; // Unused
+	Header header;
 
 	ExpectedPayloadReader Next();
 
-	Artifact(Version &version, Manifest &manifest, lexer::Lexer<token::Token, token::Type> lexer) :
+	Artifact(
+		Version &version,
+		Manifest &manifest,
+		Header &header,
+		lexer::Lexer<token::Token, token::Type> lexer) :
 		lexer_ {lexer},
 		version {version},
-		manifest {manifest} {
+		manifest {manifest},
+		header {header} {
 	}
 };
 
 using ExpectedArtifact = expected::expected<Artifact, error::Error>;
 
-ExpectedArtifact Parse(io::Reader &reader);
+ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig conf = {});
 
 } // namespace parser
 } // namespace artifact

--- a/artifact/parser.hpp
+++ b/artifact/parser.hpp
@@ -31,6 +31,7 @@
 #include <artifact/v3/payload/payload.hpp>
 
 #include <artifact/lexer.hpp>
+#include <artifact/token.hpp>
 
 #include <artifact/error.hpp>
 
@@ -74,7 +75,7 @@ using ExpectedPayloadReader = expected::expected<payload::Reader, error::Error>;
 // Structure to hold the contents of a Mender artifact file.
 class Artifact {
 private:
-	lexer::Lexer lexer_;
+	lexer::Lexer<token::Token, token::Type> lexer_;
 	unsigned int payload_index_ {0};
 
 public:
@@ -85,7 +86,7 @@ public:
 
 	ExpectedPayloadReader Next();
 
-	Artifact(Version &version, Manifest &manifest, lexer::Lexer lexer) :
+	Artifact(Version &version, Manifest &manifest, lexer::Lexer<token::Token, token::Type> lexer) :
 		lexer_ {lexer},
 		version {version},
 		manifest {manifest} {

--- a/artifact/parser_test.cpp
+++ b/artifact/parser_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <common/log.hpp>
 #include <common/processes.hpp>
 
 #include <common/testing.hpp>
@@ -39,6 +40,8 @@ class ParserTestEnv : public testing::Test {
 public:
 protected:
 	static void SetUpTestSuite() {
+		mender::common::log::SetLevel(mender::common::log::LogLevel::Trace);
+
 		string script = R"(#! /bin/sh
 
     DIRNAME=$(dirname $0)

--- a/artifact/parser_test.cpp
+++ b/artifact/parser_test.cpp
@@ -134,5 +134,5 @@ TEST(ParserTest, TestParseMumboJumbo) {
 	auto artifact = mender::artifact::parser::Parse(sr);
 
 	ASSERT_FALSE(artifact) << artifact.error().message << std::endl;
-	ASSERT_EQ(artifact.error().message, "Got unexpected token : 'Unrecognized' expected 'version'");
+	ASSERT_EQ(artifact.error().message, "Got unexpected token : 'EOF' expected 'version'");
 }

--- a/artifact/parser_test.cpp
+++ b/artifact/parser_test.cpp
@@ -15,15 +15,15 @@
 #include <artifact/parser.hpp>
 #include <artifact/lexer.hpp>
 
+#include <string>
+#include <fstream>
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 #include <common/log.hpp>
 #include <common/processes.hpp>
-
 #include <common/testing.hpp>
-
-#include <fstream>
 
 
 using namespace std;

--- a/artifact/token.hpp
+++ b/artifact/token.hpp
@@ -39,6 +39,7 @@ namespace expected = mender::common::expected;
 
 enum class Type {
 	Uninitialized = 0,
+	EOFToken,
 	Unrecognized,
 	Version,
 	Manifest,
@@ -51,6 +52,7 @@ enum class Type {
 
 const unordered_map<const Type, const string> type_map {
 	{Type::Uninitialized, "Uninitialized"},
+	{Type::EOFToken, "EOF"},
 	{Type::Unrecognized, "Unrecognized"},
 	{Type::Version, "version"},
 	{Type::Manifest, "manifest"},

--- a/artifact/token.hpp
+++ b/artifact/token.hpp
@@ -17,6 +17,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <regex>
 
 #include <common/log.hpp>
 #include <common/expected.hpp>
@@ -24,6 +25,9 @@
 namespace mender {
 namespace artifact {
 namespace token {
+
+const std::regex payload_regexp {
+	"data/[0-9]{4}\\.tar(\\.(gz|xz|zst))?", std::regex_constants::ECMAScript};
 
 using namespace std;
 
@@ -90,7 +94,7 @@ private:
 		if (type_name.find("header.tar") == 0) {
 			return Type::Header;
 		}
-		if (type_name.find("data/0000.tar") == 0) {
+		if (regex_match(type_name, payload_regexp)) {
 			return Type::Payload;
 		}
 		log::Error("Unrecognized token: " + type_name);

--- a/artifact/v3/header/CMakeLists.txt
+++ b/artifact/v3/header/CMakeLists.txt
@@ -1,0 +1,27 @@
+
+# Test the parser
+add_executable(artifact_header_parser_test EXCLUDE_FROM_ALL
+  header.cpp
+  header_info.cpp
+  type_info.cpp
+  ${CMAKE_SOURCE_DIR}/artifact/error.cpp
+  header_test.cpp
+)
+target_link_libraries(artifact_header_parser_test PRIVATE
+  common_log
+  common_io
+  common_error
+  common_tar
+  common_json
+  common_testing
+  common_processes
+  common_conf
+  GTest::gtest_main
+  gmock
+)
+target_include_directories(artifact_header_parser_test PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+)
+gtest_discover_tests(artifact_header_parser_test)
+add_dependencies(check artifact_header_parser_test)

--- a/artifact/v3/header/header.cpp
+++ b/artifact/v3/header/header.cpp
@@ -1,0 +1,191 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/header/header.hpp>
+
+#include <iomanip>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/json.hpp>
+#include <common/common.hpp>
+#include <common/conf/paths.hpp>
+
+#include <artifact/error.hpp>
+#include <artifact/lexer.hpp>
+#include <artifact/tar/tar.hpp>
+
+#include <artifact/v3/header/token.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+
+using namespace std;
+
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+namespace log = mender::common::log;
+namespace json = mender::common::json;
+
+
+namespace {
+string IndexString(int index) {
+	stringstream index_string {};
+	index_string << setw(4) << setfill('0') << index;
+	return index_string.str();
+}
+} // namespace
+
+ExpectedHeader Parse(io::Reader &reader, ParserConfig conf) {
+	Header header {};
+
+	shared_ptr<tar::Reader> tar_reader {make_shared<tar::Reader>(reader)};
+
+	auto lexer = lexer::Lexer<header::token::Token, header::token::Type> {tar_reader};
+
+	token::Token tok = lexer.Next();
+
+	if (tok.type != token::Type::HeaderInfo) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Got unexpected token: '" + tok.TypeToString() + "' expected 'header-info'"));
+	}
+
+	auto expected_info = header::info::Parse(*tok.value);
+
+	if (!expected_info) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info: " + expected_info.error().message));
+	}
+	header.info = expected_info.value();
+
+	tok = lexer.Next();
+	vector<ArtifactScript> state_scripts {};
+	while (tok.type == token::Type::ArtifactScripts) {
+		log::Trace("Parsing state script...");
+		const string artifact_script_path =
+			mender::common::conf::paths::Join(conf.artifact_scripts_filesystem_path, tok.name);
+		errno = 0;
+		ofstream myfile(artifact_script_path);
+		log::Trace("state script name: " + tok.name);
+		if (!myfile.good()) {
+			auto io_errno = errno;
+			return expected::unexpected(error::Error(
+				std::generic_category().default_error_condition(io_errno),
+				"Failed to create a file for writing the Artifact script: " + artifact_script_path
+					+ " to the filesystem"));
+		}
+		io::StreamWriter sw {myfile};
+
+		auto err = io::Copy(sw, *tok.value);
+		if (err != error::NoError) {
+			return expected::unexpected(err);
+		}
+
+		state_scripts.push_back(artifact_script_path);
+
+		tok = lexer.Next();
+	}
+
+	header.artifactScripts = move(state_scripts);
+
+	vector<SubHeader> subheaders {};
+
+	int current_index {0};
+	while (tok.type != token::Type::EOFToken) {
+		log::Trace("Parsing the sub-header ...");
+
+		// NOTE: We currently do not support multiple payloads
+		if (current_index != 0) {
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::ParseError,
+				"Multiple header entries found. Currently only one is supported"));
+		}
+
+		SubHeader sub_header {};
+		if (tok.type != token::Type::ArtifactHeaderTypeInfo) {
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::ParseError,
+				"Unexpected entry: " + tok.TypeToString() + " expected: type-info"));
+		}
+
+		if (current_index != tok.Index()) {
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::ParseError,
+				"Unexpected index order for the type-info: " + tok.name + " expected: headers/"
+					+ IndexString(current_index) + "/type-info"));
+		}
+		auto expected_type_info = type_info::Parse(*tok.value);
+		if (!expected_type_info) {
+			return expected::unexpected(expected_type_info.error());
+		}
+		sub_header.type_info = expected_type_info.value();
+
+		// NOTE (workaround): Bug in the Artifact format writer:
+		// If the type is a RootfsImage, then the payload-type will be empty. This
+		// is a bug in the mender-artifact tool, which writes the payload. For now,
+		// just work around it.
+		if (header.info.payloads[current_index].type == Payload::RootfsImage) {
+			log::Debug(
+				"Setting the type-info in payload nr " + to_string(current_index)
+				+ " to rootfs-image");
+			sub_header.type_info.type = "rootfs-image";
+		}
+
+		tok = lexer.Next();
+
+		log::Trace("sub-header: looking for meta-data");
+
+		// meta-data (optional)
+		if (tok.type == token::Type::ArtifactHeaderMetaData) {
+			if (current_index != tok.Index()) {
+				return expected::unexpected(parser_error::MakeError(
+					parser_error::Code::ParseError,
+					"Unexpected index order for the meta-data: " + tok.name + " expected: headers/"
+						+ IndexString(current_index) + "/meta-data"));
+			}
+			// auto expected_meta_data = meta_data::Parse(*tok.value);
+			// if (!expected_meta_data) {
+			// TODO - follow-up (MEN-6424)
+			// return expected::unexpected(expected_meta_data.error());
+			// sub_header.metadata = expected_meta_data.value();
+			// }
+			tok = lexer.Next();
+		}
+		log::Trace("sub-header: parsed the meta-data");
+
+		header.subHeaders.push_back(sub_header);
+
+		current_index++;
+	}
+
+	return header;
+}
+
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/artifact/v3/header/header.hpp
+++ b/artifact/v3/header/header.hpp
@@ -1,0 +1,176 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_V3_HEADER_PARSER_HPP
+#define MENDER_ARTIFACT_V3_HEADER_PARSER_HPP
+
+#include <string>
+#include <utility>
+#include <vector>
+#include <unordered_map>
+
+#include <common/optional.hpp>
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+
+#include <artifact/config.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+
+using namespace std;
+
+
+namespace optional = mender::common::optional;
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+
+//
+// +---header-info
+//
+
+enum class Payload {
+	RootfsImage,
+	ModuleImage,
+	EmptyPayload,
+};
+
+struct PayloadType {
+	Payload type;
+	string name;
+};
+
+struct Provides {
+	string artifact_name;
+	optional::optional<string> artifact_group;
+};
+
+struct Depends {
+	vector<string> device_type;
+	optional::optional<vector<string>> artifact_name;
+	optional::optional<vector<string>> artifact_group;
+};
+
+struct Info {
+	vector<PayloadType> payloads;
+	Provides provides;
+	Depends depends;
+};
+
+using ExpectedHeaderInfo = expected::expected<header::Info, error::Error>;
+
+namespace info {
+ExpectedHeaderInfo Parse(io::Reader &reader);
+}
+
+//
+// |    +---scripts
+// |    |    |
+// |    |    +---State_Enter
+// |    |    +---State_Leave
+// |    |    +---State_Error
+// |    |    `---<more scripts>
+//
+
+using ArtifactScript = string;
+
+//
+// |    `---headers
+// |         |
+// |         +---0000
+// |         |    |
+// |         |    +---type-info
+// |         |    |
+// |         |    +---meta-data
+// |         |
+// |         +---0001
+// |         |    |
+// |         |    `---<more headers>
+// |         |
+// |         `---000n ...
+//
+
+struct TypeInfo {
+	string type;
+	optional::optional<unordered_map<string, string>> artifact_provides;
+	optional::optional<unordered_map<string, string>> artifact_depends;
+	optional::optional<vector<string>> clears_artifact_provides;
+};
+
+struct MetaData {};
+
+struct SubHeader {
+	TypeInfo type_info {};
+	optional::optional<MetaData> metadata {};
+};
+
+namespace type_info {
+using ExpectedTypeInfo = expected::expected<TypeInfo, error::Error>;
+
+ExpectedTypeInfo Parse(io::Reader &reader);
+} // namespace type_info
+
+namespace meta_data {
+using ExpectedMetaData = expected::expected<MetaData, error::Error>;
+
+ExpectedMetaData Parse(io::Reader &reader);
+} // namespace meta_data
+
+
+// +---header.tar[.gz|.xz|.zst] (Optionally compressed)
+// |    |
+// |    +---header-info
+// |    |
+// |    +---scripts
+// |    |    |
+// |    |    +---State_Enter
+// |    |    +---State_Leave
+// |    |    +---State_Error
+// |    |    `---<more scripts>
+// |    |
+// |    `---headers
+// |         |
+// |         +---0000
+// |         |    |
+// |         |    +---type-info
+// |         |    |
+// |         |    +---meta-data
+// |         |
+// |         +---0001
+// |         |    |
+// |         |    `---<more headers>
+// |         |
+// |         `---000n ...
+
+struct Header {
+	Info info;
+	optional::optional<vector<ArtifactScript>> artifactScripts;
+	vector<SubHeader> subHeaders {};
+};
+
+using ExpectedHeader = expected::expected<Header, error::Error>;
+
+using ParserConfig = artifact::parser::config::ParserConfig;
+
+ExpectedHeader Parse(io::Reader &reader, ParserConfig conf = {"./"});
+
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+#endif // MENDER_ARTIFACT_V3_HEADER_PARSER_HPP

--- a/artifact/v3/header/header_info.cpp
+++ b/artifact/v3/header/header_info.cpp
@@ -1,0 +1,195 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/header/header.hpp>
+
+#include <vector>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/json.hpp>
+
+#include <artifact/error.hpp>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+namespace info {
+
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+namespace log = mender::common::log;
+namespace json = mender::common::json;
+
+using ExpectedPayloadType = expected::expected<vector<PayloadType>, error::Error>;
+
+ExpectedPayloadType ToPayloadTypes(const json::Json &j) {
+	if (!j.IsArray()) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError, "The JSON object is not an array"));
+	}
+	vector<PayloadType> vector_elements {};
+	size_t vector_size {j.GetArraySize().value()};
+	for (size_t i = 0; i < vector_size; ++i) {
+		auto expected_element =
+			j.Get(i).and_then([](const json::Json &j) { return j.Get("type"); });
+		if (!expected_element) {
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::ParseError,
+				"Failed to get the type from the payload: " + expected_element.error().message));
+		}
+		auto json_element = expected_element.value();
+		if (json_element.IsString()) {
+			string payload_type = json_element.GetString().value();
+			if (payload_type == "") {
+				return expected::unexpected(
+					parser_error::MakeError(parser_error::Code::ParseError, "Empty Payload type"));
+			}
+			Payload type {Payload::RootfsImage};
+			if (payload_type != "rootfs-image") {
+				type = Payload::ModuleImage;
+			}
+			vector_elements.push_back({type, payload_type});
+		} else if (json_element.IsNull()) {
+			vector_elements.push_back({Payload::EmptyPayload, ""});
+		} else {
+			return expected::unexpected(
+				parser_error::MakeError(parser_error::Code::ParseError, "Unexpected payload type"));
+		}
+	}
+	return vector_elements;
+}
+
+ExpectedHeaderInfo Parse(io::Reader &reader) {
+	log::Trace("Parse(header-info)");
+
+	Info info {};
+
+	auto expected_json = json::Load(reader);
+
+	if (!expected_json) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header JSON: " + expected_json.error().message));
+	}
+
+	const auto header_info_json = expected_json.value();
+
+	//
+	// Payloads (required)
+	//
+	log::Trace("Parsing the payloads");
+
+	auto payloads = header_info_json.Get("payloads").and_then(ToPayloadTypes);
+	if (!payloads) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info payloads JSON: " + payloads.error().message));
+	}
+	info.payloads = payloads.value();
+
+	//
+	// provides (required)
+	//
+	log::Trace("Parsing the header-info artifact_provides");
+
+	auto provides = header_info_json.Get("artifact_provides");
+	if (!provides) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info artifact_provides JSON: " + provides.error().message));
+	}
+
+	// provides:artifact_name (required)
+	log::Trace("Parsing the header-info provides:artifact_name");
+	auto artifact_name = provides.value().Get("artifact_name").and_then(json::ToString);
+
+	if (!artifact_name) {
+		return expected::unexpected(
+			parser_error::MakeError(parser_error::Code::ParseError, artifact_name.error().message));
+	}
+	info.provides.artifact_name = artifact_name.value();
+
+	// provides:artifact_group (optional)
+	log::Trace("Parsing the header-info provides:artifact_group (if any)");
+	auto artifact_group = provides.value().Get("artifact_group").and_then(json::ToString);
+	if (!artifact_group && artifact_group.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info artifact_group provides JSON: "
+				+ artifact_group.error().message));
+	}
+	if (artifact_group) {
+		info.provides.artifact_group = artifact_group.value();
+	}
+
+	//
+	// depends (required)
+	//
+	log::Trace("Parsing the header-info depends:artifact_depends (if any)");
+
+	auto depends = header_info_json.Get("artifact_depends");
+	if (!depends) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info artifact_depends JSON: " + depends.error().message));
+	}
+
+	// device_type[string] (required)
+	auto device_type = depends.value().Get("device_type").and_then(json::ToStringVector);
+	if (!device_type) {
+		return expected::unexpected(
+			parser_error::MakeError(parser_error::Code::ParseError, device_type.error().message));
+	}
+	info.depends.device_type = device_type.value();
+
+
+	// depends::artifact_name (optional)
+	auto artifact_name_depends =
+		depends.value().Get("artifact_name").and_then(json::ToStringVector);
+	if (!artifact_name_depends && artifact_name_depends.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info artifact_name depends JSON: "
+				+ artifact_name_depends.error().message));
+	}
+	if (artifact_name_depends) {
+		info.depends.artifact_name = artifact_name_depends.value();
+	}
+
+	// depends::artifact_group (optional)
+	auto artifact_group_depends =
+		depends.value().Get("artifact_group").and_then(json::ToStringVector);
+	if (!artifact_group_depends && artifact_group_depends.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the header-info artifact_group_depends JSON: "
+				+ artifact_group_depends.error().message));
+	}
+	if (artifact_group_depends) {
+		info.depends.artifact_group = artifact_group_depends.value();
+	}
+
+	return info;
+}
+
+} // namespace info
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/artifact/v3/header/header_test.cpp
+++ b/artifact/v3/header/header_test.cpp
@@ -1,0 +1,448 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/header/header.hpp>
+
+#include <string>
+#include <fstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <common/processes.hpp>
+#include <common/testing.hpp>
+#include <common/log.hpp>
+#include <common/conf/paths.hpp>
+
+#include <artifact/tar/tar.hpp>
+
+
+using namespace std;
+
+namespace io = mender::common::io;
+namespace tar = mender::tar;
+namespace processes = mender::common::processes;
+namespace mendertesting = mender::common::testing;
+
+namespace header = mender::artifact::v3::header;
+
+using ExpectedHeader = mender::artifact::v3::header::ExpectedHeader;
+
+class HeaderTestEnv : public testing::Test {
+public:
+protected:
+	static void CreateTestArtifact(
+		mendertesting::TemporaryDirectory &tmpdir,
+		string update_type,
+		vector<string> extra_artifact_args) {
+		string script = R"(#! /bin/sh
+
+DIRNAME=$(dirname $0)
+
+# Create two dummy Artifact scripts
+echo foobar > ${DIRNAME}/ArtifactInstall_Enter_01_test-dummy
+echo foobar > ${DIRNAME}/ArtifactInstall_Enter_02_test-dummy
+
+# Create some dummy meta-data
+echo '{"foo": "bar"}' > ${DIRNAME}/meta-data-file
+
+# Create an Artifact
+echo foobar > ${DIRNAME}/testdata
+mender-artifact write)";
+
+		script += " " + update_type + " ";
+
+		script += R"(\
+    --compression=none    \
+    --device-type header-test-device \
+    -artifact-name header-tester-name \
+    --file ${DIRNAME}/testdata )";
+
+		for (const auto &arg : extra_artifact_args) {
+			script += +" " + arg + " ";
+		}
+		script += R"(--output-path ${DIRNAME}/artifact.mender || exit 1
+
+#Extract the header
+tar xOf ${DIRNAME}/artifact.mender header.tar > ${DIRNAME}/header.tar || exit 2
+
+exit 0)";
+
+		const string script_fname = tmpdir.Path() + "/test-script.sh";
+
+		std::ofstream os(script_fname.c_str(), std::ios::out);
+		os << script;
+		os.close();
+
+		int ret = chmod(script_fname.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+		ASSERT_EQ(ret, 0);
+
+		processes::Process proc({script_fname});
+		auto ex_line_data = proc.GenerateLineData();
+		ASSERT_TRUE(ex_line_data);
+		EXPECT_EQ(proc.GetExitStatus(), 0) << "error message: " + ex_line_data.error().message;
+	}
+
+	static void CreateWrongHeadersFromHeader(
+		mendertesting::TemporaryDirectory &tmpdir, string tar_archive) {
+		string script = R"(#! /bin/sh
+
+set -e
+
+			)";
+		script += "cd " + tmpdir.Path();
+		script += R"(
+#Extract the archive
+					  tar xvf )"
+				  + mender::common::conf::paths::Join(tmpdir.Path(), tar_archive);
+
+		script += R"(
+
+# Create an archive with files out of order
+tar cvf wrong-file-order.tar headers/0000/type-info header-info
+
+tar tvf wrong-file-order.tar >&2
+
+#Change the indexes
+mkdir headers/0001
+mv headers/0000/type-info  headers/0001/type-info
+mv headers/0000/meta-data  headers/0001/meta-data 2>/dev/null || true
+
+# Recreate the archive
+tar cvf wrong-index.tar header-info headers/0001/type-info $(stat headers/0001/meta-data 2>/dev/null && echo headers/0001/meta-data)
+
+
+exit 0)";
+
+		const string script_fname = tmpdir.Path() + "/create-wrong-script.sh";
+
+		std::ofstream os(script_fname.c_str(), std::ios::out);
+		os << script;
+		os.close();
+
+		int ret = chmod(script_fname.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+		ASSERT_EQ(ret, 0);
+
+		processes::Process proc({script_fname});
+		auto ex_line_data = proc.GenerateLineData();
+		ASSERT_TRUE(ex_line_data);
+		EXPECT_EQ(proc.GetExitStatus(), 0) << "error message: " + ex_line_data.error().message;
+	}
+};
+
+TEST_F(HeaderTestEnv, TestHeaderRootfsAllFlagsSetSuccess) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(
+		tmpdir,
+		"rootfs-image",
+		{{R"(--script ${DIRNAME}/ArtifactInstall_Enter_01_test-dummy)"},
+		 {R"(--script ${DIRNAME}/ArtifactInstall_Enter_02_test-dummy)"},
+		 {"--provides-group test-artifact-group1"},
+		 {"--artifact-name-depends header-test-artifact-name-depends"},
+		 {"--depends-groups header-artifact-depends-group"},
+		 {"--depends foo:bar"}});
+
+
+	std::fstream fs {tmpdir.Path() + "/header.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header =
+		header::Parse(sr, mender::artifact::parser::config::ParserConfig {tmpdir.Path()});
+
+	ASSERT_TRUE(expected_header) << expected_header.error().message;
+
+	auto header = expected_header.value();
+
+	//
+	// Header-info
+	//
+
+	EXPECT_EQ(header.info.payloads.size(), 1);
+	EXPECT_EQ(header.info.payloads.at(0).type, header::Payload::RootfsImage);
+	EXPECT_EQ(header.info.provides.artifact_name, "header-tester-name");
+	EXPECT_EQ(header.info.depends.device_type.at(0), "header-test-device");
+
+	// Optional provides (artifact_group)
+	ASSERT_TRUE(header.info.provides.artifact_group);
+	EXPECT_EQ(header.info.provides.artifact_group, "test-artifact-group1");
+
+	// depends
+
+	// device-type
+	ASSERT_EQ(header.info.depends.device_type.size(), 1);
+	EXPECT_EQ(header.info.depends.device_type.at(0), "header-test-device");
+
+	// depends:artifact-name (optional)
+	ASSERT_TRUE(header.info.depends.artifact_name);
+	ASSERT_EQ(header.info.depends.artifact_name.value().size(), 1);
+	EXPECT_EQ(header.info.depends.artifact_name.value().at(0), "header-test-artifact-name-depends");
+
+	// depends:artifact-groups (optional)
+	ASSERT_TRUE(header.info.depends.artifact_group);
+	ASSERT_EQ(header.info.depends.artifact_group.value().size(), 1);
+	EXPECT_EQ(header.info.depends.artifact_group.value().at(0), "header-artifact-depends-group");
+
+	//
+	// Artifact Scripts
+	//
+	ASSERT_TRUE(header.artifactScripts);
+	EXPECT_EQ(header.artifactScripts.value().size(), 2);
+	EXPECT_THAT(
+		header.artifactScripts.value().at(0),
+		testing::AnyOf(
+			testing::EndsWith("ArtifactInstall_Enter_01_test-dummy"),
+			testing::EndsWith("ArtifactInstall_Enter_02_test-dummy")));
+	EXPECT_THAT(
+		header.artifactScripts.value().at(1),
+		testing::AnyOf(
+			testing::EndsWith("ArtifactInstall_Enter_01_test-dummy"),
+			testing::EndsWith("ArtifactInstall_Enter_02_test-dummy")));
+
+
+	//
+	// Sub-headers
+	//
+	EXPECT_EQ(header.subHeaders.size(), 1);
+
+	//
+	// type-info
+	//
+
+	EXPECT_EQ(header.subHeaders.at(0).type_info.type, "rootfs-image");
+
+	// type_info/0000/artifact_provides
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.artifact_provides);
+	EXPECT_EQ(
+		header.subHeaders.at(0).type_info.artifact_provides.value()["rootfs-image.checksum"],
+		"aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f");
+
+	// type_info/0000/artifact_depends
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.artifact_depends);
+	EXPECT_EQ(header.subHeaders.at(0).type_info.artifact_depends.value()["foo"], "bar");
+
+	// type_info/0000/clears_artifact_provides
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.clears_artifact_provides);
+	EXPECT_EQ(
+		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(0), "artifact_group");
+	EXPECT_EQ(
+		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(1),
+		"rootfs_image_checksum");
+	EXPECT_EQ(
+		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(2), "rootfs-image.*");
+
+	// meta-data
+}
+
+TEST_F(HeaderTestEnv, TestHeaderModuleImageAllFlagsSetSuccess) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(
+		tmpdir,
+		"module-image",
+		{{"--type dummy-update-module"},
+		 {R"(--script ${DIRNAME}/ArtifactInstall_Enter_01_test-dummy)"},
+		 {R"(--script ${DIRNAME}/ArtifactInstall_Enter_02_test-dummy)"},
+		 {"--provides-group test-artifact-group1"},
+		 {"--artifact-name-depends header-test-artifact-name-depends"},
+		 {R"(--meta-data ${DIRNAME}/meta-data-file)"},
+		 {"--depends-groups header-artifact-depends-group"},
+		 {"--depends foo:bar"}});
+
+
+	std::fstream fs {tmpdir.Path() + "/header.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header =
+		header::Parse(sr, mender::artifact::parser::config::ParserConfig {tmpdir.Path()});
+
+	ASSERT_TRUE(expected_header) << expected_header.error().message;
+
+	auto header = expected_header.value();
+
+	//
+	// Header-info
+	//
+
+	EXPECT_EQ(header.info.payloads.size(), 1);
+	EXPECT_EQ(header.info.payloads.at(0).type, header::Payload::ModuleImage);
+	EXPECT_EQ(header.info.payloads.at(0).name, "dummy-update-module");
+	EXPECT_EQ(header.info.provides.artifact_name, "header-tester-name");
+	EXPECT_EQ(header.info.depends.device_type.at(0), "header-test-device");
+
+	// Optional provides (artifact_group)
+	ASSERT_TRUE(header.info.provides.artifact_group);
+	EXPECT_EQ(header.info.provides.artifact_group, "test-artifact-group1");
+
+	// depends
+
+	// device-type
+	ASSERT_EQ(header.info.depends.device_type.size(), 1);
+	EXPECT_EQ(header.info.depends.device_type.at(0), "header-test-device");
+
+	// depends:artifact-name (optional)
+	ASSERT_TRUE(header.info.depends.artifact_name);
+	ASSERT_EQ(header.info.depends.artifact_name.value().size(), 1);
+	EXPECT_EQ(header.info.depends.artifact_name.value().at(0), "header-test-artifact-name-depends");
+
+	// depends:artifact-groups (optional)
+	ASSERT_TRUE(header.info.depends.artifact_group);
+	ASSERT_EQ(header.info.depends.artifact_group.value().size(), 1);
+	EXPECT_EQ(header.info.depends.artifact_group.value().at(0), "header-artifact-depends-group");
+
+	//
+	// Artifact Scripts
+	//
+	ASSERT_TRUE(header.artifactScripts);
+	EXPECT_EQ(header.artifactScripts.value().size(), 2);
+	EXPECT_THAT(
+		header.artifactScripts.value().at(0),
+		testing::AnyOf(
+			testing::EndsWith("ArtifactInstall_Enter_01_test-dummy"),
+			testing::EndsWith("ArtifactInstall_Enter_02_test-dummy")));
+	EXPECT_THAT(
+		header.artifactScripts.value().at(1),
+		testing::AnyOf(
+			testing::EndsWith("ArtifactInstall_Enter_01_test-dummy"),
+			testing::EndsWith("ArtifactInstall_Enter_02_test-dummy")));
+
+	//
+	// Sub-headers
+	//
+	EXPECT_EQ(header.subHeaders.size(), 1);
+
+	//
+	// type-info
+	//
+
+	EXPECT_EQ(header.subHeaders.at(0).type_info.type, "dummy-update-module");
+
+	// type_info/0000/artifact_provides
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.artifact_provides);
+	EXPECT_EQ(
+		header.subHeaders.at(0)
+			.type_info.artifact_provides.value()["rootfs-image.dummy-update-module.version"],
+		"header-tester-name");
+
+	// type_info/0000/artifact_depends
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.artifact_depends);
+	EXPECT_EQ(header.subHeaders.at(0).type_info.artifact_depends.value()["foo"], "bar");
+
+	// type_info/0000/clears_artifact_provides
+	EXPECT_TRUE(header.subHeaders.at(0).type_info.clears_artifact_provides);
+	EXPECT_EQ(
+		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(0),
+		"rootfs-image.dummy-update-module.*");
+
+	// meta-data
+}
+
+
+TEST_F(HeaderTestEnv, TestTwoArtifactScriptsSuccess) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(
+		tmpdir,
+		"rootfs-image",
+		{
+			{R"(--script ${DIRNAME}/ArtifactInstall_Enter_01_test-dummy)"},
+			{R"(--script ${DIRNAME}/ArtifactInstall_Enter_02_test-dummy)"},
+		});
+
+
+	std::fstream fs {tmpdir.Path() + "/header.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header = header::Parse(sr);
+
+	ASSERT_TRUE(expected_header) << expected_header.error().message;
+
+	auto header = expected_header.value();
+
+	ASSERT_TRUE(header.artifactScripts);
+	EXPECT_EQ(header.artifactScripts.value().size(), 2);
+}
+
+TEST_F(HeaderTestEnv, TestOneArtifactScripts) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(
+		tmpdir,
+		"rootfs-image",
+		{
+			{R"(--script ${DIRNAME}/ArtifactInstall_Enter_01_test-dummy)"},
+		});
+
+	std::fstream fs {tmpdir.Path() + "/header.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header = header::Parse(sr);
+
+	ASSERT_TRUE(expected_header) << expected_header.error().message;
+
+	auto header = expected_header.value();
+
+	ASSERT_TRUE(header.artifactScripts);
+	EXPECT_EQ(header.artifactScripts.value().size(), 1);
+}
+
+TEST_F(HeaderTestEnv, TestHeaderNoExtraData) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(tmpdir, "module-image", {"--type test-module-image"});
+
+	std::fstream fs {tmpdir.Path() + "/header.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header = header::Parse(sr);
+
+	ASSERT_TRUE(expected_header) << expected_header.error().message;
+}
+
+TEST_F(HeaderTestEnv, TestHeaderIndexError) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(tmpdir, "module-image", {"--type test-module-image"});
+
+	CreateWrongHeadersFromHeader(tmpdir, "header.tar");
+
+	std::fstream fs {tmpdir.Path() + "/wrong-index.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header = header::Parse(sr);
+
+	ASSERT_FALSE(expected_header);
+	EXPECT_EQ(
+		expected_header.error().message,
+		"Unexpected index order for the type-info: headers/0001/type-info expected: headers/0000/type-info");
+}
+
+TEST_F(HeaderTestEnv, TestHeaderFilesOutOfOrder) {
+	mendertesting::TemporaryDirectory tmpdir {};
+	CreateTestArtifact(tmpdir, "module-image", {"--type test-module-image"});
+
+	CreateWrongHeadersFromHeader(tmpdir, "header.tar");
+
+	std::fstream fs {tmpdir.Path() + "/wrong-file-order.tar"};
+
+	mender::common::io::StreamReader sr {fs};
+
+	ExpectedHeader expected_header = header::Parse(sr);
+
+	ASSERT_FALSE(expected_header);
+	EXPECT_EQ(
+		expected_header.error().message,
+		"Got unexpected token: 'type-info' expected 'header-info'");
+}

--- a/artifact/v3/header/token.hpp
+++ b/artifact/v3/header/token.hpp
@@ -1,0 +1,136 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_V3_HEADER_TOKEN_HPP
+#define MENDER_ARTIFACT_V3_HEADER_TOKEN_HPP
+
+
+#include <unordered_map>
+#include <string>
+#include <regex>
+#include <memory>
+
+#include <common/log.hpp>
+#include <common/expected.hpp>
+
+const std::regex artifact_script_regexp {
+	"scripts/Artifact(Install|Reboot|Rollback|RollbackReboot|Failure)_(Enter|Leave)_[0-9][0-9](_\\S+)?",
+	std::regex_constants::ECMAScript};
+
+const int artifact_headers_index_position {8};
+const int artifact_headers_index_length {4};
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+namespace token {
+
+using namespace std;
+
+namespace tar = mender::tar;
+
+namespace log = mender::common::log;
+namespace error = mender::common::error;
+namespace expected = mender::common::expected;
+
+enum class Type {
+	Uninitialized = 0,
+	EOFToken,
+	Unrecognized,
+	HeaderInfo,
+	ArtifactScripts,
+	ArtifactHeaderTypeInfo,
+	ArtifactHeaderMetaData,
+};
+
+unordered_map<const Type, string> type_map {
+	{Type::Uninitialized, "Uninitialized"},
+	{Type::EOFToken, "EOF"},
+	{Type::Unrecognized, "Unrecognized"},
+	{Type::HeaderInfo, "header-info"},
+	{Type::ArtifactScripts, "artifact-scripts"},
+	{Type::ArtifactHeaderTypeInfo, "type-info"},
+	{Type::ArtifactHeaderMetaData, "header-meta-data"},
+};
+
+class Token {
+public:
+	Type type;
+	string name {};
+	shared_ptr<tar::Entry> value;
+
+	Token() :
+		type {Type::Uninitialized} {
+	}
+	explicit Token(Type t) :
+		type {t} {
+	}
+	Token(const string &type_name, tar::Entry &entry) :
+		type {StringToType(type_name)},
+		name {StringToName(type_name)},
+		value {make_shared<tar::Entry>(entry)} {
+	}
+
+	const string TypeToString() const {
+		return type_map.at(type);
+	}
+
+	const int Index() const {
+		switch (type) {
+		case Type::ArtifactHeaderTypeInfo:
+			// fallthrough
+		case Type::ArtifactHeaderMetaData:
+			return stoi(
+				this->name.substr(artifact_headers_index_position, artifact_headers_index_length));
+			break;
+		default:
+			return -1;
+		}
+	}
+
+private:
+	Type StringToType(const string &type_name) {
+		log::Trace("StringToType: " + type_name);
+		if (type_name == "header-info") {
+			return Type::HeaderInfo;
+		}
+		if (std::regex_match(type_name, artifact_script_regexp)) {
+			return Type::ArtifactScripts;
+		}
+		if (std::regex_match(type_name, regex("headers/[0-9]{4}/type-info"))) {
+			return Type::ArtifactHeaderTypeInfo;
+		}
+		if (regex_match(type_name, regex("headers/[0-9]{4}/meta-data"))) {
+			return Type::ArtifactHeaderMetaData;
+		}
+		log::Error("Unrecognized token: " + type_name);
+		return Type::Unrecognized;
+	}
+
+	string StringToName(const string &type_name) {
+		if (std::regex_match(type_name, artifact_script_regexp)) {
+			return type_name.substr(7 + 1); // Strip the scripts + / prefix
+		}
+		return type_name;
+	}
+};
+
+} // namespace token
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender
+
+#endif // MENDER_ARTIFACT_V3_HEADER_TOKEN_HPP

--- a/artifact/v3/header/type_info.cpp
+++ b/artifact/v3/header/type_info.cpp
@@ -1,0 +1,148 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/header/header.hpp>
+
+#include <vector>
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/json.hpp>
+#include <common/common.hpp>
+
+#include <artifact/error.hpp>
+#include <artifact/lexer.hpp>
+#include <artifact/tar/tar.hpp>
+
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+
+namespace type_info {
+
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace error = mender::common::error;
+namespace log = mender::common::log;
+namespace json = mender::common::json;
+
+ExpectedTypeInfo Parse(io::Reader &reader) {
+	TypeInfo type_info;
+
+	log::Trace("Parse(type-info)...");
+
+	auto expected_json = json::Load(reader);
+
+	if (!expected_json) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the  sub-header JSON: " + expected_json.error().message));
+	}
+
+	const json::Json type_info_json = expected_json.value();
+
+	//
+	// Parse the single payload_type key:value (required)
+	//
+
+	log::Trace("type-info: Parsing the payload type");
+
+	auto expected_payload = type_info_json.Get("type").and_then(json::ToString);
+	if (!expected_payload) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the type-info payload type JSON: "
+				+ expected_payload.error().message));
+	}
+
+	auto payload_type = expected_payload.value();
+	type_info.type = payload_type;
+
+
+	log::Trace("type-info: Parsing the artifact_provides");
+
+	//
+	// artifact_provides (Optional)
+	//
+
+	auto expected_artifact_provides =
+		type_info_json.Get("artifact_provides").and_then(json::ToKeyValuesMap);
+	if (!expected_artifact_provides
+		&& expected_artifact_provides.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the type-info artifact_provides JSON: "
+				+ expected_artifact_provides.error().message));
+	}
+	if (expected_artifact_provides) {
+		type_info.artifact_provides = expected_artifact_provides.value();
+	} else {
+		log::Trace("No artifact_provides found in type-info");
+	}
+
+
+	//
+	// artifact_depends (Optional)
+	//
+	log::Trace("type-info: Parsing the artifact_depends");
+
+	auto expected_artifact_depends =
+		type_info_json.Get("artifact_depends").and_then(json::ToKeyValuesMap);
+	if (!expected_artifact_depends
+		&& expected_artifact_depends.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the type-info artifact_depends JSON: "
+				+ expected_artifact_provides.error().message));
+	}
+	if (expected_artifact_depends) {
+		type_info.artifact_depends = expected_artifact_depends.value();
+	} else {
+		log::Trace("No artifact_depends found in type-info");
+	}
+
+	//
+	// clears_artifact_provides (Optional)
+	//
+
+	log::Trace("type-info: Parsing the clears_artifact_provides");
+	auto expected_clears_artifact_provides =
+		type_info_json.Get("clears_artifact_provides").and_then(json::ToStringVector);
+	if (!expected_clears_artifact_provides
+		&& expected_clears_artifact_provides.error().code.value() != json::KeyError) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the type-info clears_artifact_depends JSON: "
+				+ expected_artifact_provides.error().message));
+	}
+	if (expected_clears_artifact_provides) {
+		type_info.clears_artifact_provides = expected_clears_artifact_provides.value();
+	} else {
+		log::Trace("No artifact_clears_provides found in type-info");
+	}
+
+	log::Trace("Finished parsing the type-info..");
+
+	return type_info;
+}
+
+} // namespace type_info
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/artifact/v3/manifest/manifest.cpp
+++ b/artifact/v3/manifest/manifest.cpp
@@ -80,6 +80,14 @@ ExpectedManifest Parse(mender::common::io::Reader &reader) {
 	return m;
 }
 
+string Manifest::Get(const string &key) {
+	auto value = this->map_.find(key);
+	if (value != this->map_.end()) {
+		return value->second;
+	}
+	return "";
+}
+
 } // namespace manifest
 } // namespace v3
 } // namespace artifact

--- a/artifact/v3/manifest/manifest.cpp
+++ b/artifact/v3/manifest/manifest.cpp
@@ -45,7 +45,21 @@ const string manifest_line_regex_string {
 	"^([0-9a-z]{" + to_string(expected_shasum_length) + "})[[:space:]]{"
 	+ to_string(expected_whitespace) + "}([/.[:alnum:]]+)$"};
 
+const vector<string> supported_compression_suffixes {".gz", ".xz", ".zst"};
+
 namespace {
+
+string MaybeStripSuffix(string s, vector<string> suffixes) {
+	auto s_ {s};
+	for (const auto &suffix : suffixes) {
+		if (s.substr(s.size() - suffix.size()) == suffix) {
+			s_.erase(s.size() - suffix.size());
+			return s_;
+		}
+	}
+	return s_;
+}
+
 ExpectedManifestLine Tokenize(const string &line) {
 	const std::regex manifest_line_regex(
 		manifest_line_regex_string, std::regex_constants::ECMAScript);
@@ -59,7 +73,9 @@ ExpectedManifestLine Tokenize(const string &line) {
 				+ ") is not in the expected manifest format: " + manifest_line_regex_string));
 	}
 
-	return ManifestLine {.shasum = base_match[1], .entry_name = base_match[2]};
+	return ManifestLine {
+		.shasum = base_match[1],
+		.entry_name = MaybeStripSuffix(base_match[2], supported_compression_suffixes)};
 }
 } // namespace
 

--- a/artifact/v3/manifest/manifest.hpp
+++ b/artifact/v3/manifest/manifest.hpp
@@ -35,13 +35,7 @@ namespace error = mender::common::error;
 
 class Manifest {
 public:
-	string Get(const string &key) {
-		auto value = map_.find(key);
-		if (value != map_.end()) {
-			return value->second;
-		}
-		return "";
-	}
+	string Get(const string &key);
 
 	unordered_map<string, string> map_;
 };

--- a/common/io.cpp
+++ b/common/io.cpp
@@ -85,6 +85,15 @@ ExpectedSize ByteWriter::Write(
 }
 
 
+ExpectedSize StreamWriter::Write(
+	vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
+	os_.write(reinterpret_cast<const char *>(&*start), end - start);
+	if (!os_) {
+		return expected::unexpected(Error(make_error_condition(errc::io_error), ""));
+	}
+	return end - start;
+}
+
 class ReaderStreamBuffer : public streambuf {
 public:
 	ReaderStreamBuffer(Reader &reader) :

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -150,6 +150,21 @@ public:
 		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) override;
 };
 
+class StreamWriter : virtual public Writer {
+private:
+	std::ostream &os_;
+
+public:
+	StreamWriter(std::ostream &stream) :
+		os_ {stream} {
+	}
+	StreamWriter(std::ostream &&stream) :
+		os_ {stream} {
+	}
+	ExpectedSize Write(
+		vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) override;
+};
+
 } // namespace io
 } // namespace common
 } // namespace mender

--- a/common/json.hpp
+++ b/common/json.hpp
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <map>
+#include <unordered_map>
 
 #include <common/error.hpp>
 #include <common/expected.hpp>
@@ -122,6 +123,14 @@ ExpectedJson Load(istream &str);
 ExpectedJson Load(io::Reader &reader);
 
 string EscapeString(const string &str);
+
+using ExpectedStringVector = expected::ExpectedStringVector;
+using KeyValueMap = unordered_map<string, string>;
+using ExpectedKeyValueMap = expected::expected<KeyValueMap, error::Error>;
+
+ExpectedStringVector ToStringVector(const json::Json &j);
+ExpectedKeyValueMap ToKeyValuesMap(const json::Json &j);
+ExpectedString ToString(const json::Json &j);
 
 } // namespace json
 } // namespace common

--- a/common/optional.hpp
+++ b/common/optional.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_OPTIONAL_HPP
+#define MENDER_COMMON_OPTIONAL_HPP
+
+#include <nonstd/optional.hpp>
+
+namespace mender {
+namespace common {
+namespace optional {
+
+using nonstd::nullopt;
+using nonstd::optional;
+
+} // namespace optional
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_OPTIONAL_HPP


### PR DESCRIPTION
Implementation of the header-parser, minus the meta-data parsing, which will be handled as a follow-up in https://northerntech.atlassian.net/browse/MEN-6424.

For now it's directly importing the `vendor/expected` lib, but I will move this out into our own wrapper in a separate PR in parallel, and then rebase on top of it.