### PR TITLE
fix: Fix json GetChildren() test

### DIFF
--- a/common/json_test.cpp
+++ b/common/json_test.cpp
@@ -329,7 +329,7 @@ TEST(JsonDataTests, GetDataValues) {
 }
 
 TEST(JsonDataTests, GetChildren) {
-	json::ExpectedJson ej = json::LoadFromString(json_example_str);
+	json::ExpectedJson ej = json::Load(json_example_str);
 	ASSERT_TRUE(ej);
 
 	json::Json j = ej.value();


### PR DESCRIPTION
Rebase caused a mismatch between LoadFromString() replaced by overloaded Load() and GetChildren() being introduced.

Ticket: none
Changelog: none
