### PR TITLE
chore: Remove unneeded `EventLoop::Post` in `CheckNewDeployments`.

### DIFF
--- a/mender-update/deployments.hpp
+++ b/mender-update/deployments.hpp
@@ -60,7 +60,6 @@ error::Error CheckNewDeployments(
 	context::MenderContext &ctx,
 	const string &server_url,
 	http::Client &client,
-	events::EventLoop &loop,
 	CheckUpdatesAPIResponseHandler api_handler);
 
 enum class DeploymentStatus {
@@ -88,7 +87,6 @@ error::Error PushStatus(
 	const string &substate,
 	const string &server_url,
 	http::Client &client,
-	events::EventLoop &loop,
 	StatusAPIResponseHandler api_handler);
 
 } // namespace deployments

--- a/mender-update/deployments_test.cpp
+++ b/mender-update/deployments_test.cpp
@@ -129,7 +129,6 @@ TEST_F(DeploymentsTests, TestV2APIWithNextDeployment) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&response_data, &handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 			ASSERT_TRUE(resp);
@@ -216,7 +215,6 @@ TEST_F(DeploymentsTests, TestV2APIWithNoNextDeployment) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 			ASSERT_TRUE(resp);
@@ -302,7 +300,6 @@ TEST_F(DeploymentsTests, TestV2APIError) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 			ASSERT_FALSE(resp);
@@ -417,7 +414,6 @@ TEST_F(DeploymentsTests, TestV1APIFallbackWithNextDeployment) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&response_data, &handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 			ASSERT_TRUE(resp);
@@ -530,7 +526,6 @@ TEST_F(DeploymentsTests, TestV1APIFallbackWithNoNextDeployment) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 			ASSERT_TRUE(resp);
@@ -642,7 +637,6 @@ TEST_F(DeploymentsTests, TestV1APIFallbackWithError) {
 		ctx,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::CheckUpdatesAPIResponse resp) {
 			handler_called = true;
 
@@ -721,7 +715,6 @@ TEST_F(DeploymentsTests, PushStatusTest) {
 		substatus,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::StatusAPIResponse resp) {
 			handler_called = true;
 			EXPECT_EQ(resp, error::NoError);
@@ -794,7 +787,6 @@ TEST_F(DeploymentsTests, PushStatusNoSubstatusTest) {
 		substatus,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::StatusAPIResponse resp) {
 			handler_called = true;
 			EXPECT_EQ(resp, error::NoError);
@@ -867,7 +859,6 @@ TEST_F(DeploymentsTests, PushStatusFailureTest) {
 		substatus,
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](deps::StatusAPIResponse resp) {
 			handler_called = true;
 			EXPECT_NE(resp, error::NoError);

--- a/mender-update/inventory.cpp
+++ b/mender-update/inventory.cpp
@@ -73,7 +73,6 @@ error::Error PushInventoryData(
 	const string &inventory_generators_dir,
 	const string &server_url,
 	http::Client &client,
-	events::EventLoop &loop,
 	APIResponseHandler api_handler) {
 	auto ex_inv_data = inv_parser::GetInventoryData(inventory_generators_dir);
 	if (!ex_inv_data) {

--- a/mender-update/inventory.hpp
+++ b/mender-update/inventory.hpp
@@ -56,7 +56,6 @@ error::Error PushInventoryData(
 	const string &inventory_generators_dir,
 	const string &server_url,
 	http::Client &client,
-	events::EventLoop &loop,
 	APIResponseHandler api_handler);
 
 } // namespace inventory

--- a/mender-update/inventory_test.cpp
+++ b/mender-update/inventory_test.cpp
@@ -113,7 +113,6 @@ exit 0
 		test_scripts_dir.Path(),
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](error::Error err) {
 			handler_called = true;
 			ASSERT_EQ(err, error::NoError);
@@ -190,7 +189,6 @@ exit 0
 		test_scripts_dir.Path(),
 		"http://127.0.0.1:" TEST_PORT,
 		client,
-		loop,
 		[&handler_called, &loop](error::Error err) {
 			handler_called = true;
 			ASSERT_NE(err, error::NoError);


### PR DESCRIPTION
Doing this is unnecessary because the `AsyncCall()` that it performs is already an asynchronous call which will be posted on the event loop, so there is no need to post twice. This has the convenient side effect of getting rid of the `EventLoop` argument.

Also add error handling for the `AsyncCall()`, which was missing, and remove the loop argument from many API functions that don't actually use it.
