### PR TITLE
refac(artifact): Add the Parse interface to the toplevel artifact::

### DIFF
--- a/artifact/artifact.cpp
+++ b/artifact/artifact.cpp
@@ -27,6 +27,10 @@ namespace error = mender::common::error;
 namespace expected = mender::common::expected;
 
 
+ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig conf) {
+	return parser::Parse(reader, conf);
+}
+
 ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index) {
 	// Check if the index is available
 	if (index >= artifact.header.info.payloads.size()) {

--- a/artifact/artifact.hpp
+++ b/artifact/artifact.hpp
@@ -18,8 +18,10 @@
 #include <string>
 
 #include <common/json.hpp>
+#include <common/io.hpp>
 
 #include <artifact/parser.hpp>
+#include <artifact/config.hpp>
 
 namespace mender {
 namespace artifact {
@@ -29,8 +31,17 @@ using namespace std;
 namespace error = mender::common::error;
 namespace expected = mender::common::expected;
 namespace json = mender::common::json;
+namespace io = mender::common::io;
 
 using error::Error;
+
+using artifact::parser::Artifact;
+
+using ExpectedArtifact = expected::expected<Artifact, error::Error>;
+
+ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig conf = {});
+
+using namespace mender::artifact::v3::payload;
 
 struct HeaderView {
 	string artifact_group;
@@ -53,7 +64,7 @@ using ExpectedPayloadHeaderView = expected::expected<PayloadHeaderView, error::E
 // This means that a PayloadHeaderView is the union of the global header-info,
 // and the type-info for the given payload. A view will never leak information
 // which is dedicated to another payload (given by it's index).
-ExpectedPayloadHeaderView View(parser::Artifact &artifact, size_t index);
+ExpectedPayloadHeaderView View(Artifact &artifact, size_t index);
 
 } // namespace artifact
 } // namespace mender

--- a/artifact/config.hpp
+++ b/artifact/config.hpp
@@ -19,7 +19,6 @@
 
 namespace mender {
 namespace artifact {
-namespace parser {
 namespace config {
 
 using namespace std;
@@ -29,7 +28,6 @@ struct ParserConfig {
 };
 
 } // namespace config
-} // namespace parser
 } // namespace artifact
 } // namespace mender
 

--- a/artifact/v3/header/header.hpp
+++ b/artifact/v3/header/header.hpp
@@ -171,7 +171,7 @@ struct Header {
 
 using ExpectedHeader = expected::expected<Header, error::Error>;
 
-using ParserConfig = artifact::parser::config::ParserConfig;
+using ParserConfig = artifact::config::ParserConfig;
 
 ExpectedHeader Parse(io::Reader &reader, ParserConfig conf = {"./"});
 

--- a/artifact/v3/header/header_test.cpp
+++ b/artifact/v3/header/header_test.cpp
@@ -162,7 +162,7 @@ TEST_F(HeaderTestEnv, TestHeaderRootfsAllFlagsSetSuccess) {
 	mender::common::io::StreamReader sr {fs};
 
 	ExpectedHeader expected_header =
-		header::Parse(sr, mender::artifact::parser::config::ParserConfig {tmpdir.Path()});
+		header::Parse(sr, mender::artifact::config::ParserConfig {tmpdir.Path()});
 
 	ASSERT_TRUE(expected_header) << expected_header.error().message;
 
@@ -266,7 +266,7 @@ TEST_F(HeaderTestEnv, TestHeaderModuleImageAllFlagsSetSuccess) {
 	mender::common::io::StreamReader sr {fs};
 
 	ExpectedHeader expected_header =
-		header::Parse(sr, mender::artifact::parser::config::ParserConfig {tmpdir.Path()});
+		header::Parse(sr, mender::artifact::config::ParserConfig {tmpdir.Path()});
 
 	ASSERT_TRUE(expected_header) << expected_header.error().message;
 

--- a/mender-update/update_module/v3/update_module.hpp
+++ b/mender-update/update_module/v3/update_module.hpp
@@ -42,7 +42,7 @@ using context::MenderContext;
 using error::Error;
 using expected::ExpectedBool;
 using expected::ExpectedStringVector;
-using mender::artifact::parser::Artifact;
+using mender::artifact::Artifact;
 
 enum class RebootAction { No, Automatic, Yes };
 

--- a/mender-update/update_module/v3/update_module_test.cpp
+++ b/mender-update/update_module/v3/update_module_test.cpp
@@ -200,9 +200,9 @@ public:
 		ASSERT_TRUE(CreateArtifact());
 		std::fstream fs {path::Join(temp_dir.Path(), "artifact.mender")};
 		io::StreamReader sr {fs};
-		auto expected_artifact = mender::artifact::parser::Parse(sr);
+		auto expected_artifact = mender::artifact::Parse(sr);
 		ASSERT_TRUE(expected_artifact);
-		auto artifact = expected_artifact.value();
+		mender::artifact::Artifact artifact = expected_artifact.value();
 
 		auto expected_payload_header = mender::artifact::View(artifact, 0);
 		ASSERT_TRUE(expected_payload_header) << expected_payload_header.error().message;


### PR DESCRIPTION
`parser::` should not be exposed outside of the artifact:: namespace. Hence we alias the `parser::Artifact`, and wrap the `Next` method, to provide the top-level interface in `artifact`.

