### PR TITLE
chore: 3.3.x compilation fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 variables:
   GOLANG_VERSION: "1.17.6"
   LICENSE_HEADERS_IGNORE_FILES_REGEXP: "./ltmain.sh"
+  DEBIAN_FRONTEND: noninteractive
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -31,7 +32,7 @@ test:
     - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
     - tar -cvf $CI_PROJECT_DIR/unit-coverage.tar tests/unit-coverage
   tags:
-    - mender-qa-slave
+    - mender-qa-worker-generic
   artifacts:
     expire_in: 2w
     reports:
@@ -41,16 +42,17 @@ test:
 
 test:modules-artifact-gen:
   stage: test
-  image: python:3.9
+  image: ubuntu:22.04
   before_script:
+    - apt update && apt install -yy $(cat support/modules-artifact-gen/tests/deb-requirements.txt)
     # mender-artifact
-    - curl https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
-      -o /usr/local/bin/mender-artifact
-    - chmod +x /usr/local/bin/mender-artifact
+    - curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc
+    - echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/jammy/experimental main" | tee /etc/apt/sources.list.d/mender.list
+    - apt update && apt install -yy mender-artifact
     # Test dependencies
     - pip install -r support/modules-artifact-gen/tests/requirements.txt
   script:
-    - python -m pytest support/modules-artifact-gen/tests
+    - python3 -m pytest support/modules-artifact-gen/tests
 
 test:docker:
   image: docker
@@ -83,7 +85,7 @@ publish:tests:
     - goveralls
       -repotoken ${COVERALLS_TOKEN}
       -service gitlab-ci
-      -jobid $(git rev-parse HEAD)
+      -jobid $CI_PIPELINE_ID
       -covermode set
       -flagname unittests
       -parallel

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - trigger
 
 variables:
-  GOLANG_VERSION: "1.17.6"
+  GOLANG_VERSION: "1.17.13"
   LICENSE_HEADERS_IGNORE_FILES_REGEXP: "./ltmain.sh"
   DEBIAN_FRONTEND: noninteractive
 
@@ -19,7 +19,7 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'
 
-test:
+test:unit:
   stage: test
   image: golang:1.17
   before_script:
@@ -42,23 +42,26 @@ test:
 
 test:modules-artifact-gen:
   stage: test
-  image: ubuntu:22.04
+  image: ubuntu:18.04
   before_script:
-    - apt update && apt install -yy $(cat support/modules-artifact-gen/tests/deb-requirements.txt)
+    - apt-get update
+    - apt-get install -y wget python3-pip
+    - apt install -yy $(cat support/modules-artifact-gen/tests/deb-requirements.txt)
     # mender-artifact
-    - curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc
-    - echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/jammy/experimental main" | tee /etc/apt/sources.list.d/mender.list
-    - apt update && apt install -yy mender-artifact
+    - wget https://downloads.mender.io/mender-artifact/3.9.0/linux/mender-artifact
+    - chmod 755 mender-artifact
+    - mv mender-artifact /usr/bin/
     # Test dependencies
-    - pip install -r support/modules-artifact-gen/tests/requirements.txt
+    - pip3 install -r support/modules-artifact-gen/tests/requirements.txt
   script:
+    - python3 --version
     - python3 -m pytest support/modules-artifact-gen/tests
 
 test:docker:
   image: docker
   needs: []
   services:
-    - docker:19.03.5-dind
+    - docker:20.10.21-dind
   stage: test
   script:
     - ./tests/build-docker
@@ -67,7 +70,7 @@ publish:tests:
   stage: publish
   image: golang:1.17-alpine3.14
   dependencies:
-    - test
+    - test:unit
   before_script:
     # Install dependencies
     - apk add --no-cache git

--- a/app/state.go
+++ b/app/state.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //	Licensed under the Apache License, Version 2.0 (the "License");
 //	you may not use this file except in compliance with the License.

--- a/support/modules-artifact-gen/tests/deb-requirements.txt
+++ b/support/modules-artifact-gen/tests/deb-requirements.txt
@@ -1,0 +1,2 @@
+curl
+python3-pip


### PR DESCRIPTION
3.3.x is failing: https://gitlab.com/Northern.tech/Mender/mender/-/pipelines/943410534

```
# github.com/mendersoftware/mender/app
app/auth.go:266:15: undefined: timers
app/auth.go:279:5: undefined: timers
app/auth.go:295:15: undefined: timers
app/auth.go:304:5: undefined: timers
app/auth.go:413:16: undefined: timers
app/auth.go:418:6: undefined: timers
app/auth.go:476:13: undefined: timers
app/auth.go:481:3: undefined: timers
make: *** [Makefile:85: mender] Error 1
```

Ticket: None