### PR TITLE
chore(crypto): harvest the OpenSSL error message for all failed calls

### DIFF
--- a/common/crypto_test.cpp
+++ b/common/crypto_test.cpp
@@ -23,6 +23,8 @@
 
 using namespace std;
 
+using testing::StartsWith;
+
 namespace error = mender::common::error;
 
 namespace mender {
@@ -44,7 +46,8 @@ TEST(CryptoTest, TestKeyFileNotFound) {
 	string private_key_file = "./i-do-not-exist.pem";
 	auto expected_signature = crypto::Sign(private_key_file, {});
 	ASSERT_FALSE(expected_signature);
-	EXPECT_EQ(expected_signature.error().message, "Failed to open the private key file");
+	EXPECT_THAT(
+		expected_signature.error().message, StartsWith("Failed to open the private key file"));
 }
 
 TEST(CryptoTest, TestPublicKeyExtraction) {
@@ -60,7 +63,8 @@ TEST(CryptoTest, TestPublicKeyExtractionError) {
 	string private_key_file = "./i-do-not-exist.pem";
 	auto expected_public_key = crypto::ExtractPublicKey(private_key_file);
 	ASSERT_FALSE(expected_public_key);
-	EXPECT_EQ(expected_public_key.error().message, "Failed to open the private key file");
+	EXPECT_THAT(
+		expected_public_key.error().message, StartsWith("Failed to open the private key file"));
 }
 
 TEST(CryptoTest, TestEncodeDecodeBase64) {


### PR DESCRIPTION
Since the OpenSSL errors are stored in a queue, and harvested in a FIFO like fashion, it is important that we do harvest the messages upon every call which fails, otherwise the extraction will generate the wrong error messages.

