### PR TITLE
Fix artifact payload name bug

### DIFF
--- a/artifact/parser_test.cpp
+++ b/artifact/parser_test.cpp
@@ -178,7 +178,7 @@ TEST_F(ParserTestEnv, TestParseMultipleFilesInPayload) {
 
 	auto discard_writer = io::Discard {};
 	auto err = io::Copy(discard_writer, payload_reader);
-	EXPECT_NE(error::NoError, err);
+	EXPECT_EQ(error::NoError, err);
 
 	expected_payload_file = payload.Next();
 	EXPECT_TRUE(expected_payload_file);
@@ -190,7 +190,7 @@ TEST_F(ParserTestEnv, TestParseMultipleFilesInPayload) {
 
 	discard_writer = io::Discard {};
 	err = io::Copy(discard_writer, payload_reader);
-	EXPECT_NE(error::NoError, err);
+	EXPECT_EQ(error::NoError, err);
 
 	expected_payload_file = payload.Next();
 	ASSERT_FALSE(expected_payload_file);

--- a/artifact/v3/payload/payload.cpp
+++ b/artifact/v3/payload/payload.cpp
@@ -43,7 +43,7 @@ ExpectedPayloadReader Payload::Next() {
 			parser_error::Code::ParseError, expected_tar_entry.error().message));
 	}
 	auto tar_entry {expected_tar_entry.value()};
-	return Reader {move(tar_entry), manifest_.Get(tar_entry.Name())};
+	return Reader {move(tar_entry), manifest_.Get("data/0000/" + tar_entry.Name())};
 }
 
 } // namespace payload

--- a/artifact/v3/payload/payload_test.cpp
+++ b/artifact/v3/payload/payload_test.cpp
@@ -45,15 +45,13 @@ protected:
 
     DIRNAME=$(dirname $0)
 
-    mkdir --parents data/0000
-
     # Create small tar payload file
-    echo foobar > data/0000/testdata
-    tar cvf ${DIRNAME}/test.tar data/0000/testdata
+    echo foobar > testdata
+    tar cvf ${DIRNAME}/test.tar testdata
 
     # Create a tar with multiple files
-    echo barbaz > data/0000/testdata2
-    tar cvf ${DIRNAME}/multiple-files-payload.tar data/0000/testdata data/0000/testdata2
+    echo barbaz > testdata2
+    tar cvf ${DIRNAME}/multiple-files-payload.tar testdata testdata2
 
     exit 0
     )";
@@ -140,7 +138,7 @@ TEST_F(PayloadTestEnv, TestPayloadMultipleFiles) {
 
 	auto payload_reader {expected_payload.value()};
 
-	EXPECT_EQ(payload_reader.Name(), "data/0000/testdata");
+	EXPECT_EQ(payload_reader.Name(), "testdata");
 	EXPECT_EQ(payload_reader.Size(), 7);
 
 	auto discard_writer = io::Discard {};
@@ -152,7 +150,7 @@ TEST_F(PayloadTestEnv, TestPayloadMultipleFiles) {
 
 	payload_reader = expected_payload.value();
 
-	EXPECT_EQ(payload_reader.Name(), "data/0000/testdata2");
+	EXPECT_EQ(payload_reader.Name(), "testdata2");
 	EXPECT_EQ(payload_reader.Size(), 7);
 
 	discard_writer = io::Discard {};


### PR DESCRIPTION
Quick fix for the bug with the payload name.

I simply hard-coded the name. We do not support multiple payloads at the moment anyways.