### PR TITLE
Add full support for storing Artifact scripts

### DIFF
--- a/artifact/config.hpp
+++ b/artifact/config.hpp
@@ -25,6 +25,7 @@ using namespace std;
 
 struct ParserConfig {
 	string artifact_scripts_filesystem_path;
+	int artifact_scripts_version;
 	vector<string> artifact_verify_keys;
 };
 

--- a/artifact/v3/header/header.cpp
+++ b/artifact/v3/header/header.cpp
@@ -111,6 +111,30 @@ ExpectedHeader Parse(io::Reader &reader, ParserConfig conf) {
 		tok = lexer.Next();
 	}
 
+	// Write the Artifact script version file
+	if (state_scripts.size() > 0) {
+		const string artifact_script_version_file =
+			path::Join(conf.artifact_scripts_filesystem_path, "version");
+		errno = 0;
+		ofstream myfile(artifact_script_version_file);
+		log::Trace("Creating the Artifact script version file: " + artifact_script_version_file);
+		if (!myfile.good()) {
+			auto io_errno = errno;
+			return expected::unexpected(error::Error(
+				std::generic_category().default_error_condition(io_errno),
+				"Failed to create the Artifact script version file: "
+					+ artifact_script_version_file));
+		}
+		myfile << to_string(conf.artifact_scripts_version);
+		if (!myfile.good()) {
+			auto io_errno = errno;
+			return expected::unexpected(error::Error(
+				std::generic_category().default_error_condition(io_errno),
+				"I/O error writing the Artifact scripts version file"));
+		}
+	}
+
+
 	header.artifactScripts = std::move(state_scripts);
 
 	vector<SubHeader> subheaders {};

--- a/artifact/v3/header/header_test.cpp
+++ b/artifact/v3/header/header_test.cpp
@@ -162,8 +162,10 @@ TEST_F(HeaderTestEnv, TestHeaderRootfsAllFlagsSetSuccess) {
 
 	mender::common::io::StreamReader sr {fs};
 
-	ExpectedHeader expected_header =
-		header::Parse(sr, mender::artifact::config::ParserConfig {tmpdir.Path()});
+	ExpectedHeader expected_header = header::Parse(
+		sr,
+		mender::artifact::config::ParserConfig {
+			.artifact_scripts_filesystem_path = tmpdir.Path(), .artifact_scripts_version = 3});
 
 	ASSERT_TRUE(expected_header) << expected_header.error().message;
 
@@ -213,6 +215,8 @@ TEST_F(HeaderTestEnv, TestHeaderRootfsAllFlagsSetSuccess) {
 		testing::AnyOf(
 			testing::EndsWith("ArtifactInstall_Enter_01_test-dummy"),
 			testing::EndsWith("ArtifactInstall_Enter_02_test-dummy")));
+	// Check that the version file version is set correctly
+	EXPECT_TRUE(mendertesting::FileContains(path::Join(tmpdir.Path(), "version"), "3"));
 
 
 	//

--- a/mender-update/daemon/states.cpp
+++ b/mender-update/daemon/states.cpp
@@ -209,6 +209,7 @@ void UpdateDownloadState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &pos
 void UpdateDownloadState::ParseArtifact(Context &ctx, sm::EventPoster<StateEvent> &poster) {
 	artifact::config::ParserConfig config {
 		.artifact_scripts_filesystem_path = conf::paths::DefaultArtScriptsPath,
+		.artifact_scripts_version = 3,
 	};
 	auto exp_parser = artifact::Parse(*ctx.deployment.artifact_reader, config);
 	if (!exp_parser) {

--- a/mender-update/daemon/states.cpp
+++ b/mender-update/daemon/states.cpp
@@ -208,7 +208,7 @@ void UpdateDownloadState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &pos
 
 void UpdateDownloadState::ParseArtifact(Context &ctx, sm::EventPoster<StateEvent> &poster) {
 	artifact::config::ParserConfig config {
-		conf::paths::DefaultArtScriptsPath,
+		.artifact_scripts_filesystem_path = conf::paths::DefaultArtScriptsPath,
 	};
 	auto exp_parser = artifact::Parse(*ctx.deployment.artifact_reader, config);
 	if (!exp_parser) {

--- a/mender-update/standalone/standalone.cpp
+++ b/mender-update/standalone/standalone.cpp
@@ -290,7 +290,7 @@ ResultAndError Install(context::MenderContext &main_context, const string &src) 
 	}
 
 	artifact::config::ParserConfig config {
-		paths::DefaultArtScriptsPath,
+		.artifact_scripts_filesystem_path = paths::DefaultArtScriptsPath,
 	};
 	auto exp_parser = artifact::Parse(*artifact_reader, config);
 	if (!exp_parser) {

--- a/mender-update/standalone/standalone.cpp
+++ b/mender-update/standalone/standalone.cpp
@@ -291,6 +291,7 @@ ResultAndError Install(context::MenderContext &main_context, const string &src) 
 
 	artifact::config::ParserConfig config {
 		.artifact_scripts_filesystem_path = paths::DefaultArtScriptsPath,
+		.artifact_scripts_version = 3,
 	};
 	auto exp_parser = artifact::Parse(*artifact_reader, config);
 	if (!exp_parser) {


### PR DESCRIPTION
Both in the standalone, and daemon mode.

In fact most of the functionality was already there, I just tacked on the version script writing as a part of the Artifact parsing.