### PR TITLE
chore: Fix mender-auth CLI interface.

### DIFF
--- a/mender-auth/CMakeLists.txt
+++ b/mender-auth/CMakeLists.txt
@@ -1,12 +1,8 @@
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
-add_executable(mender-auth actions.cpp main.cpp)
+add_executable(mender-auth main.cpp)
 target_link_libraries(mender-auth PRIVATE
-  common_log
-  common_conf
-  common_setup
-  api_auth
-  mender_auth_ipc_server
+  mender_auth_cli
 )
 install(TARGETS mender-auth
   DESTINATION bin
@@ -20,3 +16,4 @@ add_custom_target(uninstall-mender-auth
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_subdirectory(ipc)
+add_subdirectory(cli)

--- a/mender-auth/cli/CMakeLists.txt
+++ b/mender-auth/cli/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(mender_auth_cli STATIC
+  actions.cpp
+  cli.cpp
+)
+target_link_libraries(mender_auth_cli PUBLIC
+  common_conf
+  common_crypto
+  common_error
+  common_json
+  common_path
+  common_setup
+  mender_auth_ipc_server
+)

--- a/mender-auth/cli/actions.cpp
+++ b/mender-auth/cli/actions.cpp
@@ -30,7 +30,7 @@ namespace cli {
 using namespace std;
 
 namespace events = mender::common::events;
-namespace mlog = mender::common::log;
+namespace log = mender::common::log;
 namespace path = mender::common::path;
 
 namespace ipc = mender::auth::ipc;
@@ -57,8 +57,8 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 
 	auto err = ipc_server.Listen(server_url);
 	if (err != error::NoError) {
-		mlog::Error("Failed to start the listen loop");
-		mlog::Error(err.String());
+		log::Error("Failed to start the listen loop");
+		log::Error(err.String());
 		return error::MakeError(error::ExitWithFailureError, "");
 	}
 

--- a/mender-auth/cli/actions.cpp
+++ b/mender-auth/cli/actions.cpp
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include <mender-auth/actions.hpp>
+#include <mender-auth/cli/actions.hpp>
+
 #include <mender-auth/context.hpp>
 
 #include <common/conf.hpp>
@@ -20,7 +21,7 @@
 
 namespace mender {
 namespace auth {
-namespace actions {
+namespace cli {
 
 using namespace std;
 
@@ -44,6 +45,6 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 	return error::MakeError(error::ProgrammingError, "Not implemented...");
 }
 
-} // namespace actions
+} // namespace cli
 } // namespace auth
 } // namespace mender

--- a/mender-auth/cli/actions.hpp
+++ b/mender-auth/cli/actions.hpp
@@ -24,7 +24,7 @@
 
 namespace mender {
 namespace auth {
-namespace actions {
+namespace cli {
 
 using namespace std;
 
@@ -53,7 +53,7 @@ private:
 	unique_ptr<crypto::PrivateKey> private_key_;
 };
 
-} // namespace actions
+} // namespace cli
 } // namespace auth
 } // namespace mender
 

--- a/mender-auth/cli/cli.cpp
+++ b/mender-auth/cli/cli.cpp
@@ -1,0 +1,147 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <mender-auth/cli/cli.hpp>
+
+#include <string>
+
+#include <common/conf.hpp>
+#include <common/events.hpp>
+#include <common/expected.hpp>
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/setup.hpp>
+
+#include <mender-auth/cli/actions.hpp>
+#include <mender-auth/ipc/server.hpp>
+
+namespace mender {
+namespace auth {
+namespace cli {
+
+using namespace std;
+
+namespace conf = mender::common::conf;
+namespace events = mender::common::events;
+namespace expected = mender::common::expected;
+namespace io = mender::common::io;
+namespace mlog = mender::common::log;
+namespace setup = mender::common::setup;
+
+namespace ipc = mender::auth::ipc;
+
+static expected::ExpectedString GetPassphraseFromFile(const string &filepath) {
+	string passphrase = "";
+	if (filepath == "") {
+		return passphrase;
+	}
+
+	auto ex_ifs = io::OpenIfstream(filepath == "-" ? io::paths::Stdin : filepath);
+	if (!ex_ifs) {
+		return expected::unexpected(ex_ifs.error());
+	}
+	auto &ifs = ex_ifs.value();
+
+	errno = 0;
+	getline(ifs, passphrase);
+	if (ifs.bad()) {
+		int io_errno = errno;
+		error::Error err {
+			generic_category().default_error_condition(io_errno),
+			"Failed to read passphrase from '" + filepath + "'"};
+		return expected::unexpected(err);
+	}
+
+	return passphrase;
+}
+
+static ExpectedActionPtr ParseUpdateArguments(
+	const conf::MenderConfig &config,
+	vector<string>::const_iterator start,
+	vector<string>::const_iterator end) {
+	if (start == end) {
+		return expected::unexpected(conf::MakeError(conf::InvalidOptionsError, "Need an action"));
+	}
+
+	if (start[0] == "daemon") {
+		string passphrase = "";
+		conf::CmdlineOptionsIterator opts_iter(start + 1, end, {"--passphrase-file"}, {});
+		auto ex_opt_val = opts_iter.Next();
+
+		while (ex_opt_val
+			   && ((ex_opt_val.value().option != "") || (ex_opt_val.value().value != ""))) {
+			auto opt_val = ex_opt_val.value();
+			if ((opt_val.option == "--passphrase-file")) {
+				auto ex_passphrase = GetPassphraseFromFile(opt_val.value);
+				if (!ex_passphrase) {
+					return expected::unexpected(ex_passphrase.error());
+				}
+				passphrase = ex_passphrase.value();
+			}
+			ex_opt_val = opts_iter.Next();
+		}
+		if (!ex_opt_val) {
+			return expected::unexpected(ex_opt_val.error());
+		}
+		return DaemonAction::Create(config, passphrase);
+	} else {
+		return expected::unexpected(
+			conf::MakeError(conf::InvalidOptionsError, "No such action: " + start[0]));
+	}
+}
+
+error::Error DoMain(int argc, char *argv[]) {
+	setup::GlobalSetup();
+
+	conf::MenderConfig config;
+	if (argc > 1) {
+		vector<string> args(argv + 1, argv + argc);
+		auto arg_pos = config.ProcessCmdlineArgs(args.begin(), args.end());
+		if (!arg_pos) {
+			return arg_pos.error();
+		}
+
+		auto action = ParseUpdateArguments(config, args.begin() + arg_pos.value(), args.end());
+		if (!action) {
+			return action.error();
+		}
+	} else {
+		auto err = config.LoadDefaults();
+		if (err != error::NoError) {
+			return err;
+		}
+	}
+
+	events::EventLoop loop {};
+
+	auto ipc_server {ipc::Server(loop, config)};
+
+	const string server_url {"http://127.0.0.1:8001"};
+
+	auto err = ipc_server.Listen(server_url);
+	if (err != error::NoError) {
+		mlog::Error("Failed to start the listen loop");
+		mlog::Error(err.String());
+		return error::MakeError(error::ExitWithFailureError, "");
+	}
+
+	loop.Run();
+	mlog::Info("Finished running the main loop!");
+
+	return error::NoError;
+}
+
+} // namespace cli
+} // namespace auth
+} // namespace mender

--- a/mender-auth/cli/cli.hpp
+++ b/mender-auth/cli/cli.hpp
@@ -12,27 +12,21 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include <iostream>
+#ifndef MENDER_AUTH_CLI_HPP
+#define MENDER_AUTH_CLI_HPP
 
 #include <common/error.hpp>
 
-#include <mender-auth/cli/cli.hpp>
-
-using namespace std;
+namespace mender {
+namespace auth {
+namespace cli {
 
 namespace error = mender::common::error;
 
-int main(int argc, char *argv[]) {
-	auto err = mender::auth::cli::DoMain(argc, argv);
+error::Error DoMain(int argc, char *argv[]);
 
-	if (err != error::NoError) {
-		if (err.code == error::MakeError(error::ExitWithSuccessError, "").code) {
-			return 0;
-		} else if (err.code != error::MakeError(error::ExitWithFailureError, "").code) {
-			cerr << "Failed to process command line options: " + err.String() << endl;
-		}
-		return 1;
-	}
+} // namespace cli
+} // namespace auth
+} // namespace mender
 
-	return 0;
-}
+#endif // MENDER_AUTH_CLI_HPP


### PR DESCRIPTION
Require `daemon` argument to actually run the daemon, and produce
failure when no argument is given.

Ticket: MEN-6639