### PR TITLE
feat(artifact/payload): Support multiple files read in each payload

### DIFF
--- a/artifact/error.hpp
+++ b/artifact/error.hpp
@@ -31,6 +31,7 @@ enum Code {
 	NoError = 0,
 	ParseError,
 	TypeError,
+	NoMorePayloadFilesError,
 	EOFError,
 };
 

--- a/artifact/parser.cpp
+++ b/artifact/parser.cpp
@@ -117,14 +117,14 @@ ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig config) {
 };
 
 
-ExpectedPayloadReader Artifact::Next() {
+ExpectedPayload Artifact::Next() {
 	// Currently only one payload supported
 	if (payload_index_ != 0) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::EOFError, "Reached the end of the Artifact"));
 	}
 	payload_index_++;
-	return payload::Verify(*(this->lexer_.current.value), this->manifest.Get("data/0000.tar"));
+	return payload::Payload(*(this->lexer_.current.value), manifest);
 }
 
 } // namespace parser

--- a/artifact/parser.hpp
+++ b/artifact/parser.hpp
@@ -57,7 +57,7 @@ using Header = mender::artifact::v3::header::Header;
 
 namespace payload = mender::artifact::v3::payload;
 
-using ExpectedPayloadReader = expected::expected<payload::Reader, error::Error>;
+using ExpectedPayload = expected::expected<payload::Payload, error::Error>;
 
 // Structure to hold the contents of a Mender artifact file.
 class Artifact {
@@ -71,7 +71,7 @@ public:
 	// manifest::sig::ManifestSignature manifest_sig {}; // Unused
 	Header header;
 
-	ExpectedPayloadReader Next();
+	ExpectedPayload Next();
 
 	Artifact(
 		Version &version,

--- a/artifact/v3/payload/CMakeLists.txt
+++ b/artifact/v3/payload/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Test the parser
 add_executable(artifact_payload_parser_test EXCLUDE_FROM_ALL
   payload.cpp
+  ${CMAKE_SOURCE_DIR}/artifact/v3/manifest/manifest.cpp
+  ${CMAKE_SOURCE_DIR}/artifact/error.cpp
   payload_test.cpp
 )
 target_link_libraries(artifact_payload_parser_test PRIVATE

--- a/artifact/v3/payload/payload_test.cpp
+++ b/artifact/v3/payload/payload_test.cpp
@@ -21,6 +21,7 @@
 #include <gmock/gmock.h>
 
 #include <artifact/tar/tar.hpp>
+#include <artifact/v3/manifest/manifest.hpp>
 
 #include <common/processes.hpp>
 #include <common/testing.hpp>
@@ -33,6 +34,8 @@ namespace tar = mender::tar;
 namespace processes = mender::common::processes;
 namespace mendertesting = mender::common::testing;
 namespace payload = mender::artifact::v3::payload;
+namespace manifest = mender::artifact::v3::manifest;
+
 
 class PayloadTestEnv : public testing::Test {
 public:
@@ -42,12 +45,18 @@ protected:
 
     DIRNAME=$(dirname $0)
 
-		# Create small tar payload file
-		echo foobar > ${DIRNAME}/testdata
-		tar cvf ${DIRNAME}/test.tar ${DIRNAME}/testdata
+    mkdir --parents data/0000
 
-		exit 0
-		)";
+    # Create small tar payload file
+    echo foobar > data/0000/testdata
+    tar cvf ${DIRNAME}/test.tar data/0000/testdata
+
+    # Create a tar with multiple files
+    echo barbaz > data/0000/testdata2
+    tar cvf ${DIRNAME}/multiple-files-payload.tar data/0000/testdata data/0000/testdata2
+
+    exit 0
+    )";
 
 		const string script_fname = tmpdir->Path() + "/test-script.sh";
 
@@ -80,20 +89,18 @@ TEST_F(PayloadTestEnv, TestPayloadSuccess) {
 
 	mender::common::io::StreamReader sr {fs};
 
-	mender::tar::Reader tar_reader {sr};
+	manifest::Manifest manifest {
+		{{"data/0000/testdata",
+		  "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f"}}};
 
-	mender::tar::Entry tar_entry = tar_reader.Next().value();
+	auto payload = payload::Payload(sr, manifest);
 
-	ASSERT_THAT(tar_entry.Name(), testing::EndsWith("testdata"));
-
-	payload::Reader p = payload::Verify(
-		tar_entry, "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f");
+	auto expected_payload = payload.Next();
+	ASSERT_TRUE(expected_payload);
 
 	auto discard_writer = io::Discard {};
-
-	auto err = io::Copy(discard_writer, p);
-
-	EXPECT_EQ(error::NoError, err) << "Got unexpected error: " << err.message;
+	auto err = io::Copy(discard_writer, expected_payload.value());
+	EXPECT_EQ(error::NoError, err);
 }
 
 TEST_F(PayloadTestEnv, TestPayloadFailure) {
@@ -101,20 +108,58 @@ TEST_F(PayloadTestEnv, TestPayloadFailure) {
 
 	mender::common::io::StreamReader sr {fs};
 
-	mender::tar::Reader tar_reader {sr};
+	manifest::Manifest manifest {
+		{{"data/0000/testdata",
+		  // Ends with (e) not (f)
+		  "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019e"}}};
 
-	mender::tar::Entry tar_entry = tar_reader.Next().value();
+	auto payload = payload::Payload(sr, manifest);
 
-	ASSERT_THAT(tar_entry.Name(), testing::EndsWith("testdata"));
-
-	payload::Reader p = payload::Verify(
-		tar_entry,
-		// Ends with (e) not (f)
-		"aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019e");
+	auto expected_payload = payload.Next();
+	ASSERT_TRUE(expected_payload);
 
 	auto discard_writer = io::Discard {};
-
-	auto err = io::Copy(discard_writer, p);
-
+	auto err = io::Copy(discard_writer, expected_payload.value());
 	EXPECT_NE(error::NoError, err);
+}
+
+TEST_F(PayloadTestEnv, TestPayloadMultipleFiles) {
+	std::fstream fs {tmpdir->Path() + "/multiple-files-payload.tar"};
+
+	mender::common::io::StreamReader reader {fs};
+
+	manifest::Manifest manifest {
+		{{"data/0000/testdata", "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f"},
+		 {"data/0000/testdata2",
+		  "73a2c64f9545172c1195efb6616ca5f7afd1df6f245407cafb90de3998a1c97f"}}};
+
+	auto p = payload::Payload(reader, manifest);
+
+	auto expected_payload = p.Next();
+	ASSERT_TRUE(expected_payload);
+
+	auto payload_reader {expected_payload.value()};
+
+	EXPECT_EQ(payload_reader.Name(), "data/0000/testdata");
+	EXPECT_EQ(payload_reader.Size(), 7);
+
+	auto discard_writer = io::Discard {};
+	auto err = io::Copy(discard_writer, payload_reader);
+	EXPECT_EQ(error::NoError, err);
+
+	expected_payload = p.Next();
+	EXPECT_TRUE(expected_payload);
+
+	payload_reader = expected_payload.value();
+
+	EXPECT_EQ(payload_reader.Name(), "data/0000/testdata2");
+	EXPECT_EQ(payload_reader.Size(), 7);
+
+	discard_writer = io::Discard {};
+	err = io::Copy(discard_writer, payload_reader);
+	EXPECT_EQ(error::NoError, err);
+
+	expected_payload = p.Next();
+	EXPECT_FALSE(expected_payload);
+	EXPECT_EQ(expected_payload.error().message, "Reached the end of the archive");
 }


### PR DESCRIPTION
This adds support for reading multiple files from each payload.

The solution is just an extension of the existing `Next()` interface, so that
now:

```
artifact::Parse() -> artifact

artifact.Next() -> Payload

Payload.Next() -> payload::Reader

...

Payload.Next() -> NoMorePayloadFilesError
```

Hence, each payload, and each file in the given payload can be processed in
turn.

The reader verifies the checksum of the given file as it is consumed, and
returns an error if there is a checksum mismatch.

The `payload::Reader` also has accessors for getting the `filename` and the
`size` of the given file.

Ticket: MEN-6452
Changelog: None