### PR TITLE
chore: Expire token before committing, so that credentials are verified.

### DIFF
--- a/api/client.hpp
+++ b/api/client.hpp
@@ -47,6 +47,10 @@ public:
 		http::ResponseHandler header_handler,
 		http::ResponseHandler body_handler) override;
 
+	void ExpireToken() {
+		authenticator_.ExpireToken();
+	}
+
 private:
 	auth::Authenticator &authenticator_;
 };

--- a/mender-update/daemon/state_machine.cpp
+++ b/mender-update/daemon/state_machine.cpp
@@ -79,7 +79,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	main_states_.AddTransition(update_install_state_,                se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
 
 	main_states_.AddTransition(update_check_reboot_state_,           se::Success,                    send_reboot_status_state_,            tf::Immediate);
-	main_states_.AddTransition(update_check_reboot_state_,           se::NothingToDo,                send_commit_status_state_,            tf::Immediate);
+	main_states_.AddTransition(update_check_reboot_state_,           se::NothingToDo,                update_before_commit_state_,          tf::Immediate);
 	main_states_.AddTransition(update_check_reboot_state_,           se::Failure,                    update_check_rollback_state_,         tf::Immediate);
 	main_states_.AddTransition(update_check_reboot_state_,           se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
 
@@ -90,9 +90,12 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	main_states_.AddTransition(update_reboot_state_,                 se::Failure,                    update_check_rollback_state_,         tf::Immediate);
 	main_states_.AddTransition(update_reboot_state_,                 se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
 
-	main_states_.AddTransition(update_verify_reboot_state_,          se::Success,                    send_commit_status_state_,            tf::Immediate);
+	main_states_.AddTransition(update_verify_reboot_state_,          se::Success,                    update_before_commit_state_,          tf::Immediate);
 	main_states_.AddTransition(update_verify_reboot_state_,          se::Failure,                    update_check_rollback_state_,         tf::Immediate);
 	main_states_.AddTransition(update_verify_reboot_state_,          se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+
+	// Cannot fail.
+	main_states_.AddTransition(update_before_commit_state_,          se::Success,                    send_commit_status_state_,            tf::Immediate);
 
 	main_states_.AddTransition(send_commit_status_state_,            se::Success,                    update_commit_state_,                 tf::Immediate);
 	main_states_.AddTransition(send_commit_status_state_,            se::Failure,                    update_check_rollback_state_,         tf::Immediate);

--- a/mender-update/daemon/state_machine.hpp
+++ b/mender-update/daemon/state_machine.hpp
@@ -75,6 +75,7 @@ private:
 	UpdateRebootState update_reboot_state_;
 	UpdateVerifyRebootState update_verify_reboot_state_;
 	SendStatusUpdateState send_commit_status_state_;
+	UpdateBeforeCommitState update_before_commit_state_;
 	UpdateCommitState update_commit_state_;
 	UpdateAfterCommitState update_after_commit_state_;
 	UpdateCheckRollbackState update_check_rollback_state_;

--- a/mender-update/daemon/states.cpp
+++ b/mender-update/daemon/states.cpp
@@ -479,6 +479,14 @@ void UpdateVerifyRebootState::OnEnterSaveState(Context &ctx, sm::EventPoster<Sta
 			ctx.event_loop, DefaultStateHandler {poster}));
 }
 
+void UpdateBeforeCommitState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) {
+	// It's possible that the update we have done has changed our credentials. Therefore it's
+	// important that we try to log in from scratch and do not use the token we already have.
+	ctx.http_client.ExpireToken();
+
+	poster.PostEvent(StateEvent::Success);
+}
+
 void UpdateCommitState::OnEnterSaveState(Context &ctx, sm::EventPoster<StateEvent> &poster) {
 	log::Debug("Entering ArtifactCommit state");
 

--- a/mender-update/daemon/states.hpp
+++ b/mender-update/daemon/states.hpp
@@ -162,6 +162,11 @@ public:
 	}
 };
 
+class UpdateBeforeCommitState : virtual public StateType {
+public:
+	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
+};
+
 class UpdateCommitState : virtual public SaveState {
 public:
 	void OnEnterSaveState(Context &ctx, sm::EventPoster<StateEvent> &poster) override;


### PR DESCRIPTION
While we don't test a scenario with broken credentials exactly, it is indirectly tested because what would happen is that the status update would fail. This is already tested in other ways, so let's leave it at that.

Ticket: MEN-6582
