### PR TITLE
chore: Construct IO objects from shared_ptr passed by value

### DIFF
--- a/common/io.hpp
+++ b/common/io.hpp
@@ -127,7 +127,7 @@ public:
 		// the object.
 		is_(&stream, [](std::istream *stream) {}) {
 	}
-	StreamReader(shared_ptr<std::istream> &stream) :
+	StreamReader(shared_ptr<std::istream> stream) :
 		is_ {stream} {
 	}
 	ExpectedSize Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override;
@@ -183,7 +183,7 @@ public:
 		receiver_(&receiver, [](vector<uint8_t> *vec) {}) {
 	}
 
-	ByteWriter(shared_ptr<vector<uint8_t>> &receiver) :
+	ByteWriter(shared_ptr<vector<uint8_t>> receiver) :
 		receiver_ {receiver} {
 	}
 
@@ -203,7 +203,7 @@ public:
 	StreamWriter(std::ostream &stream) :
 		os_(&stream, [](std::ostream *str) {}) {
 	}
-	StreamWriter(shared_ptr<std::ostream> &stream) :
+	StreamWriter(shared_ptr<std::ostream> stream) :
 		os_ {stream} {
 	}
 	ExpectedSize Write(

--- a/common/io_test.cpp
+++ b/common/io_test.cpp
@@ -15,6 +15,7 @@
 #include <common/io.hpp>
 
 #include <cerrno>
+#include <functional>
 
 #include <common/testing.hpp>
 
@@ -273,6 +274,18 @@ TEST(IO, TestByteWriter) {
 	// still have access to it so there should be no errors
 	err = Copy(*byte_writer2, string_reader);
 	ASSERT_EQ(error::NoError, err);
+
+	auto vec3 = make_shared<vector<uint8_t>>();
+	function<bool()> some_fn = []() { return false; };
+	{
+		auto fn = [vec3]() {
+			auto writer = make_shared<io::ByteWriter>(vec3);
+			writer->SetUnlimited(true);
+			return true;
+		};
+		some_fn = fn;
+	}
+	EXPECT_EQ(some_fn(), true);
 }
 
 class StreamIOTests : public testing::Test {


### PR DESCRIPTION
A follow-up to bc4061daf8b725db94433227a11d00e46d89bc05 and 1bb88cdf8007a162b8a8ec3ae668f4b1a0c1b34c that added constructors from shared pointers passed by reference. If we capture shared pointers by copy, they cannot be passed further as references and thus we need constructors from shared pointers passed by value. However, having both variants (value and reference) makes the constructors ambiguous so we have to only provide the by-value constructors.

Ticket: MEN-6494
Changelog: none