### PR TITLE
build(boost): Fix the Boost find_package variable

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -99,7 +99,7 @@ add_library(common_events STATIC
   events/platform/boost/events_io.cpp
 )
   # Note: Use SYSTEM include style, since Boost triggers some of our warnings.
-target_include_directories(common_events SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
+target_include_directories(common_events SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_compile_options(common_events PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_compile_definitions(common_events PUBLIC MENDER_USE_BOOST_ASIO=${MENDER_USE_BOOST_ASIO})
 target_link_libraries(common_events PUBLIC common_error)
@@ -124,7 +124,7 @@ endif()
 
 add_library(common_http STATIC http/http.cpp http/platform/beast/http.cpp)
   # Note: Use SYSTEM include style, since Boost triggers some of our warnings.
-target_include_directories(common_http SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
+target_include_directories(common_http SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_compile_options(common_http PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_link_libraries(common_http PUBLIC
   common


### PR DESCRIPTION
The real name is `Boost_INCLUDE_DIRS` with the trailing `S`.

The singular is a cache variable.

See the documentation for more.


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
