### PR TITLE
Add a mender::common::main_test loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ add_custom_target(coverage_no_tests
 # CMake is not clever enough to build the tests before running them so we use
 # the 'check' target below that does both.
 add_custom_target(check
-  COMMAND ${CMAKE_CTEST_COMMAND}
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
 )
 
 # CMake doesn't generate the 'uninstall' target.

--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(artifact_parser PUBLIC ${CMAKE_SOURCE_DIR})
 add_executable(artifact_parser_test EXCLUDE_FROM_ALL parser_test.cpp)
 target_link_libraries(artifact_parser_test PRIVATE
   artifact_parser
-  GTest::gtest_main
+  main_test
   gmock
   common_testing
   common_io

--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(artifact_parser_test PRIVATE
   common_io
   common_processes
   sha
-  common_conf
+  common_path
 )
 target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR}/artifact)

--- a/artifact/sha/CMakeLists.txt
+++ b/artifact/sha/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(sha PUBLIC
 
 # Test the shasummer
 add_executable(sha_test EXCLUDE_FROM_ALL sha_test.cpp)
-target_link_libraries(sha_test PRIVATE sha GTest::gtest_main gmock common_io)
+target_link_libraries(sha_test PRIVATE sha main_test gmock common_io)
 target_include_directories(sha_test PRIVATE
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/artifact

--- a/artifact/tar/CMakeLists.txt
+++ b/artifact/tar/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(tar_test EXCLUDE_FROM_ALL tar_test.cpp)
 target_link_libraries(tar_test PUBLIC
   common_tar
   common_testing
-  GTest::gtest_main
+  main_test
   gmock
   common_io
   common_processes

--- a/artifact/v3/header/CMakeLists.txt
+++ b/artifact/v3/header/CMakeLists.txt
@@ -15,8 +15,8 @@ target_link_libraries(artifact_header_parser_test PRIVATE
   common_json
   common_testing
   common_processes
-  common_path
-  GTest::gtest_main
+  common_conf
+  main_test
   gmock
 )
 target_include_directories(artifact_header_parser_test PRIVATE

--- a/artifact/v3/manifest/CMakeLists.txt
+++ b/artifact/v3/manifest/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(artifact_manifest_parser_test PRIVATE
   common_log
   common_io
   common_error
-  GTest::gtest_main
+  main_test
   gmock
 )
 target_include_directories(artifact_manifest_parser_test PRIVATE

--- a/artifact/v3/payload/CMakeLists.txt
+++ b/artifact/v3/payload/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(artifact_payload_parser_test EXCLUDE_FROM_ALL
   payload_test.cpp
 )
 target_link_libraries(artifact_payload_parser_test PRIVATE
-  GTest::gtest_main
+  main_test
   gmock
   common_io
   common_error

--- a/artifact/v3/version/CMakeLists.txt
+++ b/artifact/v3/version/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(artifact_version_parser_test EXCLUDE_FROM_ALL
   version_test.cpp
 )
 target_link_libraries(artifact_version_parser_test PRIVATE
-  GTest::gtest_main
+  main_test
   gmock
   common_io
   common_error

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -17,8 +17,14 @@ if(MENDER_USE_BOOST_FS)
   target_link_libraries(common_path PUBLIC ${Boost_LIBRARIES})
 endif()
 
+add_library(main_test STATIC EXCLUDE_FROM_ALL main_test.cpp)
+target_link_libraries(main_test PRIVATE common_log)
+target_link_libraries(main_test PUBLIC common_setup gmock)
+target_compile_options(main_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
+add_dependencies(check main_test)
+
 add_executable(io_test EXCLUDE_FROM_ALL io_test.cpp)
-target_link_libraries(io_test PUBLIC common_io common_error GTest::gtest_main gmock)
+target_link_libraries(io_test PUBLIC common_io common_error main_test gmock)
 gtest_discover_tests(io_test)
 add_dependencies(check io_test)
 
@@ -34,9 +40,10 @@ endif()
 
 add_library(common_testing STATIC testing.cpp)
 target_compile_options(common_testing PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
+target_link_libraries(common_testing PUBLIC common_events)
 
 add_executable(json_test EXCLUDE_FROM_ALL json_test.cpp)
-target_link_libraries(json_test PUBLIC common_json GTest::gtest_main gmock)
+target_link_libraries(json_test PUBLIC common_json main_test gmock)
 gtest_discover_tests(json_test)
 add_dependencies(check json_test)
 
@@ -58,7 +65,7 @@ target_link_libraries(key_value_database_test PRIVATE
   common_testing
   common_error
   common_key_value_database
-  GTest::gtest_main
+  main_test
   gmock
 )
 target_compile_definitions(key_value_database_test PRIVATE MENDER_USE_LMDB=${MENDER_USE_LMDB})
@@ -80,12 +87,13 @@ target_link_libraries(common_events PUBLIC common_error)
 target_link_libraries(common_events PUBLIC ${Boost_LIBRARIES})
 
 add_executable(events_test EXCLUDE_FROM_ALL events_test.cpp)
-target_link_libraries(events_test PUBLIC common_events GTest::gtest_main)
+target_compile_options(events_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
+target_link_libraries(events_test PUBLIC common_events main_test)
 gtest_discover_tests(events_test ${MENDER_TEST_FLAGS})
 add_dependencies(check events_test)
 
 add_executable(events_io_test EXCLUDE_FROM_ALL events_io_test.cpp)
-target_link_libraries(events_io_test PUBLIC common_events common_path common_setup common_testing GTest::gtest_main)
+target_link_libraries(events_io_test PUBLIC common_events common_path common_setup common_testing main_test)
 gtest_discover_tests(events_io_test ${MENDER_TEST_FLAGS})
 add_dependencies(check events_io_test)
 
@@ -97,7 +105,7 @@ target_link_libraries(common_http PUBLIC common common_events common_error commo
 target_compile_definitions(common_http PUBLIC MENDER_USE_BOOST_BEAST=${MENDER_USE_BOOST_BEAST})
 
 add_executable(http_test EXCLUDE_FROM_ALL http_test.cpp)
-target_link_libraries(http_test PUBLIC common_io common_http GTest::gtest_main gmock)
+target_link_libraries(http_test PUBLIC common_io common_http main_test gmock)
 gtest_discover_tests(http_test ${MENDER_TEST_FLAGS})
 add_dependencies(check http_test)
 
@@ -110,7 +118,7 @@ target_link_libraries(common_log PUBLIC common_error ${Boost_LIBRARIES})
 
 # Test MenderLog
 add_executable(log_test EXCLUDE_FROM_ALL log_test.cpp)
-target_link_libraries(log_test PRIVATE common_log common_testing GTest::gtest_main gmock)
+target_link_libraries(log_test PRIVATE common_log common_testing main_test gmock)
 gtest_discover_tests(log_test)
 add_dependencies(check log_test)
 
@@ -121,7 +129,7 @@ if(${json_sources} MATCHES ".*nlohmann.*")
 endif()
 
 add_executable(config_parser_test EXCLUDE_FROM_ALL config_parser_test.cpp)
-target_link_libraries(config_parser_test PUBLIC common_config_parser GTest::gtest_main gmock)
+target_link_libraries(config_parser_test PUBLIC common_config_parser main_test gmock)
 # The test uses some non-c++11 stuff, even though the implementation is c++11.
 target_compile_options(config_parser_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 gtest_discover_tests(config_parser_test)
@@ -138,7 +146,7 @@ if(${procs_sources} MATCHES ".*tiny_process_library.*")
 endif()
 
 add_executable(processes_test EXCLUDE_FROM_ALL processes_test.cpp)
-target_link_libraries(processes_test PUBLIC common_path common_processes GTest::gtest_main gmock)
+target_link_libraries(processes_test PUBLIC common_path common_processes main_test gmock)
 target_include_directories(processes_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(processes_test)
 add_dependencies(check processes_test)
@@ -149,7 +157,7 @@ target_link_libraries(common_key_value_parser PUBLIC common_error)
 target_include_directories(common_key_value_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(key_value_parser_test EXCLUDE_FROM_ALL key_value_parser_test.cpp)
-target_link_libraries(key_value_parser_test PUBLIC common_key_value_parser GTest::gtest_main gmock)
+target_link_libraries(key_value_parser_test PUBLIC common_key_value_parser main_test gmock)
 target_include_directories(key_value_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(key_value_parser_test)
 add_dependencies(check key_value_parser_test)
@@ -160,7 +168,7 @@ target_include_directories(common_identity_parser PRIVATE ${CMAKE_SOURCE_DIR} ${
 target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes)
 
 add_executable(identity_parser_test EXCLUDE_FROM_ALL identity_parser_test.cpp)
-target_link_libraries(identity_parser_test PUBLIC common_identity_parser GTest::gtest_main gmock)
+target_link_libraries(identity_parser_test PUBLIC common_identity_parser main_test gmock)
 target_include_directories(identity_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(identity_parser_test)
 add_dependencies(check identity_parser_test)
@@ -178,7 +186,7 @@ if(MENDER_USE_BOOST_FS)
 endif()
 
 add_executable(inventory_parser_test EXCLUDE_FROM_ALL inventory_parser_test.cpp)
-target_link_libraries(inventory_parser_test PUBLIC common_inventory_parser common_testing GTest::gtest_main gmock)
+target_link_libraries(inventory_parser_test PUBLIC common_inventory_parser common_testing main_test gmock)
 target_include_directories(inventory_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(inventory_parser_test)
 add_dependencies(check inventory_parser_test)
@@ -187,7 +195,7 @@ add_library(common_conf STATIC conf/conf.cpp conf/platform/posix/paths.cpp)
 target_link_libraries(common_conf PUBLIC common_log common_error common_path common_config_parser)
 
 add_executable(conf_test EXCLUDE_FROM_ALL conf_test.cpp)
-target_link_libraries(conf_test PUBLIC common_conf GTest::gtest_main gmock)
+target_link_libraries(conf_test PUBLIC common_conf main_test gmock)
 target_include_directories(conf_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(conf_test)
 add_dependencies(check conf_test)

--- a/common/events_io_test.cpp
+++ b/common/events_io_test.cpp
@@ -33,14 +33,7 @@ namespace path = mender::common::path;
 
 using TestEventLoop = mtesting::TestEventLoop;
 
-class EventsIo : public testing::Test {
-protected:
-	void SetUp() override {
-		mender::common::setup::GlobalSetup();
-	}
-};
-
-TEST_F(EventsIo, ReadAndWriteWithPipes) {
+TEST(EventsIo, ReadAndWriteWithPipes) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -74,7 +67,7 @@ TEST_F(EventsIo, ReadAndWriteWithPipes) {
 	EXPECT_EQ(to_receive, to_send);
 }
 
-TEST_F(EventsIo, PartialRead) {
+TEST(EventsIo, PartialRead) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -119,7 +112,7 @@ TEST_F(EventsIo, PartialRead) {
 	EXPECT_EQ(to_receive, to_send);
 }
 
-TEST_F(EventsIo, PartialWrite) {
+TEST(EventsIo, PartialWrite) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -171,7 +164,7 @@ TEST_F(EventsIo, PartialWrite) {
 	EXPECT_EQ(to_receive, to_send);
 }
 
-TEST_F(EventsIo, Errors) {
+TEST(EventsIo, Errors) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -201,7 +194,7 @@ TEST_F(EventsIo, Errors) {
 	EXPECT_EQ(err.code, make_error_condition(errc::invalid_argument));
 }
 
-TEST_F(EventsIo, CloseWriter) {
+TEST(EventsIo, CloseWriter) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -225,7 +218,7 @@ TEST_F(EventsIo, CloseWriter) {
 	loop.Run();
 }
 
-TEST_F(EventsIo, CloseReader) {
+TEST(EventsIo, CloseReader) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -249,7 +242,7 @@ TEST_F(EventsIo, CloseReader) {
 	loop.Run();
 }
 
-TEST_F(EventsIo, CancelWrite) {
+TEST(EventsIo, CancelWrite) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -280,7 +273,7 @@ TEST_F(EventsIo, CancelWrite) {
 	loop.Run();
 }
 
-TEST_F(EventsIo, CancelRead) {
+TEST(EventsIo, CancelRead) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -318,7 +311,7 @@ TEST_F(EventsIo, CancelRead) {
 	EXPECT_TRUE(in_write);
 }
 
-TEST_F(EventsIo, FileOpen) {
+TEST(EventsIo, FileOpen) {
 	mtesting::TemporaryDirectory tmpdir;
 	TestEventLoop loop;
 	string tmpfile = path::Join(tmpdir.Path(), "file");
@@ -361,7 +354,7 @@ TEST_F(EventsIo, FileOpen) {
 	EXPECT_EQ(string(recv.begin(), recv.begin() + 5), "stuff");
 }
 
-TEST_F(EventsIo, FileOpenErrors) {
+TEST(EventsIo, FileOpenErrors) {
 	TestEventLoop loop;
 	mtesting::TemporaryDirectory tmpdir;
 	string tmpfile = tmpdir.Path() + "does/not/exist";
@@ -377,7 +370,7 @@ TEST_F(EventsIo, FileOpenErrors) {
 	EXPECT_EQ(err.code, make_error_condition(errc::no_such_file_or_directory));
 }
 
-TEST_F(EventsIo, DestroyWriterBeforeHandlerIsCalled) {
+TEST(EventsIo, DestroyWriterBeforeHandlerIsCalled) {
 	TestEventLoop loop;
 
 	int fds[2];
@@ -408,7 +401,7 @@ TEST_F(EventsIo, DestroyWriterBeforeHandlerIsCalled) {
 	loop.Run();
 }
 
-TEST_F(EventsIo, DestroyReaderBeforeHandlerIsCalled) {
+TEST(EventsIo, DestroyReaderBeforeHandlerIsCalled) {
 	TestEventLoop loop;
 
 	int fds[2];

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -143,11 +143,7 @@ static void SetupLoggerAttributes() {
 }
 
 Logger::Logger(const string &name) :
-	name_(name),
-	level_(global_logger_.Level()) {
-	src::severity_logger<LogLevel> slg;
-	slg.add_attribute("Name", attrs::constant<std::string>(name));
-	this->logger = slg;
+	Logger(name, global_logger_.Level()) {
 }
 
 Logger::Logger(const string &name, LogLevel level) :

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -174,7 +174,11 @@ void Logger::AddField(const LogField &field) {
 Logger Setup() {
 	SetupLoggerSinks();
 	SetupLoggerAttributes();
+#ifdef NDEBUG
 	return Logger("Global", LogLevel::Info);
+#else
+	return Logger("Global", LogLevel::Debug);
+#endif
 }
 
 Logger global_logger_ = Setup();

--- a/common/log_test.cpp
+++ b/common/log_test.cpp
@@ -49,8 +49,13 @@ TEST_F(LogTestEnv, SetLogLevel) {
 TEST_F(LogTestEnv, GlobalLoggerSetLogLevel) {
 	namespace log = mender::common::log;
 
+#ifdef NDEBUG
 	EXPECT_EQ(log::LogLevel::Info, logger.Level())
 		<< "Unexpected standard LogLevel - should be Info";
+#else
+	EXPECT_EQ(log::LogLevel::Debug, logger.Level())
+		<< "Unexpected standard LogLevel - should be Info";
+#endif
 	log::SetLevel(log::LogLevel::Warning);
 	EXPECT_EQ(log::LogLevel::Warning, log::Level());
 

--- a/common/log_test.cpp
+++ b/common/log_test.cpp
@@ -45,23 +45,6 @@ TEST_F(LogTestEnv, SetLogLevel) {
 	EXPECT_EQ(log::LogLevel::Warning, logger.Level());
 }
 
-
-TEST_F(LogTestEnv, GlobalLoggerSetLogLevel) {
-	namespace log = mender::common::log;
-
-#ifdef NDEBUG
-	EXPECT_EQ(log::LogLevel::Info, logger.Level())
-		<< "Unexpected standard LogLevel - should be Info";
-#else
-	EXPECT_EQ(log::LogLevel::Debug, logger.Level())
-		<< "Unexpected standard LogLevel - should be Info";
-#endif
-	log::SetLevel(log::LogLevel::Warning);
-	EXPECT_EQ(log::LogLevel::Warning, log::Level());
-
-	log::SetLevel(log::LogLevel::Info);
-}
-
 TEST_F(LogTestEnv, LogLevelFilter) {
 	namespace log = mender::common::log;
 	testing::internal::CaptureStderr();

--- a/common/main_test.cpp
+++ b/common/main_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <common/log.hpp>
+#include <common/setup.hpp>
+
+using namespace testing;
+
+class GlobalTestEnvironment : public ::testing::Environment {
+public:
+	void SetUp() override {
+		mender::common::setup::GlobalSetup();
+		mender::common::log::SetLevel(mender::common::log::LogLevel::Trace);
+	}
+};
+
+int main(int argc, char **argv) {
+	printf("Running mender_test::main\n");
+
+	::testing::AddGlobalTestEnvironment(new GlobalTestEnvironment);
+	::testing::InitGoogleTest(&argc, argv);
+
+	return RUN_ALL_TESTS();
+}

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(mender_context PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BI
 target_link_libraries(mender_context PUBLIC common_error common_key_value_database common_conf common_json common_path)
 
 add_executable(context_test EXCLUDE_FROM_ALL context_test.cpp)
-target_link_libraries(context_test PUBLIC mender_context common_testing GTest::gtest_main gmock)
+target_link_libraries(context_test PUBLIC mender_context common_testing main_test gmock)
 target_include_directories(context_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(context_test)
 add_dependencies(check context_test)
@@ -29,7 +29,7 @@ install(TARGETS mender-update
 )
 
 add_executable(update_module_test EXCLUDE_FROM_ALL update_module/v3/update_module_test.cpp)
-target_link_libraries(update_module_test PUBLIC update_module common_testing GTest::gtest_main gmock)
+target_link_libraries(update_module_test PUBLIC update_module common_testing main_test gmock)
 target_include_directories(update_module_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(update_module_test)
 add_dependencies(check update_module_test)


### PR DESCRIPTION
This means we can call setup and teardown functions for the entire test framework.

For now we only set the log-level to `Trace` for all the tests.

I also did some minor fixes to the logger, feel free to reject any of these at will. I can also move it to a separate PR if you want.