### PR TITLE
chore: Clean-up `gmock` use in tests

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(auth_test EXCLUDE_FROM_ALL auth_test.cpp)
 target_link_libraries(auth_test PUBLIC
   api_auth
   common_testing
-  main_test gmock
+  main_test
 )
 gtest_discover_tests(auth_test
   ${MENDER_TEST_FLAGS}
@@ -36,7 +36,7 @@ add_executable(client_test EXCLUDE_FROM_ALL client_test.cpp)
 target_link_libraries(client_test PUBLIC
   api_client
   common_testing
-  main_test gmock
+  main_test
 )
 gtest_discover_tests(client_test
   ${MENDER_TEST_FLAGS}

--- a/api/auth_test.cpp
+++ b/api/auth_test.cpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <iostream>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <common/http.hpp>

--- a/api/client_test.cpp
+++ b/api/client_test.cpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <iostream>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <api/auth.hpp>

--- a/artifact/sha/CMakeLists.txt
+++ b/artifact/sha/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(sha PUBLIC
 
 # Test the shasummer
 add_executable(sha_test EXCLUDE_FROM_ALL sha_test.cpp)
-target_link_libraries(sha_test PRIVATE sha main_test gmock common_io)
+target_link_libraries(sha_test PRIVATE sha main_test common_io)
 target_include_directories(sha_test PRIVATE
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/artifact

--- a/artifact/sha/sha_test.cpp
+++ b/artifact/sha/sha_test.cpp
@@ -16,7 +16,6 @@
 #include <common/io.hpp>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <string>
 #include <vector>
 

--- a/artifact/v3/manifest/CMakeLists.txt
+++ b/artifact/v3/manifest/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(artifact_manifest_parser_test PRIVATE
   common_io
   common_error
   main_test
-  gmock
   artifact_parser
 )
 target_include_directories(artifact_manifest_parser_test PRIVATE

--- a/artifact/v3/manifest/manifest_test.cpp
+++ b/artifact/v3/manifest/manifest_test.cpp
@@ -17,7 +17,6 @@
 #include <string>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 #include <common/log.hpp>
 

--- a/artifact/v3/manifest_sig/CMakeLists.txt
+++ b/artifact/v3/manifest_sig/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(artifact_manifest_sig_parser_test PRIVATE
   common_error
   common_crypto
   GTest::gtest_main
-  gmock
 )
 target_include_directories(artifact_manifest_sig_parser_test PRIVATE
   ${CMAKE_SOURCE_DIR}

--- a/artifact/v3/manifest_sig/manifest_sig_test.cpp
+++ b/artifact/v3/manifest_sig/manifest_sig_test.cpp
@@ -17,7 +17,6 @@
 #include <string>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 using namespace std;
 

--- a/artifact/v3/payload/CMakeLists.txt
+++ b/artifact/v3/payload/CMakeLists.txt
@@ -4,7 +4,6 @@ add_executable(artifact_payload_parser_test EXCLUDE_FROM_ALL
 )
 target_link_libraries(artifact_payload_parser_test PRIVATE
   main_test
-  gmock
   common_io
   common_error
   common_log

--- a/artifact/v3/payload/payload_test.cpp
+++ b/artifact/v3/payload/payload_test.cpp
@@ -18,7 +18,6 @@
 #include <fstream>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 #include <artifact/tar/tar.hpp>
 #include <artifact/v3/manifest/manifest.hpp>

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 add_library(main_test STATIC EXCLUDE_FROM_ALL main_test.cpp)
 target_link_libraries(main_test PRIVATE common_log)
-target_link_libraries(main_test PUBLIC common_setup gmock)
+target_link_libraries(main_test PUBLIC common_setup gtest)
 target_compile_options(main_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 add_dependencies(tests main_test)
 
@@ -62,7 +62,7 @@ target_link_libraries(common_testing PUBLIC
   common_log
   common_json
   common_processes
-  gmock
+  gtest
 )
 
 add_executable(json_test EXCLUDE_FROM_ALL json_test.cpp)
@@ -170,7 +170,7 @@ if(${json_sources} MATCHES ".*nlohmann.*")
 endif()
 
 add_executable(config_parser_test EXCLUDE_FROM_ALL config_parser_test.cpp)
-target_link_libraries(config_parser_test PUBLIC common_config_parser main_test gmock)
+target_link_libraries(config_parser_test PUBLIC common_config_parser main_test)
 # The test uses some non-c++11 stuff, even though the implementation is c++11.
 target_compile_options(config_parser_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 gtest_discover_tests(config_parser_test)
@@ -204,7 +204,7 @@ target_link_libraries(common_key_value_parser PUBLIC common_error)
 target_include_directories(common_key_value_parser PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 
 add_executable(key_value_parser_test EXCLUDE_FROM_ALL key_value_parser_test.cpp)
-target_link_libraries(key_value_parser_test PUBLIC common_key_value_parser main_test gmock)
+target_link_libraries(key_value_parser_test PUBLIC common_key_value_parser main_test)
 target_include_directories(key_value_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(key_value_parser_test)
 add_dependencies(tests key_value_parser_test)
@@ -215,7 +215,7 @@ target_include_directories(common_identity_parser PRIVATE ${CMAKE_SOURCE_DIR} ${
 target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes)
 
 add_executable(identity_parser_test EXCLUDE_FROM_ALL identity_parser_test.cpp)
-target_link_libraries(identity_parser_test PUBLIC common_identity_parser main_test gmock)
+target_link_libraries(identity_parser_test PUBLIC common_identity_parser main_test)
 target_include_directories(identity_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(identity_parser_test)
 add_dependencies(tests identity_parser_test)
@@ -228,7 +228,7 @@ target_include_directories(common_inventory_parser PRIVATE ${CMAKE_SOURCE_DIR} $
 target_link_libraries(common_inventory_parser PUBLIC common_key_value_parser common_processes common_log)
 
 add_executable(inventory_parser_test EXCLUDE_FROM_ALL inventory_parser_test.cpp)
-target_link_libraries(inventory_parser_test PUBLIC common_inventory_parser common_testing main_test gmock)
+target_link_libraries(inventory_parser_test PUBLIC common_inventory_parser common_testing main_test)
 target_include_directories(inventory_parser_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(inventory_parser_test)
 add_dependencies(tests inventory_parser_test)
@@ -237,7 +237,7 @@ add_library(common_conf STATIC conf/conf.cpp)
 target_link_libraries(common_conf PUBLIC common_log common_error common_path common_config_parser)
 
 add_executable(conf_test EXCLUDE_FROM_ALL conf_test.cpp)
-target_link_libraries(conf_test PUBLIC common_conf main_test gmock)
+target_link_libraries(conf_test PUBLIC common_conf main_test)
 target_include_directories(conf_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(conf_test)
 add_dependencies(tests conf_test)

--- a/common/config_parser_test.cpp
+++ b/common/config_parser_test.cpp
@@ -16,7 +16,6 @@
 #include <common/json.hpp>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 #include <fstream>
 

--- a/common/identity_parser_test.cpp
+++ b/common/identity_parser_test.cpp
@@ -16,7 +16,6 @@
 
 #include <sys/stat.h>
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <fstream>
 
 #include <common/key_value_parser.hpp>

--- a/common/inventory_parser_test.cpp
+++ b/common/inventory_parser_test.cpp
@@ -16,7 +16,6 @@
 
 #include <sys/stat.h>
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <fstream>
 
 #include <common/key_value_parser.hpp>

--- a/mender-auth/ipc/CMakeLists.txt
+++ b/mender-auth/ipc/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(mender_auth_ipc_server_test PUBLIC
   mender_auth_ipc_server
   common_http
   common_testing
-  main_test gmock
+  main_test
 )
 target_include_directories(mender_auth_ipc_server_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(mender_auth_ipc_server_test

--- a/mender-auth/ipc/server_test.cpp
+++ b/mender-auth/ipc/server_test.cpp
@@ -19,7 +19,6 @@
 #include <thread>
 #include <vector>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <common/conf.hpp>

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -17,7 +17,6 @@ target_link_libraries(context_test PUBLIC
   mender_context
   common_testing
   main_test
-  gmock
 )
 target_include_directories(context_test PRIVATE ${CMAKE_SOURCE_DIR})
 gtest_discover_tests(context_test)
@@ -126,7 +125,6 @@ target_link_libraries(mender_update_state_test PUBLIC
   common_testing
   mender_update_daemon
   main_test
-  gmock
 )
 target_compile_options(mender_update_state_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 # Use NO_PRETTY_VALUES to avoid very long byte strings in the output due to

--- a/mender-update/context_test.cpp
+++ b/mender-update/context_test.cpp
@@ -26,7 +26,6 @@
 #include <common/testing.hpp>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 namespace artifact = mender::artifact;
 namespace error = mender::common::error;

--- a/mender-update/daemon/state_test.cpp
+++ b/mender-update/daemon/state_test.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <common/common.hpp>


### PR DESCRIPTION
Many tests had the header and include path while only using GTest.

Completely unnecessary clean-up...