### PR TITLE
build(ubuntu-focal): Remove CMake v3.17 import libarchive target

### DIFF
--- a/artifact/tar/CMakeLists.txt
+++ b/artifact/tar/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT LibArchive_FOUND)
 endif()
 
 target_link_libraries(common_tar PUBLIC
-  LibArchive::LibArchive
+  ${LibArchive_LIBRARIES}
   common_error
   common_log
   common_io


### PR DESCRIPTION
According to the documentation:

https://cmake.org/cmake/help/latest/module/FindLibArchive.html

The LibArchive::LibArchive call is added in CMake v3.17.

Since Ubuntu Focal, have 3.16 available, this will not link properly.

Ticket: MEN-6395


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
