### PR TITLE
fix: Support parsing device_type with no endl at the end

### DIFF
--- a/api/auth.hpp
+++ b/api/auth.hpp
@@ -39,8 +39,6 @@ namespace events = mender::common::events;
 namespace optional = mender::common::optional;
 
 
-expected::ExpectedString GetPrivateKey();
-
 enum AuthClientErrorCode {
 	NoError = 0,
 	SetupError,

--- a/mender-update/context/context.cpp
+++ b/mender-update/context/context.cpp
@@ -216,11 +216,13 @@ expected::ExpectedString MenderContext::GetDeviceType() {
 
 	string ret = line.substr(eq_pos, string::npos);
 
-	errno = 0;
-	getline(is, line);
-	if ((line != "") || (!is.eof())) {
-		auto err = MakeError(ValueError, "Trailing device_type data");
-		return expected::ExpectedString(expected::unexpected(err));
+	if (!is.eof()) {
+		errno = 0;
+		getline(is, line);
+		if ((line != "") || (!is.eof())) {
+			auto err = MakeError(ValueError, "Trailing device_type data");
+			return expected::ExpectedString(expected::unexpected(err));
+		}
 	}
 
 	return expected::ExpectedString(ret);

--- a/mender-update/context_test.cpp
+++ b/mender-update/context_test.cpp
@@ -414,6 +414,15 @@ TEST_F(ContextTests, GetDeviceTypeValid) {
 	auto ex_s = ctx.GetDeviceType();
 	ASSERT_TRUE(ex_s);
 	EXPECT_EQ(ex_s.value(), "Some device type");
+
+	os.open(cfg.data_store_dir + "/device_type");
+	ASSERT_TRUE(os);
+	os << "device_type=Device type no endl";
+	os.close();
+
+	ex_s = ctx.GetDeviceType();
+	ASSERT_TRUE(ex_s);
+	EXPECT_EQ(ex_s.value(), "Device type no endl");
 }
 
 TEST_F(ContextTests, GetDeviceTypeNoexist) {


### PR DESCRIPTION
* chore: Remove unused declaration `GetPrivateKey`
* fix: Support parsing device_type with no endl at the end
As currently formatted by `mender setup` from the golang client
