### PR TITLE
State saving functions

### DIFF
--- a/common/json.hpp
+++ b/common/json.hpp
@@ -138,6 +138,8 @@ using ExpectedKeyValueMap = expected::expected<KeyValueMap, error::Error>;
 ExpectedStringVector ToStringVector(const json::Json &j);
 ExpectedKeyValueMap ToKeyValuesMap(const json::Json &j);
 ExpectedString ToString(const json::Json &j);
+ExpectedInt64 ToInt(const json::Json &j);
+ExpectedBool ToBool(const json::Json &j);
 
 // Template which we specialize for the given type in the platform dependent implementation
 template <typename DataType>

--- a/common/json/json.cpp
+++ b/common/json/json.cpp
@@ -147,6 +147,14 @@ ExpectedKeyValueMap ToKeyValuesMap(const json::Json &j) {
 	return kv_map;
 }
 
+ExpectedInt64 ToInt(const json::Json &j) {
+	return j.GetInt();
+}
+
+ExpectedBool ToBool(const json::Json &j) {
+	return j.GetBool();
+}
+
 template <typename T>
 expected::expected<T, error::Error> Get(
 	const json::Json &json, const string &key, MissingOk missing_ok) {

--- a/mender-update/context.hpp
+++ b/mender-update/context.hpp
@@ -55,6 +55,7 @@ enum MenderContextErrorCode {
 	// already prints a nicely formatted message.
 	ExitStatusOnlyError,
 	UnexpectedHttpResponse,
+	StateDataStoreCountExceededError,
 };
 
 class MenderContextErrorCategoryClass : public std::error_category {

--- a/mender-update/context/context.cpp
+++ b/mender-update/context/context.cpp
@@ -82,6 +82,8 @@ string MenderContextErrorCategoryClass::message(int code) const {
 		return "ExitStatusOnlyError";
 	case UnexpectedHttpResponse:
 		return "Unexpected HTTP response";
+	case StateDataStoreCountExceededError:
+		return "State data store count exceeded";
 	}
 	assert(false);
 	return "Unknown";

--- a/mender-update/daemon/context.cpp
+++ b/mender-update/daemon/context.cpp
@@ -14,16 +14,22 @@
 
 #include <mender-update/daemon/context.hpp>
 
+#include <common/common.hpp>
 #include <common/log.hpp>
 
 namespace mender {
 namespace update {
 namespace daemon {
 
+namespace common = mender::common;
 namespace log = mender::common::log;
 namespace main_context = mender::update::context;
 
-const int STATE_DATA_VERSION = 2;
+const int kStateDataVersion = 2;
+
+// The maximum times we are allowed to move through update states. If this is exceeded then the
+// update will be forcefully aborted. This can happen if we are in a reboot loop, for example.
+const int kMaxStateDataStoreCount = 50;
 
 ExpectedStateData ApiResponseJsonToStateData(const json::Json &json) {
 	StateData data;
@@ -140,6 +146,265 @@ Context::Context(main_context::MenderContext &mender_context, events::EventLoop 
 	event_loop(event_loop),
 	deployment_client(http::ClientConfig(mender_context.GetConfig().server_url), event_loop),
 	download_client(http::ClientConfig(mender_context.GetConfig().server_url), event_loop) {
+}
+
+static string GenerateStateDataJson(const StateData &state_data) {
+	stringstream content;
+
+	auto append_vector = [&content](const vector<string> &data) {
+		for (auto entry = data.begin(); entry != data.end(); entry++) {
+			if (entry != data.begin()) {
+				content << ",";
+			}
+			content << R"(")" << json::EscapeString(*entry) << R"(")";
+		}
+	};
+
+	auto append_map = [&content](const unordered_map<string, string> &data) {
+		for (auto entry = data.begin(); entry != data.end(); entry++) {
+			if (entry != data.begin()) {
+				content << ",";
+			}
+			content << R"(")" << json::EscapeString(entry->first) << R"(":")"
+					<< json::EscapeString(entry->second) << R"(")";
+		}
+	};
+
+	content << "{";
+	{
+		content << R"("Version":)" << to_string(state_data.version) << ",";
+		content << R"("Name":")" << json::EscapeString(state_data.state) << R"(",)";
+		content << R"("UpdateInfo":{)";
+		{
+			auto &update_info = state_data.update_info;
+			content << R"("Artifact":{)";
+			{
+				auto &artifact = update_info.artifact;
+				content << R"("Source":{)";
+				{
+					content << R"("URI":")" << json::EscapeString(artifact.source.uri) << R"(",)";
+					content << R"("Expire":")" << json::EscapeString(artifact.source.expire)
+							<< R"(")";
+				}
+				content << "},";
+
+				content << R"("CompatibleDevices":[)";
+				append_vector(artifact.compatible_devices);
+				content << "],";
+
+				content << R"("PayloadTypes":[)";
+				append_vector(artifact.payload_types);
+				content << "],";
+
+				content << R"("ArtifactName":")" << json::EscapeString(artifact.artifact_name)
+						<< R"(",)";
+				content << R"("ArtifactGroup":")" << json::EscapeString(artifact.artifact_group)
+						<< R"(",)";
+
+				content << R"("TypeInfoProvides":{)";
+				append_map(artifact.type_info_provides);
+				content << "},";
+
+				content << R"("ClearsArtifactProvides":[)";
+				append_vector(artifact.clears_artifact_provides);
+				content << "]";
+			}
+			content << "},";
+
+			content << R"("ID":")" << json::EscapeString(update_info.id) << R"(",)";
+
+			content << R"("RebootRequested":[)";
+			append_vector(update_info.reboot_requested);
+			content << R"(],)";
+
+			content << R"("SupportsRollback":")"
+					<< json::EscapeString(update_info.supports_rollback) << R"(",)";
+			content << R"("StateDataStoreCount":)" << to_string(update_info.state_data_store_count)
+					<< R"(,)";
+			content << R"("HasDBSchemaUpdate":)"
+					<< string(update_info.has_db_schema_update ? "true" : "false");
+		}
+		content << "}";
+	}
+	content << "}";
+
+	return std::move(*content.rdbuf()).str();
+}
+
+error::Error Context::SaveDeploymentStateData(kv_db::Transaction &txn, StateData &state_data) {
+	// We do not currently support this being set to true. It is only relevant if upgrading from
+	// a client older than 2.0. It can become relevant again later if we upgrade the schema
+	// version. See also comment about state_data_key_uncommitted.
+	AssertOrReturnError(!state_data.update_info.has_db_schema_update);
+
+	if (state_data.update_info.state_data_store_count++ >= kMaxStateDataStoreCount) {
+		return main_context::MakeError(
+			main_context::StateDataStoreCountExceededError,
+			"State looping detected, breaking out of loop");
+	}
+
+	string content = GenerateStateDataJson(state_data);
+
+	// TODO: Handle commit stage here.
+	string store_key;
+	if (state_data.update_info.has_db_schema_update) {
+		store_key = mender_context.state_data_key_uncommitted;
+	} else {
+		store_key = mender_context.state_data_key;
+	}
+
+	auto err = txn.Write(store_key, common::ByteVectorFromString(content));
+	if (err != error::NoError) {
+		return err.WithContext("Could not write state data");
+	}
+
+	return error::NoError;
+}
+
+error::Error Context::SaveDeploymentStateData(StateData &state_data) {
+	auto &db = mender_context.GetMenderStoreDB();
+	return db.WriteTransaction([this, &state_data](kv_db::Transaction &txn) {
+		return SaveDeploymentStateData(txn, state_data);
+	});
+}
+
+static error::Error UnmarshalJsonStateData(const json::Json &json, StateData &state_data) {
+#define SetOrReturnIfError(dst, expr) \
+	if (!expr) {                      \
+		return expr.error();          \
+	}                                 \
+	dst = expr.value()
+
+#define EmptyOrSetOrReturnIfError(dst, expr)                                   \
+	if (!expr) {                                                               \
+		if (expr.error().code == kv_db::MakeError(kv_db::KeyError, "").code) { \
+			dst.clear();                                                       \
+		} else {                                                               \
+			return expr.error();                                               \
+		}                                                                      \
+	} else {                                                                   \
+		dst = expr.value();                                                    \
+	}
+
+	auto exp_int = json.Get("Version").and_then(json::ToInt);
+	SetOrReturnIfError(state_data.version, exp_int);
+
+	if (state_data.version != kStateDataVersion) {
+		return error::Error(
+			make_error_condition(errc::not_supported),
+			"State Data version not supported by this client");
+	}
+
+	auto exp_string = json.Get("Name").and_then(json::ToString);
+	SetOrReturnIfError(state_data.state, exp_string);
+
+	const auto &exp_json_update_info = json.Get("UpdateInfo");
+	SetOrReturnIfError(const auto &json_update_info, exp_json_update_info);
+
+	const auto &exp_json_artifact = json_update_info.Get("Artifact");
+	SetOrReturnIfError(const auto &json_artifact, exp_json_artifact);
+
+	const auto &exp_json_source = json_artifact.Get("Source");
+	SetOrReturnIfError(const auto &json_source, exp_json_source);
+
+	auto &update_info = state_data.update_info;
+	auto &artifact = update_info.artifact;
+	auto &source = artifact.source;
+
+	exp_string = json_source.Get("URI").and_then(json::ToString);
+	SetOrReturnIfError(source.uri, exp_string);
+
+	exp_string = json_source.Get("Expire").and_then(json::ToString);
+	SetOrReturnIfError(source.expire, exp_string);
+
+	auto exp_string_vector = json_artifact.Get("CompatibleDevices").and_then(json::ToStringVector);
+	SetOrReturnIfError(artifact.compatible_devices, exp_string_vector);
+
+	exp_string_vector = json_artifact.Get("PayloadTypes").and_then(json::ToStringVector);
+	SetOrReturnIfError(artifact.payload_types, exp_string_vector);
+
+	exp_string = json_artifact.Get("ArtifactName").and_then(json::ToString);
+	SetOrReturnIfError(artifact.artifact_name, exp_string);
+
+	exp_string = json_artifact.Get("ArtifactGroup").and_then(json::ToString);
+	SetOrReturnIfError(artifact.artifact_group, exp_string);
+
+	auto exp_string_map = json_artifact.Get("TypeInfoProvides").and_then(json::ToKeyValuesMap);
+	EmptyOrSetOrReturnIfError(artifact.type_info_provides, exp_string_map);
+
+	exp_string_vector = json_artifact.Get("ClearsArtifactProvides").and_then(json::ToStringVector);
+	EmptyOrSetOrReturnIfError(artifact.clears_artifact_provides, exp_string_vector);
+
+	exp_string = json_update_info.Get("ID").and_then(json::ToString);
+	SetOrReturnIfError(update_info.id, exp_string);
+
+	exp_string_vector = json_update_info.Get("RebootRequested").and_then(json::ToStringVector);
+	SetOrReturnIfError(update_info.reboot_requested, exp_string_vector);
+
+	auto exp_bool = json_update_info.Get("SupportsRollback").and_then(json::ToBool);
+	SetOrReturnIfError(update_info.supports_rollback, exp_bool);
+
+	exp_int = json_update_info.Get("StateDataStoreCount").and_then(json::ToInt);
+	SetOrReturnIfError(update_info.state_data_store_count, exp_int);
+
+	exp_bool = json_update_info.Get("HasDBSchemaUpdate").and_then(json::ToBool);
+	SetOrReturnIfError(update_info.has_db_schema_update, exp_bool);
+
+#undef SetOrReturnIfError
+#undef EmptyOrSetOrReturnIfError
+
+	return error::NoError;
+}
+
+expected::ExpectedBool Context::LoadDeploymentStateData(StateData &state_data) {
+	auto &db = mender_context.GetMenderStoreDB();
+	auto err = db.WriteTransaction([this, &state_data](kv_db::Transaction &txn) {
+		auto exp_content = txn.Read(mender_context.state_data_key);
+		if (!exp_content) {
+			return exp_content.error().WithContext("Could not load state data");
+		}
+		auto &content = exp_content.value();
+
+		auto exp_json = json::Load(common::StringFromByteVector(content));
+		if (!exp_json) {
+			return exp_json.error().WithContext("Could not load state data");
+		}
+
+		auto err = UnmarshalJsonStateData(exp_json.value(), state_data);
+		if (err != error::NoError) {
+			if (err.code != make_error_condition(errc::not_supported)) {
+				return err.WithContext("Could not load state data");
+			}
+
+			// Try again with the state_data_key_uncommitted.
+			exp_content = txn.Read(mender_context.state_data_key_uncommitted);
+			if (!exp_content) {
+				return err.WithContext("Could not load state data").FollowedBy(exp_content.error());
+			}
+			auto &content = exp_content.value();
+
+			exp_json = json::Load(common::StringFromByteVector(content));
+			if (!exp_json) {
+				return err.WithContext("Could not load state data").FollowedBy(exp_json.error());
+			}
+
+			auto inner_err = UnmarshalJsonStateData(exp_json.value(), state_data);
+			if (inner_err != error::NoError) {
+				return err.WithContext("Could not load state data").FollowedBy(inner_err);
+			}
+		}
+
+		// Every load also saves, which increments the state_data_store_count.
+		return SaveDeploymentStateData(txn, state_data);
+	});
+
+	if (err == error::NoError) {
+		return true;
+	} else if (err.code == kv_db::MakeError(kv_db::KeyError, "").code) {
+		return false;
+	} else {
+		return expected::unexpected(err);
+	}
 }
 
 } // namespace daemon

--- a/mender-update/daemon/context.hpp
+++ b/mender-update/daemon/context.hpp
@@ -146,6 +146,24 @@ public:
 		unique_ptr<update_module::UpdateModule> update_module;
 	} deployment;
 
+	// Database values for the `StateData::state` member above.
+	static const string kUpdateStateDownload;
+	static const string kUpdateStateArtifactInstall;
+	static const string kUpdateStateArtifactReboot;
+	static const string kUpdateStateArtifactVerifyReboot;
+	static const string kUpdateStateArtifactCommit;
+	static const string kUpdateStateAfterArtifactCommit;
+	static const string kUpdateStateArtifactRollback;
+	static const string kUpdateStateArtifactRollbackReboot;
+	static const string kUpdateStateArtifactVerifyRollbackReboot;
+	static const string kUpdateStateArtifactFailure;
+	static const string kUpdateStateCleanup;
+	static const string kUpdateStateStatusReportRetry;
+
+	static const string kUpdateStateUpdateAfterFirstCommit;
+	static const string kUpdateStateVerifyRollbackReboot;
+	static const string UpdateStateReportStatusError;
+
 	// Database values for the `supports_rollback` member above.
 	static const string kRollbackNotSupported;
 	static const string kRollbackSupported;

--- a/mender-update/daemon/states.hpp
+++ b/mender-update/daemon/states.hpp
@@ -67,6 +67,9 @@ class UpdateDownloadState : virtual public StateType {
 public:
 	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
 
+private:
+	// `static` since it only needs the arguments, but is still strongly tied to
+	// OnEnterSaveState.
 	static void ParseArtifact(Context &ctx, sm::EventPoster<StateEvent> &poster);
 };
 


### PR DESCRIPTION
```
commit 315039fa825552ee06f56c73b8330050e5c09eae
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jul 19 14:31:49 2023

    chore: Add database keys for saved update states.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 96b4df4ca19c153faebc4d52233dfbe8690523c4
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jul 19 13:13:54 2023

    chore: Make deployment state data load/save functions.
    
    Ticket: MEN-6565
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b2b54ee66d2203125bf7c459c11c90557de5b308
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jul 19 12:41:39 2023

    chore: Add more `json::To*` functions, for use in monadic expressions.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```