### PR TITLE
fix(tar): Narrowing conversion from la_int_64_t to ssize_t

### DIFF
--- a/artifact/tar/platform/libarchive/tar.cpp
+++ b/artifact/tar/platform/libarchive/tar.cpp
@@ -111,7 +111,7 @@ ExpectedEntry Reader::Next() {
 			MakeError(TarReaderError, "Failed to get the name of the archive entry"));
 	}
 
-	const ssize_t archive_entry_size_ {archive_entry_size(current_entry)};
+	const la_int64_t archive_entry_size_ {archive_entry_size(current_entry)};
 	if (archive_entry_size_ < 0) {
 		return expected::unexpected(
 			MakeError(TarReaderError, "Failed to get the size of the archive"));


### PR DESCRIPTION
Ticket: None
Changelog: None

