### PR TITLE
chore: Enforce use of `override` everywhere where it is appropriate.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ else()
 endif()
 
 # Default for all components.
-add_compile_options(-std=c++11 -Werror -Wall)
+add_compile_options(-std=c++11 -Werror -Wall -Wsuggest-override)
 
 if (MENDER_USE_BOOST_FS)
   set(BOOST_FILESYSTEM_NO_DEPRECATED 1)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(common_key_value_database STATIC
 target_compile_options(common_key_value_database PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 if(MENDER_USE_LMDB)
   target_sources(common_key_value_database PRIVATE key_value_database/platform/lmdb/lmdb.cpp)
-  target_include_directories(common_key_value_database PRIVATE ${CMAKE_SOURCE_DIR}/vendor/lmdbxx)
+  # Note: Use SYSTEM include style, since lmdbxx triggers some of our warnings.
+  target_include_directories(common_key_value_database SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/vendor/lmdbxx)
   target_link_libraries(common_key_value_database PUBLIC lmdb)
 endif()
 

--- a/common/http_test.cpp
+++ b/common/http_test.cpp
@@ -439,7 +439,8 @@ TEST(HttpTest, TestMultipleSimultaneousConnections) {
 
 class BodyOfXes : virtual public io::Reader {
 public:
-	expected::ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) {
+	expected::ExpectedSize Read(
+		vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override {
 		auto iter_count = end - start;
 		size_t read;
 		if (iter_count + count_ > TARGET_BODY_SIZE) {


### PR DESCRIPTION
It helps readability by knowing where overrides are, and can also prevent mistakes in cases where an override is unintentional.
