### PR TITLE
fix(http): Set the HOST header for all HTTP requests

### DIFF
--- a/common/http/platform/beast/http.cpp
+++ b/common/http/platform/beast/http.cpp
@@ -134,6 +134,10 @@ error::Error Client::AsyncCall(
 
 	logger_ = log::Logger("http_client").WithFields(log::LogField("url", req->orig_address_));
 
+	// NOTE: The AWS loadbalancer requires that the HOST header always be set, in order for the
+	// request to route to our k8s cluster. Set this in all cases.
+	req->SetHeader("HOST", req->address_.host);
+
 	request_ = req;
 	header_handler_ = header_handler;
 	body_handler_ = body_handler;

--- a/common/http_test.cpp
+++ b/common/http_test.cpp
@@ -1326,8 +1326,8 @@ TEST(HTTPSTest, CorrectDefaultCertificateStoreVerification) {
 		[&client_hit_header](http::ExpectedIncomingResponsePtr exp_resp) {
 			ASSERT_TRUE(exp_resp) << "Error message: " << exp_resp.error().String();
 			auto resp = exp_resp.value();
-			EXPECT_EQ(resp->GetStatusCode(), 200);
-			EXPECT_EQ(resp->GetStatusMessage(), "OK");
+			EXPECT_EQ(resp->GetStatusCode(), 301);
+			EXPECT_EQ(resp->GetStatusMessage(), "Moved Permanently");
 			client_hit_header = true;
 		},
 		[&client_hit_body, &loop](http::ExpectedIncomingResponsePtr exp_resp) {


### PR DESCRIPTION
The AWS Loadbalancer will not route requests to our k8s cluster unless the `HOST` header is set in the request.

Therefore, this fix sets the header for all outgoing HTTP requests.

Ticket: None
Changelog: None
