### PR TITLE
chore: Treat events with no state transitions as fatal.

### DIFF
--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -225,7 +225,8 @@ void Log_(LogLevel level, const string message) {
 }
 
 void Fatal(const string &message) {
-	return global_logger_.Log(LogLevel::Fatal, message);
+	global_logger_.Log(LogLevel::Fatal, message);
+	std::abort();
 }
 void Error(const string &message) {
 	return global_logger_.Log(LogLevel::Error, message);

--- a/common/state_machine.hpp
+++ b/common/state_machine.hpp
@@ -192,10 +192,10 @@ private:
 					// attempts in the for loop.
 					event_queue_.push(event);
 				} else {
-					log::Warning(
+					log::Fatal(
 						"State machine event " + to_string(static_cast<int>(event))
-						+ " was not handled by any state. This is a bug and could hang the state machine.");
-					assert(!to_run.empty());
+						+ " was not handled by any state. This is a bug and an irrecoverable error. "
+						+ "Aborting in the hope that restarting will help.");
 				}
 			}
 		}


### PR DESCRIPTION
This was discussed with the team members. Since an unhandled event is
almost guaranteed to hang the state machine, then it's better to
terminate and let systemd try to restart us, in the hopes that
recovery will still work.