### PR TITLE
feat(artifact): Add the logic layer for use of the actual parsed artifacts

### DIFF
--- a/artifact/CMakeLists.txt
+++ b/artifact/CMakeLists.txt
@@ -38,3 +38,7 @@ target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(artifact_parser_test PRIVATE ${CMAKE_SOURCE_DIR}/artifact)
 gtest_discover_tests(artifact_parser_test)
 add_dependencies(check artifact_parser_test)
+
+add_library(artifact STATIC artifact.cpp)
+target_link_libraries(artifact PUBLIC artifact_parser)
+target_include_directories(artifact PUBLIC ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/artifact/ ${CMAKE_BINARY_DIR})

--- a/artifact/artifact.cpp
+++ b/artifact/artifact.cpp
@@ -1,0 +1,51 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/artifact.hpp>
+
+#include <common/error.hpp>
+#include <common/expected.hpp>
+
+#include <artifact/error.hpp>
+
+
+namespace mender {
+namespace artifact {
+
+namespace error = mender::common::error;
+namespace expected = mender::common::expected;
+
+
+ExpectedMetaData View(parser::Artifact &artifact, size_t index) {
+	// Check if the inex is available
+	if (artifact.header.info.payloads.size() > index) {
+		return expected::unexpected(
+			parser_error::MakeError(parser_error::Code::ParseError, "Payload index out of range"));
+	}
+	return MetaData {
+		.version = artifact.version.version,
+		.header =
+			Header {
+				.artifact_group = artifact.header.info.provides.artifact_group.value_or(""),
+				.artifact_name = artifact.header.info.provides.artifact_name,
+				.payload_type = artifact.header.info.payloads.at(index).name,
+				.header_info = artifact.header.info.verbatim,
+				.type_info = artifact.header.subHeaders.at(index).type_info.verbatim,
+				// TODO - meta-data
+				// .meta_data = artifact.header.subHeaders.at(index).metadata.verbatim,
+			},
+	};
+};
+} // namespace artifact
+} // namespace mender

--- a/artifact/artifact.hpp
+++ b/artifact/artifact.hpp
@@ -1,0 +1,58 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_ARTIFACT_HPP_
+#define MENDER_ARTIFACT_HPP_
+
+#include <string>
+
+#include <common/json.hpp>
+
+#include <artifact/parser.hpp>
+
+namespace mender {
+namespace artifact {
+
+using namespace std;
+
+namespace error = mender::common::error;
+namespace expected = mender::common::expected;
+namespace json = mender::common::json;
+
+using error::Error;
+
+struct Header {
+	string artifact_group;
+	string artifact_name;
+	string payload_type;
+	json::Json header_info;
+	json::Json type_info;
+	json::Json meta_data;
+};
+
+struct MetaData {
+	int version;
+	Header header;
+};
+
+using ExpectedMetaData = expected::expected<MetaData, error::Error>;
+
+// View is giving the meta-data view of a given payload index
+ExpectedMetaData View(parser::Artifact &artifact, size_t index);
+
+} // namespace artifact
+} // namespace mender
+
+
+#endif // MENDER_ARTIFACT_HPP_

--- a/artifact/v3/header/CMakeLists.txt
+++ b/artifact/v3/header/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(artifact_header_parser_test PRIVATE
   common_json
   common_testing
   common_processes
-  common_conf
+  common_path
   main_test
   gmock
 )

--- a/artifact/v3/header/header.hpp
+++ b/artifact/v3/header/header.hpp
@@ -24,6 +24,7 @@
 #include <common/expected.hpp>
 #include <common/error.hpp>
 #include <common/io.hpp>
+#include <common/json.hpp>
 
 #include <artifact/config.hpp>
 
@@ -39,6 +40,8 @@ namespace optional = mender::common::optional;
 namespace expected = mender::common::expected;
 namespace io = mender::common::io;
 namespace error = mender::common::error;
+namespace json = mender::common::json;
+
 
 //
 // +---header-info
@@ -70,6 +73,7 @@ struct Info {
 	vector<PayloadType> payloads;
 	Provides provides;
 	Depends depends;
+	json::Json verbatim;
 };
 
 using ExpectedHeaderInfo = expected::expected<header::Info, error::Error>;
@@ -110,9 +114,12 @@ struct TypeInfo {
 	optional::optional<unordered_map<string, string>> artifact_provides;
 	optional::optional<unordered_map<string, string>> artifact_depends;
 	optional::optional<vector<string>> clears_artifact_provides;
+	json::Json verbatim;
 };
 
-struct MetaData {};
+struct MetaData {
+	string verbatim;
+};
 
 struct SubHeader {
 	TypeInfo type_info {};

--- a/artifact/v3/header/header_info.cpp
+++ b/artifact/v3/header/header_info.cpp
@@ -89,6 +89,7 @@ ExpectedHeaderInfo Parse(io::Reader &reader) {
 	}
 
 	const auto header_info_json = expected_json.value();
+	info.verbatim = header_info_json;
 
 	//
 	// Payloads (required)

--- a/artifact/v3/header/type_info.cpp
+++ b/artifact/v3/header/type_info.cpp
@@ -55,6 +55,8 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	}
 
 	const json::Json type_info_json = expected_json.value();
+	type_info.verbatim = type_info_json;
+
 
 	//
 	// Parse the single payload_type key:value (required)


### PR DESCRIPTION
This adds the logic wrapper around the pure parser logic in the artifact/parser.hpp file, and should be the interface used to parse and interacting with Artifact data.

Ticket: MEN-6209
Changelog: None
