### PR TITLE
test: Work around Python:3.10 base image upgrade to Debian:12 (bookworm)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 variables:
   GOLANG_VERSION: "1.17.13"
   LICENSE_HEADERS_IGNORE_FILES_REGEXP: "./ltmain.sh"
+  DEBIAN_FRONTEND: noninteractive
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -41,16 +42,17 @@ test:
 
 test:modules-artifact-gen:
   stage: test
-  image: python:3.10
+  image: ubuntu:22.04
   before_script:
+    - apt update && apt install -yy $(cat support/modules-artifact-gen/tests/deb-requirements.txt)
     # mender-artifact
-    - curl https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
-      -o /usr/local/bin/mender-artifact
-    - chmod +x /usr/local/bin/mender-artifact
+    - curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc
+    - echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/jammy/stable main" | tee /etc/apt/sources.list.d/mender.list
+    - apt update && apt install -yy mender-artifact
     # Test dependencies
     - pip install -r support/modules-artifact-gen/tests/requirements.txt
   script:
-    - python -m pytest support/modules-artifact-gen/tests
+    - python3 -m pytest support/modules-artifact-gen/tests
 
 test:docker:
   image: docker

--- a/support/modules-artifact-gen/tests/deb-requirements.txt
+++ b/support/modules-artifact-gen/tests/deb-requirements.txt
@@ -1,0 +1,2 @@
+curl
+python3-pip


### PR DESCRIPTION
This is based on libssl3, and is therefore incompatible with the downloadable mender-artifact. The package for Ubuntu 22.04 is however compatible, so use that as an image instead.
