### PR TITLE
chore: Respect type info depends in MenderContext::MatchesArtifactDepends()

### DIFF
--- a/common/common.hpp
+++ b/common/common.hpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifndef __clang__
@@ -82,6 +83,11 @@ string BestAvailableTypeName(const T &object) {
 
 static inline bool VectorContainsString(const vector<string> &vec, const string &str) {
 	return std::find(vec.begin(), vec.end(), str) != vec.end();
+}
+
+static inline bool MapContainsStringKey(
+	const unordered_map<string, string> &map, const string &str) {
+	return map.find(str) != map.end();
 }
 
 } // namespace common

--- a/mender-update/context.hpp
+++ b/mender-update/context.hpp
@@ -96,7 +96,7 @@ public:
 		return config_;
 	}
 
-	expected::ExpectedBool MatchesArtifactDepends(const artifact::HeaderInfo &hdr_info);
+	expected::ExpectedBool MatchesArtifactDepends(const artifact::HeaderView &hdr_view);
 
 	// Suffix used for updates that either can't roll back or fail their rollback.
 	static const string broken_artifact_name_suffix;
@@ -164,10 +164,10 @@ private:
 
 // Only here to make testing easier, use MenderContext::MatchesArtifactDepends().
 expected::ExpectedBool ArtifactMatchesContext(
-	const string &artifact_name,
-	const string &artifact_group,
+	const ProvidesData &provides,
 	const string &device_type,
-	const artifact::HeaderInfo &hdr_info);
+	const artifact::HeaderInfo &hdr_info,
+	const artifact::TypeInfo &type_info);
 
 } // namespace context
 } // namespace update


### PR DESCRIPTION
Actually done in the ArtifactMatchesContext() helper function which needs to check values from artifact::HeaderView::type_info (if any).

Also handle cases when `artifact_group` is missing in the local provides data gracefully (the value is not required to be present).

Ticket: MEN-6511
Changelog: none
