### PR TITLE
chore: Consistently use curly braces initialization in constructors

### DIFF
--- a/artifact/tar/platform/libarchive/wrapper.hpp
+++ b/artifact/tar/platform/libarchive/wrapper.hpp
@@ -46,7 +46,7 @@ struct ReaderContainer {
 	std::vector<uint8_t> buff_;
 
 	ReaderContainer(mender::common::io::Reader &reader, size_t block_size) :
-		reader_(reader),
+		reader_ {reader},
 		buff_(block_size) {
 	}
 };

--- a/common/conf.hpp
+++ b/common/conf.hpp
@@ -68,10 +68,10 @@ public:
 		vector<string>::const_iterator end,
 		const OptsSet &opts_with_value,
 		const OptsSet &opts_without_value) :
-		start_(start),
-		end_(end),
-		opts_with_value_(opts_with_value),
-		opts_wo_value_(opts_without_value) {};
+		start_ {start},
+		end_ {end},
+		opts_with_value_ {opts_with_value},
+		opts_wo_value_ {opts_without_value} {};
 	ExpectedOptionValue Next();
 
 	size_t GetPos() const {

--- a/common/error.hpp
+++ b/common/error.hpp
@@ -56,12 +56,12 @@ public:
 	Error() {
 	}
 	Error(const std::error_condition &ec, const std::string &msg) :
-		code(ec),
-		message(msg) {
+		code {ec},
+		message {msg} {
 	}
 	Error(const Error &e) :
-		code(e.code),
-		message(e.message) {
+		code {e.code},
+		message {e.message} {
 	}
 
 	bool operator==(const Error &other) const {

--- a/common/events/events_io.cpp
+++ b/common/events/events_io.cpp
@@ -20,8 +20,8 @@ namespace events {
 namespace io {
 
 AsyncReaderFromReader::AsyncReaderFromReader(EventLoop &loop, mio::ReaderPtr reader) :
-	reader_(reader),
-	loop_(loop) {
+	reader_ {reader},
+	loop_ {loop} {
 }
 
 AsyncReaderFromReader::~AsyncReaderFromReader() {
@@ -47,8 +47,8 @@ void AsyncReaderFromReader::Cancel() {
 }
 
 AsyncWriterFromWriter::AsyncWriterFromWriter(EventLoop &loop, mio::WriterPtr writer) :
-	writer_(writer),
-	loop_(loop) {
+	writer_ {writer},
+	loop_ {loop} {
 }
 
 AsyncWriterFromWriter::~AsyncWriterFromWriter() {

--- a/common/events/platform/boost/events_io.cpp
+++ b/common/events/platform/boost/events_io.cpp
@@ -23,12 +23,12 @@ namespace io {
 
 AsyncFileDescriptorReader::AsyncFileDescriptorReader(events::EventLoop &loop, int fd) :
 	pipe_(GetAsioIoContext(loop), fd),
-	cancelled_(make_shared<bool>(false)) {
+	cancelled_ {make_shared<bool>(false)} {
 }
 
 AsyncFileDescriptorReader::AsyncFileDescriptorReader(events::EventLoop &loop) :
 	pipe_(GetAsioIoContext(loop)),
-	cancelled_(make_shared<bool>(false)) {
+	cancelled_ {make_shared<bool>(false)} {
 }
 
 AsyncFileDescriptorReader::~AsyncFileDescriptorReader() {
@@ -91,12 +91,12 @@ void AsyncFileDescriptorReader::Cancel() {
 
 AsyncFileDescriptorWriter::AsyncFileDescriptorWriter(events::EventLoop &loop, int fd) :
 	pipe_(GetAsioIoContext(loop), fd),
-	cancelled_(make_shared<bool>(false)) {
+	cancelled_ {make_shared<bool>(false)} {
 }
 
 AsyncFileDescriptorWriter::AsyncFileDescriptorWriter(events::EventLoop &loop) :
 	pipe_(GetAsioIoContext(loop)),
-	cancelled_(make_shared<bool>(false)) {
+	cancelled_ {make_shared<bool>(false)} {
 }
 
 AsyncFileDescriptorWriter::~AsyncFileDescriptorWriter() {

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -222,7 +222,7 @@ void OutgoingRequest::SetBodyGenerator(BodyGenerator body_gen) {
 }
 
 IncomingResponse::IncomingResponse(weak_ptr<Client> client) :
-	client_(client) {
+	client_ {client} {
 }
 
 void IncomingResponse::SetBodyWriter(io::WriterPtr body_writer) {
@@ -235,7 +235,7 @@ io::AsyncReaderPtr IncomingResponse::MakeBodyAsyncReader() {
 }
 
 IncomingResponse::BodyAsyncReader::BodyAsyncReader(weak_ptr<Client> client) :
-	client_(client) {
+	client_ {client} {
 }
 
 IncomingResponse::BodyAsyncReader::~BodyAsyncReader() {

--- a/common/http/platform/beast/http.cpp
+++ b/common/http/platform/beast/http.cpp
@@ -93,9 +93,9 @@ error::Error OutgoingResponse::AsyncReply(ReplyFinishedHandler reply_finished_ha
 
 Client::Client(
 	const ClientConfig &client, events::EventLoop &event_loop, const string &logger_name) :
-	event_loop_(event_loop),
-	logger_name_(logger_name),
-	cancelled_(make_shared<bool>(false)),
+	event_loop_ {event_loop},
+	logger_name_ {logger_name},
+	cancelled_ {make_shared<bool>(false)},
 	resolver_(GetAsioIoContext(event_loop)),
 	body_buffer_(HTTP_BEAST_BUFFER_SIZE) {
 	// This is equivalent to:
@@ -683,7 +683,7 @@ ClientConfig::ClientConfig() :
 }
 
 ClientConfig::ClientConfig(string server_cert_path) :
-	server_cert_path(server_cert_path) {
+	server_cert_path {server_cert_path} {
 }
 
 ClientConfig::~ClientConfig() {
@@ -696,8 +696,8 @@ ServerConfig::~ServerConfig() {
 }
 
 Stream::Stream(Server &server) :
-	server_(server),
-	logger_("http"),
+	server_ {server},
+	logger_ {"http"},
 	socket_(server_.GetAsioIoContext(server_.event_loop_)),
 	body_buffer_(HTTP_BEAST_BUFFER_SIZE) {
 	// This is equivalent to:
@@ -1085,7 +1085,7 @@ void Stream::CallBodyHandler() {
 }
 
 Server::Server(const ServerConfig &server, events::EventLoop &event_loop) :
-	event_loop_(event_loop),
+	event_loop_ {event_loop},
 	acceptor_(GetAsioIoContext(event_loop_)) {
 }
 

--- a/common/io.hpp
+++ b/common/io.hpp
@@ -139,7 +139,7 @@ public:
 	StreamReader(std::istream &stream) :
 		// For references, initialize a shared_ptr with a null deleter, since we don't own
 		// the object.
-		is_(&stream, [](std::istream *stream) {}) {
+		is_ {&stream, [](std::istream *stream) {}} {
 	}
 	StreamReader(shared_ptr<std::istream> stream) :
 		is_ {stream} {
@@ -230,7 +230,7 @@ private:
 
 public:
 	ByteWriter(vector<uint8_t> &receiver) :
-		receiver_(&receiver, [](vector<uint8_t> *vec) {}) {
+		receiver_ {&receiver, [](vector<uint8_t> *vec) {}} {
 	}
 
 	ByteWriter(shared_ptr<vector<uint8_t>> receiver) :
@@ -251,7 +251,7 @@ private:
 
 public:
 	StreamWriter(std::ostream &stream) :
-		os_(&stream, [](std::ostream *str) {}) {
+		os_ {&stream, [](std::ostream *str) {}} {
 	}
 	StreamWriter(shared_ptr<std::ostream> stream) :
 		os_ {stream} {

--- a/common/key_value_database/in_memory/in_memory.cpp
+++ b/common/key_value_database/in_memory/in_memory.cpp
@@ -39,8 +39,8 @@ private:
 };
 
 InMemoryTransaction::InMemoryTransaction(KeyValueDatabaseInMemory &db, bool read_only) :
-	db_(db),
-	read_only_(read_only) {
+	db_ {db},
+	read_only_ {read_only} {
 }
 
 ExpectedBytes InMemoryTransaction::Read(const string &key) {

--- a/common/key_value_database/platform/lmdb/lmdb.cpp
+++ b/common/key_value_database/platform/lmdb/lmdb.cpp
@@ -35,8 +35,8 @@ private:
 };
 
 LmdbTransaction::LmdbTransaction(lmdb::txn &txn, lmdb::dbi &dbi) :
-	txn_(txn),
-	dbi_(dbi) {
+	txn_ {txn},
+	dbi_ {dbi} {
 }
 
 expected::ExpectedBytes LmdbTransaction::Read(const string &key) {
@@ -80,8 +80,8 @@ error::Error LmdbTransaction::Remove(const string &key) {
 }
 
 KeyValueDatabaseLmdb::KeyValueDatabaseLmdb() :
-	env_(make_unique<lmdb::env>(lmdb::env::create())),
-	successfully_opened_(false) {
+	env_ {make_unique<lmdb::env>(lmdb::env::create())},
+	successfully_opened_ {false} {
 }
 
 KeyValueDatabaseLmdb::~KeyValueDatabaseLmdb() {

--- a/common/log.hpp
+++ b/common/log.hpp
@@ -54,8 +54,8 @@ error::Error MakeError(LogErrorCode code, const string &msg);
 
 struct LogField {
 	LogField(const string &key, const string &value) :
-		key(key),
-		value(value) {
+		key {key},
+		value {value} {
 	}
 
 	string key;

--- a/common/log/platform/boost/boost_log.cpp
+++ b/common/log/platform/boost/boost_log.cpp
@@ -143,12 +143,12 @@ static void SetupLoggerAttributes() {
 }
 
 Logger::Logger(const string &name) :
-	Logger(name, global_logger_.Level()) {
+	Logger {name, global_logger_.Level()} {
 }
 
 Logger::Logger(const string &name, LogLevel level) :
-	name_(name),
-	level_(level) {
+	name_ {name},
+	level_ {level} {
 	src::severity_logger<LogLevel> slg;
 	slg.add_attribute("Name", attrs::constant<std::string>(name));
 	this->logger = slg;

--- a/common/processes/platform/tiny_process_library/tiny_process_library.cpp
+++ b/common/processes/platform/tiny_process_library/tiny_process_library.cpp
@@ -43,8 +43,8 @@ public:
 };
 
 Process::Process(vector<string> args) :
-	args_(args),
-	max_termination_time_(MAX_TERMINATION_TIME) {
+	args_ {args},
+	max_termination_time_ {MAX_TERMINATION_TIME} {
 	async_wait_data_ = make_shared<AsyncWaitData>();
 }
 

--- a/common/testing.cpp
+++ b/common/testing.cpp
@@ -87,7 +87,7 @@ std::string TemporaryDirectory::Path() {
 const string HttpFileServer::serve_address_ {"http://127.0.0.1:53272"};
 
 HttpFileServer::HttpFileServer(const string &dir) :
-	dir_(dir),
+	dir_ {dir},
 	server_(http::ServerConfig {}, loop_) {
 	// The reason we need this synchronization is because of the thread sanitizer and
 	// logging. AsyncServeUrl uses the logger internally, and the log level is also set by

--- a/common/testing.hpp
+++ b/common/testing.hpp
@@ -45,7 +45,7 @@ private:
 class TestEventLoop : public mender::common::events::EventLoop {
 public:
 	TestEventLoop(chrono::seconds seconds = chrono::seconds(5)) :
-		timer_(*this) {
+		timer_ {*this} {
 		timer_.AsyncWait(seconds, [this](error::Error err) {
 			Stop();
 			// Better to throw exception than FAIL(), since we want to escape the caller

--- a/mender-update/cli/actions.hpp
+++ b/mender-update/cli/actions.hpp
@@ -52,8 +52,8 @@ public:
 class InstallAction : virtual public Action {
 public:
 	InstallAction(const string &src, bool reboot_exit_code) :
-		src_(src),
-		reboot_exit_code_(reboot_exit_code) {
+		src_ {src},
+		reboot_exit_code_ {reboot_exit_code} {
 	}
 
 	error::Error Execute(context::MenderContext &main_context) override;

--- a/mender-update/context.hpp
+++ b/mender-update/context.hpp
@@ -73,7 +73,7 @@ using ExpectedProvidesData = expected::expected<ProvidesData, error::Error>;
 class MenderContext {
 public:
 	MenderContext(conf::MenderConfig &config) :
-		config_(config) {};
+		config_ {config} {};
 
 	error::Error Initialize();
 	kv_db::KeyValueDatabase &GetMenderStoreDB();

--- a/mender-update/update_module/v3/platform/c++17/fs_operations.cpp
+++ b/mender-update/update_module/v3/platform/c++17/fs_operations.cpp
@@ -363,8 +363,8 @@ error::Error UpdateModule::DeleteStreamsFiles() {
 }
 
 AsyncFifoOpener::AsyncFifoOpener(events::EventLoop &loop) :
-	event_loop_(loop),
-	cancelled_(make_shared<atomic<bool>>(true)) {
+	event_loop_ {loop},
+	cancelled_ {make_shared<atomic<bool>>(true)} {
 }
 
 AsyncFifoOpener::~AsyncFifoOpener() {

--- a/mender-update/update_module/v3/update_module.cpp
+++ b/mender-update/update_module/v3/update_module.cpp
@@ -50,14 +50,14 @@ std::string StateToString(State state) {
 }
 
 UpdateModule::UpdateModule(MenderContext &ctx, const string &payload_type) :
-	ctx_(ctx) {
+	ctx_ {ctx} {
 	update_module_path_ = path::Join(ctx.modules_path, payload_type);
 	update_module_workdir_ =
 		path::Join(ctx.modules_work_path, "modules", "v3", "payloads", "0000", "tree");
 }
 
 UpdateModule::DownloadData::DownloadData(artifact::Payload &payload) :
-	payload_(payload) {
+	payload_ {payload} {
 	buffer_.resize(MENDER_BUFSIZE);
 }
 


### PR DESCRIPTION
Where possible, leaving the more explicit calls to other constructors with parenthesis.