### PR TITLE
Enable initialization of our IO classes with shared pointers

### DIFF
--- a/common/io.cpp
+++ b/common/io.cpp
@@ -70,7 +70,7 @@ void ByteWriter::SetUnlimited(bool enabled) {
 ExpectedSize ByteWriter::Write(
 	vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
 	assert(end > start);
-	Vsize max_write {receiver_.size() - bytes_written_};
+	Vsize max_write {receiver_->size() - bytes_written_};
 	if (max_write == 0 && !unlimited_) {
 		return expected::unexpected(Error(make_error_condition(errc::no_space_on_device), ""));
 	}
@@ -79,13 +79,13 @@ ExpectedSize ByteWriter::Write(
 	if (unlimited_) {
 		bytes_to_write = iterator_size;
 		if (max_write < bytes_to_write) {
-			receiver_.resize(bytes_written_ + bytes_to_write);
+			receiver_->resize(bytes_written_ + bytes_to_write);
 			max_write = bytes_to_write;
 		}
 	} else {
 		bytes_to_write = min(iterator_size, max_write);
 	}
-	auto it = next(receiver_.begin(), bytes_written_);
+	auto it = next(receiver_->begin(), bytes_written_);
 	std::copy_n(start, bytes_to_write, it);
 	bytes_written_ += bytes_to_write;
 	return bytes_to_write;
@@ -94,8 +94,8 @@ ExpectedSize ByteWriter::Write(
 
 ExpectedSize StreamWriter::Write(
 	vector<uint8_t>::const_iterator start, vector<uint8_t>::const_iterator end) {
-	os_.write(reinterpret_cast<const char *>(&*start), end - start);
-	if (!os_) {
+	os_->write(reinterpret_cast<const char *>(&*start), end - start);
+	if (!(*(os_.get()))) {
 		return expected::unexpected(Error(make_error_condition(errc::io_error), ""));
 	}
 	return end - start;

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -173,12 +173,16 @@ using Vsize = vector<uint8_t>::size_type;
 
 class ByteWriter : virtual public Writer {
 private:
-	vector<uint8_t> &receiver_;
+	shared_ptr<vector<uint8_t>> receiver_;
 	Vsize bytes_written_ {0};
 	bool unlimited_ {false};
 
 public:
 	ByteWriter(vector<uint8_t> &receiver) :
+		receiver_(&receiver, [](vector<uint8_t> *vec) {}) {
+	}
+
+	ByteWriter(shared_ptr<vector<uint8_t>> &receiver) :
 		receiver_ {receiver} {
 	}
 
@@ -192,13 +196,13 @@ public:
 
 class StreamWriter : virtual public Writer {
 private:
-	std::ostream &os_;
+	shared_ptr<std::ostream> os_;
 
 public:
 	StreamWriter(std::ostream &stream) :
-		os_ {stream} {
+		os_(&stream, [](std::ostream *str) {}) {
 	}
-	StreamWriter(std::ostream &&stream) :
+	StreamWriter(shared_ptr<std::ostream> &stream) :
 		os_ {stream} {
 	}
 	ExpectedSize Write(

--- a/common/io_test.cpp
+++ b/common/io_test.cpp
@@ -250,6 +250,33 @@ TEST(IO, TestStringReader) {
 	ASSERT_EQ(error::NoError, err);
 }
 
+TEST(IO, TestByteWriter) {
+	auto string_reader = io::StringReader("foobar");
+
+	vector<uint8_t> vec {};
+	auto byte_writer = io::ByteWriter(vec);
+	byte_writer.SetUnlimited(true);
+
+	auto err = Copy(byte_writer, string_reader);
+	ASSERT_EQ(error::NoError, err);
+
+	EXPECT_EQ(vec, (vector<uint8_t> {'f', 'o', 'o', 'b', 'a', 'r'}));
+
+	string_reader = io::StringReader("tadow!");
+	io::ByteWriter *byte_writer2;
+	{
+		auto vec2 = make_shared<vector<uint8_t>>();
+		byte_writer2 = new io::ByteWriter(vec2);
+		byte_writer2->SetUnlimited(true);
+	}
+	// vec2 out of scope, but it's a shared pointer and byte_writer2 should
+	// still have access to it so there should be no errors
+	err = Copy(*byte_writer2, string_reader);
+	ASSERT_EQ(error::NoError, err);
+
+	delete byte_writer2;
+}
+
 class StreamIOTests : public testing::Test {
 protected:
 	TemporaryDirectory tmp_dir;


### PR DESCRIPTION
Important in the async code where instances of these classes outlive the scopes in which the objects they use where created/defined.