### PR TITLE
Add tpm2tss engine support with openssl

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,8 +34,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/mendersoftware/openssl"
 	"github.com/mendersoftware/mender/utils"
+	"github.com/mendersoftware/openssl"
 )
 
 const (

--- a/client/client.go
+++ b/client/client.go
@@ -404,9 +404,9 @@ func loadServerTrust(ctx *openssl.Ctx, conf *Config) (*openssl.Ctx, error) {
 }
 
 func loadPrivateKey(keyFile string, engineId string) (key openssl.PrivateKey, err error) {
-	if utils.ispkcs11_keystring(keyFile) || utils.istpm2tss_keystring(keyFile) {
+	if utils.Ispkcs11_keystring(keyFile) || utils.Istpm2tss_keystring(keyFile) {
 		// Set keystring based on if pkcs11 or tpm2tss engine
-		keyFile = utils.parsed_keystring(keyFile)
+		keyFile = utils.Parsed_keystring(keyFile)
 		engine, err := openssl.EngineById(engineId)
 		if err != nil {
 			log.Errorf("Failed to Load '%s' engine. Err %s",

--- a/store/keystore.go
+++ b/store/keystore.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mendersoftware/openssl"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/mendersoftware/mender/utils"
 )
 
 const (
@@ -72,7 +73,9 @@ func NewKeystore(
 }
 
 func (k *Keystore) Load() error {
-	if strings.HasPrefix(k.keyName, "pkcs11:") {
+	if utils.ispkcs11_keystring(k.keyName) || utils.istpm2tss_keystring(k.keyName) {
+		// Set keystring based on if pkcs11 or tpm2tss engine
+		k.keyName = utils.parsed_keystring(k.keyName)
 		engine, err := openssl.EngineById(k.sslEngine)
 		if err != nil {
 			log.Errorf("Failed to Load '%s' engine. Err %s",

--- a/store/keystore.go
+++ b/store/keystore.go
@@ -19,10 +19,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mendersoftware/mender/utils"
 	"github.com/mendersoftware/openssl"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/mendersoftware/mender/utils"
 )
 
 const (
@@ -73,9 +73,9 @@ func NewKeystore(
 }
 
 func (k *Keystore) Load() error {
-	if utils.ispkcs11_keystring(k.keyName) || utils.istpm2tss_keystring(k.keyName) {
+	if utils.Ispkcs11_keystring(k.keyName) || utils.Istpm2tss_keystring(k.keyName) {
 		// Set keystring based on if pkcs11 or tpm2tss engine
-		k.keyName = utils.parsed_keystring(k.keyName)
+		k.keyName = utils.Parsed_keystring(k.keyName)
 		engine, err := openssl.EngineById(k.sslEngine)
 		if err != nil {
 			log.Errorf("Failed to Load '%s' engine. Err %s",

--- a/utils/openssl_engine.go
+++ b/utils/openssl_engine.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import  (
+	"strings"
+)
+
+const (
+	pkcs11URIPrefix = "pkcs11:"
+	tpmURIPrefix = "tpm2tss:"
+)
+
+func ispkcs11_keystring(key string) bool {
+	return strings.HasPrefix(key, pkcs11URIPrefix)
+}
+
+func istpm2tss_keystring(key string) bool {
+	return strings.HasPrefix(key, tpmURIPrefix)
+}
+
+// Function takes in a key string and based on the prefix outputs the correct format
+func parsed_keystring(key string) string {
+	// For tpm2tss keystring we pass in prefix + handle (i.e tpm2tss:0x81000000)
+	// to identify it is of engine tpm2tss but the actual tpm2tss engine expects just the handle
+	if istpm2tss_keystring(key) {
+		return key[len(tpmURIPrefix):]
+	}
+
+	return key
+}

--- a/utils/openssl_engine.go
+++ b/utils/openssl_engine.go
@@ -14,28 +14,28 @@
 
 package utils
 
-import  (
+import (
 	"strings"
 )
 
 const (
 	pkcs11URIPrefix = "pkcs11:"
-	tpmURIPrefix = "tpm2tss:"
+	tpmURIPrefix    = "tpm2tss:"
 )
 
-func ispkcs11_keystring(key string) bool {
+func Ispkcs11_keystring(key string) bool {
 	return strings.HasPrefix(key, pkcs11URIPrefix)
 }
 
-func istpm2tss_keystring(key string) bool {
+func Istpm2tss_keystring(key string) bool {
 	return strings.HasPrefix(key, tpmURIPrefix)
 }
 
 // Function takes in a key string and based on the prefix outputs the correct format
-func parsed_keystring(key string) string {
+func Parsed_keystring(key string) string {
 	// For tpm2tss keystring we pass in prefix + handle (i.e tpm2tss:0x81000000)
 	// to identify it is of engine tpm2tss but the actual tpm2tss engine expects just the handle
-	if istpm2tss_keystring(key) {
+	if Istpm2tss_keystring(key) {
 		return key[len(tpmURIPrefix):]
 	}
 


### PR DESCRIPTION

```
feature: Added tpm2tss engine support with openssl load key functionality

Changelog: tpm2tss engine support
Ticket: None
```
### Description

Currently, mender supports only pkcs11 format for loading keys with openssl engine. Adding functionality to load from engine `tpm2tss`. 
