### PR TITLE
feat: Add MenderContext::MatchesArtifactDepends()

### DIFF
--- a/common/common.hpp
+++ b/common/common.hpp
@@ -19,6 +19,8 @@
 
 #include <cstdint>
 #include <cstring>
+
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -76,6 +78,10 @@ string BestAvailableTypeName(const T &object) {
 #else
 	return "<Type name not available>";
 #endif
+}
+
+static inline bool VectorContainsString(const vector<string> &vec, const string &str) {
+	return std::find(vec.begin(), vec.end(), str) != vec.end();
 }
 
 } // namespace common

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -3,10 +3,12 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 add_library(mender_context STATIC context/context.cpp)
 target_include_directories(mender_context PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 target_link_libraries(mender_context PUBLIC
+  artifact
   common_error
   common_key_value_database
   common_conf
   common_json
+  common_log
   common_path
 )
 

--- a/mender-update/context.hpp
+++ b/mender-update/context.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 
+#include <artifact/artifact.hpp>
 #include <common/conf.hpp>
 #include <common/error.hpp>
 #include <common/expected.hpp>
@@ -34,6 +35,7 @@ namespace mender {
 namespace update {
 namespace context {
 
+namespace artifact = mender::artifact;
 namespace conf = mender::common::conf;
 namespace error = mender::common::error;
 namespace expected = mender::common::expected;
@@ -93,6 +95,8 @@ public:
 	const conf::MenderConfig &GetConfig() const {
 		return config_;
 	}
+
+	expected::ExpectedBool MatchesArtifactDepends(const artifact::HeaderInfo &hdr_info);
 
 	// Suffix used for updates that either can't roll back or fail their rollback.
 	static const string broken_artifact_name_suffix;
@@ -157,6 +161,13 @@ private:
 #endif // MENDER_USE_LMDB
 	conf::MenderConfig &config_;
 };
+
+// Only here to make testing easier, use MenderContext::MatchesArtifactDepends().
+expected::ExpectedBool ArtifactMatchesContext(
+	const string &artifact_name,
+	const string &artifact_group,
+	const string &device_type,
+	const artifact::HeaderInfo &hdr_info);
 
 } // namespace context
 } // namespace update


### PR DESCRIPTION
Using a helper function ArtifactMatchesContext() to make testing
easier.

Ticket: MEN-6511
Changelog: none