### PR TITLE
Header metadata parser

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -14,6 +14,7 @@ set(parser_sources
   v3/header/header.cpp
   v3/header/header_info.cpp
   v3/header/type_info.cpp
+  v3/header/meta_data.cpp
   v3/payload/payload.cpp
 )
 

--- a/artifact/artifact.cpp
+++ b/artifact/artifact.cpp
@@ -27,16 +27,16 @@ namespace error = mender::common::error;
 namespace expected = mender::common::expected;
 
 
-ExpectedPayloadHeader View(parser::Artifact &artifact, size_t index) {
+ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index) {
 	// Check if the index is available
 	if (index >= artifact.header.info.payloads.size()) {
 		return expected::unexpected(
 			parser_error::MakeError(parser_error::Code::ParseError, "Payload index out of range"));
 	}
-	return PayloadHeader {
+	return PayloadHeaderView {
 		.version = artifact.version.version,
 		.header =
-			Header {
+			HeaderView {
 				.artifact_group = artifact.header.info.provides.artifact_group.value_or(""),
 				.artifact_name = artifact.header.info.provides.artifact_name,
 				.payload_type = artifact.header.info.payloads.at(index).name,

--- a/artifact/artifact.cpp
+++ b/artifact/artifact.cpp
@@ -42,8 +42,7 @@ ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index) {
 				.payload_type = artifact.header.info.payloads.at(index).name,
 				.header_info = artifact.header.info.verbatim,
 				.type_info = artifact.header.subHeaders.at(index).type_info.verbatim,
-				// TODO - meta-data
-				// .meta_data = artifact.header.subHeaders.at(index).metadata.verbatim,
+				.meta_data = artifact.header.subHeaders.at(index).metadata.value(),
 			},
 	};
 };

--- a/artifact/artifact.hpp
+++ b/artifact/artifact.hpp
@@ -48,7 +48,11 @@ struct PayloadHeaderView {
 
 using ExpectedPayloadHeaderView = expected::expected<PayloadHeaderView, error::Error>;
 
-// View is giving the meta-data view of a given payload index
+// View is giving the meta-data view of a given payload index.
+//
+// This means that a PayloadHeaderView is the union of the global header-info,
+// and the type-info for the given payload. A view will never leak information
+// which is dedicated to another payload (given by it's index).
 ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index);
 
 } // namespace artifact

--- a/artifact/artifact.hpp
+++ b/artifact/artifact.hpp
@@ -32,7 +32,7 @@ namespace json = mender::common::json;
 
 using error::Error;
 
-struct Header {
+struct HeaderView {
 	string artifact_group;
 	string artifact_name;
 	string payload_type;
@@ -41,15 +41,15 @@ struct Header {
 	json::Json meta_data;
 };
 
-struct PayloadHeader {
+struct PayloadHeaderView {
 	int version;
-	Header header;
+	HeaderView header;
 };
 
-using ExpectedPayloadHeader = expected::expected<PayloadHeader, error::Error>;
+using ExpectedPayloadHeaderView = expected::expected<PayloadHeaderView, error::Error>;
 
 // View is giving the meta-data view of a given payload index
-ExpectedPayloadHeader View(parser::Artifact &artifact, size_t index);
+ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index);
 
 } // namespace artifact
 } // namespace mender

--- a/artifact/v3/header/CMakeLists.txt
+++ b/artifact/v3/header/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(artifact_header_parser_test EXCLUDE_FROM_ALL
   header.cpp
   header_info.cpp
   type_info.cpp
+  meta_data.cpp
   ${CMAKE_SOURCE_DIR}/artifact/error.cpp
   header_test.cpp
 )

--- a/artifact/v3/header/header.cpp
+++ b/artifact/v3/header/header.cpp
@@ -168,12 +168,11 @@ ExpectedHeader Parse(io::Reader &reader, ParserConfig conf) {
 					"Unexpected index order for the meta-data: " + tok.name + " expected: headers/"
 						+ IndexString(current_index) + "/meta-data"));
 			}
-			// auto expected_meta_data = meta_data::Parse(*tok.value);
-			// if (!expected_meta_data) {
-			// TODO - follow-up (MEN-6424)
-			// return expected::unexpected(expected_meta_data.error());
-			// sub_header.metadata = expected_meta_data.value();
-			// }
+			auto expected_meta_data = meta_data::Parse(*tok.value);
+			if (!expected_meta_data) {
+				return expected::unexpected(expected_meta_data.error());
+			}
+			sub_header.metadata = expected_meta_data.value();
 			tok = lexer.Next();
 		}
 		log::Trace("sub-header: parsed the meta-data");

--- a/artifact/v3/header/header.hpp
+++ b/artifact/v3/header/header.hpp
@@ -117,9 +117,8 @@ struct TypeInfo {
 	json::Json verbatim;
 };
 
-struct MetaData {
-	string verbatim;
-};
+// Vetted meta-data structure
+using MetaData = json::Json;
 
 struct SubHeader {
 	TypeInfo type_info {};

--- a/artifact/v3/header/header_test.cpp
+++ b/artifact/v3/header/header_test.cpp
@@ -32,6 +32,7 @@
 using namespace std;
 
 namespace io = mender::common::io;
+namespace json = mender::common::json;
 namespace tar = mender::tar;
 namespace processes = mender::common::processes;
 namespace mendertesting = mender::common::testing;
@@ -243,8 +244,6 @@ TEST_F(HeaderTestEnv, TestHeaderRootfsAllFlagsSetSuccess) {
 		"rootfs_image_checksum");
 	EXPECT_EQ(
 		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(2), "rootfs-image.*");
-
-	// meta-data
 }
 
 TEST_F(HeaderTestEnv, TestHeaderModuleImageAllFlagsSetSuccess) {
@@ -347,7 +346,9 @@ TEST_F(HeaderTestEnv, TestHeaderModuleImageAllFlagsSetSuccess) {
 		header.subHeaders.at(0).type_info.clears_artifact_provides.value().at(0),
 		"rootfs-image.dummy-update-module.*");
 
-	// meta-data
+	// headers/0000/meta-data
+	ASSERT_TRUE(header.subHeaders.at(0).metadata);
+	// EXPECT_EQ(header.subHeaders.at(0).meta_data.value().Dump(), "rootfs-image.*");
 }
 
 
@@ -446,4 +447,180 @@ TEST_F(HeaderTestEnv, TestHeaderFilesOutOfOrder) {
 	EXPECT_EQ(
 		expected_header.error().message,
 		"Got unexpected token: 'type-info' expected 'header-info'");
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataSuccess) {
+	stringstream meta_data {
+		R"(
+{
+  "foo": "bar",
+  "bar": "100",
+  "baz": 1,
+  "bur": ["foo", 1000]
+}
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_TRUE(expected_meta_data) << expected_meta_data.error().message;
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataParsingTopLevelKeys) {
+	// Invalid, can only contain top-level keys
+	stringstream meta_data {
+		R"(
+["foo", "bar" ]
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_FALSE(expected_meta_data);
+	EXPECT_EQ(expected_meta_data.error().message, "The meta-data needs to be a top-level object");
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataParsingNumbersStringsAndLists) {
+	// Invalid, can only contain strings, numbers and lists of numbers and strings
+	stringstream meta_data {
+		R"(
+{
+  "foo": { "bar": "baz" }
+}
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_FALSE(expected_meta_data);
+	EXPECT_EQ(
+		expected_meta_data.error().message,
+		"The meta-data needs to only be strings, ints and arrays of ints and strings");
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataParsingListOfObjectsNotAllowed) {
+	// Invalid, can only contain strings, numbers and lists of numbers and strings
+	// Not list of objects
+	stringstream meta_data {
+		R"(
+{
+  "foo": [ { "bar": "baz" } ]
+}
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_FALSE(expected_meta_data);
+	EXPECT_EQ(
+		expected_meta_data.error().message,
+		"The meta-data needs to only be strings, ints and arrays of ints and strings");
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataSingleBracketPayloadTest) {
+	stringstream meta_data {R"({)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_FALSE(expected_meta_data) << expected_meta_data.error().message;
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataSingleSpacePayloadTest) {
+	stringstream meta_data {R"( )"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_FALSE(expected_meta_data) << expected_meta_data.error().message;
+}
+
+
+
+// any integer less than -9007199254740991 or greater than 9007199254740991
+// 	should be stored as a string, otherwise the value will be rounded to the
+// 	nearest representable number.
+TEST_F(HeaderTestEnv, TestHeaderMetaDataIs64BitFloatingPointRepresented) {
+	stringstream meta_data {
+		R"(
+{
+  "test": 10000000,
+  "correct-max-int": 9007199254740991,
+  "correct-min-int": -9007199254740991
+}
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_TRUE(expected_meta_data);
+
+	{
+		auto val = expected_meta_data.value().Get("test").and_then(
+			[](const json::Json &json) { return json.GetInt(); });
+
+		ASSERT_TRUE(val) << val.error().message;
+		EXPECT_EQ(val.value(), 10000000);
+	}
+
+	{
+		auto val =
+			expected_meta_data.value().Get("correct-max-int").and_then([](const json::Json &json) {
+				return json.GetInt();
+			});
+
+		ASSERT_TRUE(val) << val.error().message;
+		ASSERT_EQ(val.value(), 9007199254740991);
+	}
+
+	{
+		auto val =
+			expected_meta_data.value().Get("correct-min-int").and_then([](const json::Json &json) {
+				return json.GetInt();
+			});
+
+		ASSERT_TRUE(val) << val.error().message;
+		ASSERT_EQ(val.value(), -9007199254740991);
+	}
+}
+
+TEST_F(HeaderTestEnv, TestHeaderMetaDataIs53BitFloatingPointIsRounded) {
+	stringstream meta_data {
+		R"(
+{
+  "one-out-of-53-bit-range": 9007199254740992,
+  "one-out-of-negative-53-bit-range": -9007199254740992
+}
+)"};
+
+	mender::common::io::StreamReader sr {meta_data};
+
+	auto expected_meta_data = header::meta_data::Parse(sr);
+
+	ASSERT_TRUE(expected_meta_data);
+
+	{
+		auto expected_val = expected_meta_data.value()
+								.Get("one-out-of-53-bit-range")
+								.and_then([](const json::Json &json) { return json.GetDouble(); });
+
+		ASSERT_TRUE(expected_val) << expected_val.error().message;
+		EXPECT_THAT(expected_val.value(), testing::DoubleEq(9007199254740991));
+	}
+
+	{
+		auto expected_val = expected_meta_data.value()
+								.Get("one-out-of-negative-53-bit-range")
+								.and_then([](const json::Json &json) { return json.GetDouble(); });
+
+		ASSERT_TRUE(expected_val) << expected_val.error().message;
+		EXPECT_THAT(expected_val.value(), testing::DoubleEq(-9007199254740991));
+	}
 }

--- a/artifact/v3/header/meta_data.cpp
+++ b/artifact/v3/header/meta_data.cpp
@@ -1,0 +1,100 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/v3/header/header.hpp>
+
+
+#include <common/expected.hpp>
+#include <common/error.hpp>
+#include <common/io.hpp>
+#include <common/json.hpp>
+#include <common/log.hpp>
+#include <common/common.hpp>
+
+#include <artifact/error.hpp>
+#include <string>
+#include <iostream>
+
+namespace mender {
+namespace artifact {
+namespace v3 {
+namespace header {
+namespace meta_data {
+
+const string empty_json_error_message =
+	"[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal";
+
+namespace json = mender::common::json;
+namespace log = mender::common::log;
+
+ExpectedMetaData VerifyMetaDataJson(const json::Json &json) {
+	// 1. Only contains top-level keys
+	if (!json.IsObject()) {
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError, "The meta-data needs to be a top-level object"));
+	}
+	// 2. Only allowed strings, numbers, and lists of the aforementioned
+	auto expected_children = json.GetChildren();
+	auto children = expected_children.value();
+	if (!all_of(children.cbegin(), children.cend(), [](const json::ChildrenMap::value_type &it) {
+			if (it.second.IsArray()) {
+				auto array_size = it.second.GetArraySize().value();
+				for (size_t i = 0; i < array_size; ++i) {
+					const json::ExpectedJson array_item = it.second.Get(i);
+					if (!array_item) {
+						return false;
+					}
+
+					return array_item.value().IsString() || array_item.value().IsNumber();
+				}
+				return true;
+			}
+			return it.second.IsString() || it.second.IsNumber();
+		})) {
+		auto err = parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"The meta-data needs to only be strings, ints and arrays of ints and strings");
+		return expected::unexpected(err);
+	}
+
+	return json;
+}
+
+ExpectedMetaData Parse(io::Reader &reader) {
+	log::Trace("Parsing the header meta-data");
+	auto expected_json = json::Load(reader);
+
+	if (!expected_json) {
+		log::Trace("Received json load error: " + expected_json.error().message);
+		bool is_empty_payload_error =
+			expected_json.error().message.find(empty_json_error_message) != string::npos;
+		if (is_empty_payload_error) {
+			log::Trace("Received an empty Json body. Not treating this as an error");
+			return json::Json();
+		}
+		return expected::unexpected(parser_error::MakeError(
+			parser_error::Code::ParseError,
+			"Failed to parse the  meta-data JSON: " + expected_json.error().message));
+	}
+
+	const json::Json meta_data_json = expected_json.value();
+
+	return VerifyMetaDataJson(meta_data_json);
+}
+
+} // namespace meta_data
+} // namespace header
+} // namespace v3
+} // namespace artifact
+} // namespace mender

--- a/common/config_parser/config_parser.cpp
+++ b/common/config_parser/config_parser.cpp
@@ -224,7 +224,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("UpdateControlMapExpirationTimeSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->update_control_map_expiration_time_seconds = e_cfg_int.value();
 			applied = true;
@@ -234,7 +234,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("UpdateControlMapBootExpirationTimeSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->update_control_map_boot_expiration_time_seconds = e_cfg_int.value();
 			applied = true;
@@ -244,7 +244,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("UpdatePollIntervalSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->update_poll_interval_seconds = e_cfg_int.value();
 			applied = true;
@@ -254,7 +254,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("InventoryPollIntervalSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->inventory_poll_interval_seconds = e_cfg_int.value();
 			applied = true;
@@ -264,7 +264,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("RetryPollIntervalSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->retry_poll_interval_seconds = e_cfg_int.value();
 			applied = true;
@@ -274,7 +274,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("RetryPollCount");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->retry_poll_count = e_cfg_int.value();
 			applied = true;
@@ -284,7 +284,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("StateScriptTimeoutSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->state_script_timeout_seconds = e_cfg_int.value();
 			applied = true;
@@ -294,7 +294,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("StateScriptRetryTimeoutSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->state_script_retry_timeout_seconds = e_cfg_int.value();
 			applied = true;
@@ -304,7 +304,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("StateScriptRetryIntervalSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->state_script_retry_interval_seconds = e_cfg_int.value();
 			applied = true;
@@ -314,7 +314,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 	e_cfg_value = cfg_json.Get("ModuleTimeoutSeconds");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();
-		const json::ExpectedInt e_cfg_int = value_json.GetInt();
+		const auto e_cfg_int = value_json.GetInt();
 		if (e_cfg_int) {
 			this->module_timeout_seconds = e_cfg_int.value();
 			applied = true;
@@ -447,7 +447,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		e_cfg_subval = value_json.Get("IdleConnTimeoutSeconds");
 		if (e_cfg_subval) {
 			const json::Json subval_json = e_cfg_subval.value();
-			const json::ExpectedInt e_cfg_int = subval_json.GetInt();
+			const auto e_cfg_int = subval_json.GetInt();
 			if (e_cfg_int) {
 				this->connectivity.idle_conn_timeout_seconds = e_cfg_int.value();
 				applied = true;

--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -53,6 +53,7 @@ tl::unexpected<V> unexpected(V &v) {
 using ExpectedString = expected<string, error::Error>;
 using ExpectedBytes = expected<vector<uint8_t>, error::Error>;
 using ExpectedInt = expected<int, error::Error>;
+using ExpectedInt64 = expected<int64_t, error::Error>;
 using ExpectedBool = expected<bool, error::Error>;
 using ExpectedSize = expected<size_t, error::Error>;
 using ExpectedSize = expected<size_t, error::Error>;

--- a/common/expected.hpp
+++ b/common/expected.hpp
@@ -54,6 +54,7 @@ using ExpectedString = expected<string, error::Error>;
 using ExpectedBytes = expected<vector<uint8_t>, error::Error>;
 using ExpectedInt = expected<int, error::Error>;
 using ExpectedInt64 = expected<int64_t, error::Error>;
+using ExpectedDouble = expected<double, error::Error>;
 using ExpectedBool = expected<bool, error::Error>;
 using ExpectedSize = expected<size_t, error::Error>;
 using ExpectedSize = expected<size_t, error::Error>;

--- a/common/json.hpp
+++ b/common/json.hpp
@@ -57,6 +57,7 @@ error::Error MakeError(JsonErrorCode code, const string &msg);
 
 using ExpectedString = mender::common::expected::ExpectedString;
 using ExpectedInt64 = mender::common::expected::ExpectedInt64;
+using ExpectedDouble = mender::common::expected::ExpectedDouble;
 using ExpectedBool = mender::common::expected::ExpectedBool;
 using ExpectedSize = mender::common::expected::ExpectedSize;
 
@@ -91,11 +92,14 @@ public:
 	bool IsArray() const;
 	bool IsString() const;
 	bool IsInt() const;
+	bool IsNumber() const;
+	bool IsDouble() const;
 	bool IsBool() const;
 	bool IsNull() const;
 
 	ExpectedString GetString() const;
 	ExpectedInt64 GetInt() const;
+	ExpectedDouble GetDouble() const;
 	ExpectedBool GetBool() const;
 
 	ExpectedSize GetArraySize() const;

--- a/common/json.hpp
+++ b/common/json.hpp
@@ -56,7 +56,7 @@ extern const JsonErrorCategoryClass JsonErrorCategory;
 error::Error MakeError(JsonErrorCode code, const string &msg);
 
 using ExpectedString = mender::common::expected::ExpectedString;
-using ExpectedInt = mender::common::expected::ExpectedInt;
+using ExpectedInt64 = mender::common::expected::ExpectedInt64;
 using ExpectedBool = mender::common::expected::ExpectedBool;
 using ExpectedSize = mender::common::expected::ExpectedSize;
 
@@ -95,7 +95,7 @@ public:
 	bool IsNull() const;
 
 	ExpectedString GetString() const;
-	ExpectedInt GetInt() const;
+	ExpectedInt64 GetInt() const;
 	ExpectedBool GetBool() const;
 
 	ExpectedSize GetArraySize() const;

--- a/common/json/platform/nlohmann/nlohmann_json.cpp
+++ b/common/json/platform/nlohmann/nlohmann_json.cpp
@@ -152,6 +152,14 @@ bool Json::IsInt() const {
 	return this->n_json.is_number_integer();
 }
 
+bool Json::IsNumber() const {
+	return this->n_json.is_number();
+}
+
+bool Json::IsDouble() const {
+	return this->n_json.is_number_float();
+}
+
 bool Json::IsBool() const {
 	return this->n_json.is_boolean();
 }
@@ -176,6 +184,15 @@ ExpectedInt64 Json::GetInt() const {
 		return s;
 	} catch (njson::type_error &e) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting int");
+		return expected::unexpected(err);
+	}
+}
+
+ExpectedDouble Json::GetDouble() const {
+	try {
+		return this->n_json.get<double>();
+	} catch (njson::type_error &e) {
+		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting double");
 		return expected::unexpected(err);
 	}
 }

--- a/common/json/platform/nlohmann/nlohmann_json.cpp
+++ b/common/json/platform/nlohmann/nlohmann_json.cpp
@@ -170,9 +170,9 @@ ExpectedString Json::GetString() const {
 	}
 }
 
-ExpectedInt Json::GetInt() const {
+ExpectedInt64 Json::GetInt() const {
 	try {
-		int s = this->n_json.get<int>();
+		int64_t s {this->n_json.get<int64_t>()};
 		return s;
 	} catch (njson::type_error &e) {
 		auto err = MakeError(JsonErrorCode::TypeError, "Type mismatch when getting int");

--- a/common/json_test.cpp
+++ b/common/json_test.cpp
@@ -275,7 +275,7 @@ TEST(JsonDataTests, GetDataValues) {
 	ASSERT_TRUE(estr);
 	EXPECT_EQ(estr.value(), "string value");
 
-	json::ExpectedInt eint = echild.value().GetInt();
+	json::ExpectedInt64 eint = echild.value().GetInt();
 	ASSERT_FALSE(eint);
 	EXPECT_EQ(eint.error().code, json::MakeError(json::JsonErrorCode::TypeError, "").code);
 	EXPECT_EQ(eint.error().message, "Type mismatch when getting int");
@@ -300,10 +300,6 @@ TEST(JsonDataTests, GetDataValues) {
 	ASSERT_TRUE(echild);
 	ebool = echild.value().GetBool();
 	EXPECT_EQ(ebool.value(), true);
-
-	eint = echild.value().GetInt();
-	ASSERT_TRUE(eint);
-	EXPECT_EQ(eint.value(), 1);
 
 	echild = j.Get("array");
 	ASSERT_TRUE(echild);

--- a/common/json_test.cpp
+++ b/common/json_test.cpp
@@ -361,3 +361,11 @@ TEST(JsonUtilTests, EscapeString) {
 	str = "A \"really\" bad\n\t combination";
 	EXPECT_EQ(json::EscapeString(str), R"(A \"really\" bad\n\t combination)");
 }
+
+TEST(Json, GetDouble) {
+	auto ej = json::Load(R"(141.14)");
+	ASSERT_TRUE(ej);
+	auto ed = ej.value().GetDouble();
+	ASSERT_TRUE(ed) << ed.error().message;
+	EXPECT_THAT(ed.value(), testing::DoubleEq(141.14));
+}

--- a/mender-update/update_module/v3/update_module.hpp
+++ b/mender-update/update_module/v3/update_module.hpp
@@ -50,7 +50,7 @@ using ExpectedRebootAction = expected::expected<RebootAction, Error>;
 
 class UpdateModule {
 public:
-	UpdateModule(MenderContext &ctx, artifact::PayloadHeader &update_meta_data) :
+	UpdateModule(MenderContext &ctx, artifact::PayloadHeaderView &update_meta_data) :
 		ctx_ {ctx},
 		update_meta_data_ {update_meta_data} {};
 
@@ -73,7 +73,7 @@ public:
 
 private:
 	context::MenderContext &ctx_;
-	artifact::PayloadHeader &update_meta_data_;
+	artifact::PayloadHeaderView &update_meta_data_;
 };
 
 ExpectedStringVector DiscoverUpdateModules(const conf::MenderConfig &config);

--- a/mender-update/update_module/v3/update_module_test.cpp
+++ b/mender-update/update_module/v3/update_module_test.cpp
@@ -327,8 +327,7 @@ TEST_F(UpdateModuleFileTreeTests, FileTreeTestHeader) {
 	})";
 	EXPECT_TRUE(FileJsonEquals(path::Join(tree_path, "header", "type_info"), expected_type_info));
 
-	// TODO
-	// EXPECT_TRUE(FileContains(path::Join(tree_path, "header", "meta_data"), "bar"));
+	EXPECT_TRUE(FileContains(path::Join(tree_path, "header", "meta_data"), ""));
 
 	err = up_mod.DeleteFileTree(tree_path);
 	ASSERT_EQ(err, error::NoError);

--- a/mender-update/update_module/v3/update_module_test.cpp
+++ b/mender-update/update_module/v3/update_module_test.cpp
@@ -256,7 +256,7 @@ protected:
 
 	conf::MenderConfig cfg {};
 	shared_ptr<context::MenderContext> ctx;
-	mender::artifact::PayloadHeader update_payload_header;
+	mender::artifact::PayloadHeaderView update_payload_header;
 };
 
 TEST_F(UpdateModuleFileTreeTests, FileTreeTestHeader) {


### PR DESCRIPTION
This adds the meta-data parser from MEN-6424, as well as a few touches to our Json implementation, notably:

* Fix: Align the `GetInt` function with the underlying Nlohmann integer representation
* feat: Json::GetDouble

Note, this is based on top of https://github.com/mendersoftware/mender/pull/1203 so feel free to ignore those commits obviously :)