### PR TITLE
test: Fix and add the daemon state script tests

### DIFF
--- a/artifact/v3/scripts/executor.cpp
+++ b/artifact/v3/scripts/executor.cpp
@@ -104,12 +104,17 @@ bool isValidStateScript(const string &file, State state, Action action) {
 
 function<bool(const string &)> Matcher(State state, Action action) {
 	return [state, action](const string &file) {
-		auto exp_executable = path::IsExecutable(file, false);
+		const bool is_valid {isValidStateScript(file, state, action)};
+		if (!is_valid) {
+			log::Trace(file + " is not a valid State Script for the state: " + Name(state, action));
+			return false;
+		}
+		auto exp_executable = path::IsExecutable(file, true);
 		if (!exp_executable) {
 			log::Debug("Issue figuring the executable bits of: " + exp_executable.error().String());
 			return false;
 		}
-		return exp_executable.value() and isValidStateScript(file, state, action);
+		return is_valid and exp_executable.value();
 	};
 }
 
@@ -138,8 +143,8 @@ string ScriptRunner::ScriptPath(State state) {
 	return this->rootfs_script_path_;
 }
 
-string ScriptRunner::Name() {
-	return state_map.at(state_) + action_map.at(action_);
+string Name(const State state, const Action action) {
+	return state_map.at(state) + action_map.at(action);
 }
 
 ScriptRunner::ScriptRunner(
@@ -218,7 +223,7 @@ Error ScriptRunner::Execute(
 		this->loop_,
 		[this, current_script, end, ignore_error, handler](Error err) {
 			if (err != error::NoError) {
-				if (ignore_error || this->action_ == Action::Error) {
+				if (ignore_error) {
 					return LogErrAndExecuteNext(err, current_script, end, ignore_error, handler);
 				}
 				return HandleScriptError(err, handler);
@@ -234,8 +239,6 @@ Error ScriptRunner::Execute(
 
 Error ScriptRunner::AsyncRunScripts(
 	State state, Action action, HandlerFunction handler, RunError on_error) {
-	this->action_ = action;
-	this->state_ = state;
 	if (IsArtifactScript(state)) {
 		// Verify the version in the version file (OK if no version file present)
 		auto version_file_error {
@@ -246,10 +249,12 @@ Error ScriptRunner::AsyncRunScripts(
 	}
 
 	// Collect
-	auto exp_scripts {path::ListFiles(ScriptPath(state_), Matcher(state_, action_))};
+	const auto script_path {ScriptPath(state)};
+	auto exp_scripts {path::ListFiles(script_path, Matcher(state, action))};
 	if (!exp_scripts) {
 		// Missing directory is OK
 		if (exp_scripts.error().IsErrno(ENOENT)) {
+			log::Warning("Found no state script directory (" + script_path + "). Continuing on");
 			handler(error::NoError);
 			return error::NoError;
 		}
@@ -268,7 +273,7 @@ Error ScriptRunner::AsyncRunScripts(
 		this->collected_scripts_ = std::move(sorted_scripts);
 	}
 
-	bool ignore_error = on_error == RunError::Ignore;
+	bool ignore_error = on_error == RunError::Ignore || action == Action::Error;
 
 	// Execute
 	auto scripts_iterator {this->collected_scripts_.begin()};

--- a/artifact/v3/scripts/executor.hpp
+++ b/artifact/v3/scripts/executor.hpp
@@ -61,7 +61,7 @@ enum class Action {
 	Error,
 };
 
-enum RunError {
+enum class RunError {
 	Ignore,
 	Fail,
 };

--- a/artifact/v3/scripts/executor.hpp
+++ b/artifact/v3/scripts/executor.hpp
@@ -66,6 +66,8 @@ enum RunError {
 	Fail,
 };
 
+string Name(const State, const Action);
+
 class ScriptRunner {
 public:
 	ScriptRunner(
@@ -90,7 +92,6 @@ public:
 
 	Error RunScripts(State state, Action action, RunError on_error = RunError::Fail);
 
-	string Name();
 
 private:
 	Error Execute(
@@ -122,8 +123,6 @@ private:
 	Error error_script_error_;
 	vector<string> collected_scripts_;
 	unique_ptr<mender::common::processes::Process> script_;
-	State state_;
-	Action action_;
 };
 
 } // namespace executor

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(mender_update_daemon PUBLIC
   mender_context
   mender_deployments
   mender_inventory
+  artifact_scripts_executor
 )
 
 add_executable(mender_update_state_test EXCLUDE_FROM_ALL daemon/state_test.cpp)

--- a/mender-update/daemon/state_events.hpp
+++ b/mender-update/daemon/state_events.hpp
@@ -20,6 +20,8 @@ namespace update {
 namespace daemon {
 
 enum class StateEvent {
+	Started,
+	AlwaysSuccess,
 	Success,
 	Failure,
 	NothingToDo,
@@ -34,6 +36,10 @@ enum class StateEvent {
 
 inline std::string StateEventToString(const StateEvent &event) {
 	switch (event) {
+	case StateEvent::Started:
+		return "Started";
+	case StateEvent::AlwaysSuccess:
+		return "AlwaysSuccess";
 	case StateEvent::Success:
 		return "Success";
 	case StateEvent::Failure:

--- a/mender-update/daemon/state_machine/state_machine.cpp
+++ b/mender-update/daemon/state_machine/state_machine.cpp
@@ -44,7 +44,12 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	send_final_status_state_(
 		optional::nullopt, event_loop, ctx.mender_context.GetConfig().retry_poll_interval_seconds),
 	exit_state_(event_loop),
-	main_states_(idle_state_),
+	main_states_(init_state_),
+	state_scripts_(
+		event_loop,
+		chrono::seconds {ctx.mender_context.GetConfig().state_script_timeout_seconds},
+		ctx_.mender_context.GetConfig().paths.GetArtScriptsPath(),
+		ctx_.mender_context.GetConfig().paths.GetRootfsScriptsPath()),
 	runner_(ctx) {
 	runner_.AddStateMachine(main_states_);
 	runner_.AddStateMachine(deployment_tracking_.states_);
@@ -54,130 +59,224 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	using se = StateEvent;
 	using tf = sm::TransitionFlag;
 
+	auto &ss = state_scripts_;
+
 	// When updating the table below, make sure that the initial states are in sync as well, in
 	// LoadStateFromDb().
 
 	// clang-format off
-	main_states_.AddTransition(idle_state_,                          se::DeploymentPollingTriggered, poll_for_deployment_state_,           tf::Deferred );
-	main_states_.AddTransition(idle_state_,                          se::InventoryPollingTriggered,  submit_inventory_state_,              tf::Deferred );
+	main_states_.AddTransition(init_state_,                             se::Started,                     ss.idle_enter_,                          tf::Immediate);
 
-	main_states_.AddTransition(submit_inventory_state_,              se::Success,                    idle_state_,                          tf::Immediate);
-	main_states_.AddTransition(submit_inventory_state_,              se::Failure,                    idle_state_,                          tf::Immediate);
+	main_states_.AddTransition(ss.idle_enter_,                          se::Success,                     idle_state_,                             tf::Immediate);
+	main_states_.AddTransition(ss.idle_enter_,                          se::Failure,                     idle_state_,                             tf::Immediate);
 
-	main_states_.AddTransition(poll_for_deployment_state_,           se::Success,                    send_download_status_state_,          tf::Immediate);
-	main_states_.AddTransition(poll_for_deployment_state_,           se::NothingToDo,                idle_state_,                          tf::Immediate);
-	main_states_.AddTransition(poll_for_deployment_state_,           se::Failure,                    idle_state_,                          tf::Immediate);
+	main_states_.AddTransition(idle_state_,                             se::DeploymentPollingTriggered,  ss.idle_leave_deploy_,                   tf::Deferred);
+	main_states_.AddTransition(idle_state_,                             se::InventoryPollingTriggered,   ss.idle_leave_inv_,                      tf::Deferred);
+
+	main_states_.AddTransition(ss.idle_leave_deploy_,                   se::Success,                     ss.sync_enter_deployment_,               tf::Immediate);
+	main_states_.AddTransition(ss.idle_leave_deploy_,                   se::Failure,                     ss.sync_enter_deployment_,               tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_enter_deployment_,               se::Success,                     poll_for_deployment_state_,              tf::Immediate);
+	main_states_.AddTransition(ss.sync_enter_deployment_,               se::Failure,                     ss.sync_error_,                          tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_error_,                          se::Success,                     ss.idle_enter_,                          tf::Immediate);
+	main_states_.AddTransition(ss.sync_error_,                          se::Failure,                     ss.idle_enter_,                          tf::Immediate);
+
+	main_states_.AddTransition(ss.idle_leave_inv_,                      se::Success,                     ss.sync_enter_inventory_,                tf::Immediate);
+	main_states_.AddTransition(ss.idle_leave_inv_,                      se::Failure,                     ss.sync_enter_inventory_,                tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_enter_inventory_,                se::Success,                     submit_inventory_state_,                 tf::Immediate);
+	main_states_.AddTransition(ss.sync_enter_inventory_,                se::Failure,                     ss.sync_error_,                          tf::Immediate);
+
+	main_states_.AddTransition(submit_inventory_state_,                 se::Success,                     ss.sync_leave_,                          tf::Immediate);
+	main_states_.AddTransition(submit_inventory_state_,                 se::Failure,                     ss.sync_error_,                          tf::Immediate);
+
+	main_states_.AddTransition(poll_for_deployment_state_,              se::Success,                     ss.sync_leave_download_,                 tf::Immediate);
+	main_states_.AddTransition(poll_for_deployment_state_,              se::NothingToDo,                 ss.sync_leave_,                          tf::Immediate);
+	main_states_.AddTransition(poll_for_deployment_state_,              se::Failure,                     ss.sync_error_,                          tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_leave_,                          se::Success,                     ss.idle_enter_,                          tf::Immediate);
+	main_states_.AddTransition(ss.sync_leave_,                          se::Failure,                     ss.sync_error_,                          tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_leave_download_,                 se::Success,                     send_download_status_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.sync_leave_download_,                 se::Failure,                     ss.sync_error_,                          tf::Immediate);
 
 	// Cannot fail due to FailureMode::Ignore.
-	main_states_.AddTransition(send_download_status_state_,          se::Success,                    update_download_state_,               tf::Immediate);
+	main_states_.AddTransition(send_download_status_state_,             se::Success,                     ss.download_enter_,                      tf::Immediate);
 
-	main_states_.AddTransition(update_download_state_,               se::Success,                    send_install_status_state_,           tf::Immediate);
-	main_states_.AddTransition(update_download_state_,               se::Failure,                    update_rollback_not_needed_state_,    tf::Immediate);
-	// Empty payload
-	main_states_.AddTransition(update_download_state_,               se::NothingToDo,                update_save_provides_state_,          tf::Immediate);
-	main_states_.AddTransition(update_download_state_,               se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.download_enter_,                      se::Success,                     update_download_state_,                  tf::Immediate);
+	main_states_.AddTransition(ss.download_enter_,                      se::Failure,                     ss.download_error_,                      tf::Immediate);
+	main_states_.AddTransition(ss.download_enter_,                      se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+	main_states_.AddTransition(ss.download_error_,                      se::Success,                     update_rollback_not_needed_state_,       tf::Immediate);
+	main_states_.AddTransition(ss.download_error_,                      se::Failure,                     update_rollback_not_needed_state_,       tf::Immediate);
+
+	main_states_.AddTransition(update_download_state_,                  se::Success,                     ss.download_leave_,                      tf::Immediate);
+	main_states_.AddTransition(update_download_state_,                  se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+	main_states_.AddTransition(update_download_state_,                  se::Failure,                     ss.download_error_,                      tf::Immediate);
+	main_states_.AddTransition(update_download_state_,                  se::NothingToDo,                 ss.download_leave_save_provides,         tf::Immediate);
+
+	main_states_.AddTransition(ss.download_leave_,                      se::Success,                     send_install_status_state_,              tf::Immediate);
+	main_states_.AddTransition(ss.download_leave_,                      se::Failure,                     ss.download_error_,                      tf::Immediate);
+
+	main_states_.AddTransition(ss.download_leave_save_provides,         se::Success,                     update_save_provides_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.download_leave_save_provides,         se::Failure,                     ss.download_error_,                      tf::Immediate);
+
+	main_states_.AddTransition(ss.install_enter_,                       se::Success,                     update_install_state_,                   tf::Immediate);
+	main_states_.AddTransition(ss.install_enter_,                       se::Failure,                     ss.install_error_rollback_,              tf::Immediate);
 
 	// Cannot fail due to FailureMode::Ignore.
-	main_states_.AddTransition(send_install_status_state_,           se::Success,                    update_install_state_,                tf::Immediate);
+	main_states_.AddTransition(send_install_status_state_,              se::Success,                     ss.install_enter_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_install_state_,                se::Success,                    update_check_reboot_state_,           tf::Immediate);
-	main_states_.AddTransition(update_install_state_,                se::Failure,                    update_check_rollback_state_,         tf::Immediate);
-	main_states_.AddTransition(update_install_state_,                se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_install_state_,                   se::Success,                     ss.install_leave_,                       tf::Immediate);
+	main_states_.AddTransition(update_install_state_,                   se::Failure,                     ss.install_error_rollback_,              tf::Immediate);
+	main_states_.AddTransition(update_install_state_,                   se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_check_reboot_state_,           se::Success,                    send_reboot_status_state_,            tf::Immediate);
-	main_states_.AddTransition(update_check_reboot_state_,           se::NothingToDo,                update_before_commit_state_,          tf::Immediate);
-	main_states_.AddTransition(update_check_reboot_state_,           se::Failure,                    update_check_rollback_state_,         tf::Immediate);
-	main_states_.AddTransition(update_check_reboot_state_,           se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.install_leave_,                       se::Success,                     update_check_reboot_state_,              tf::Immediate);
+	main_states_.AddTransition(ss.install_leave_,                       se::Failure,                     ss.install_error_rollback_,              tf::Immediate);
+	main_states_.AddTransition(ss.install_error_rollback_,              se::Success,                     update_check_rollback_state_,            tf::Immediate);
+	main_states_.AddTransition(ss.install_error_rollback_,              se::Failure,                     update_check_rollback_state_,            tf::Immediate);
+
+	main_states_.AddTransition(ss.failure_enter_,                       se::Success,                     update_failure_state_,                   tf::Immediate);
+	main_states_.AddTransition(ss.failure_enter_,                       se::Failure,                     update_failure_state_,                   tf::Immediate);
+	main_states_.AddTransition(ss.failure_enter_,                       se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+
+	main_states_.AddTransition(update_check_reboot_state_,              se::Success,                     send_reboot_status_state_,               tf::Immediate);
+	main_states_.AddTransition(update_check_reboot_state_,              se::NothingToDo,                 update_before_commit_state_,             tf::Immediate);
+	main_states_.AddTransition(update_check_reboot_state_,              se::Failure,                     update_check_rollback_state_,            tf::Immediate);
+	main_states_.AddTransition(update_check_reboot_state_,              se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
 	// Cannot fail due to FailureMode::Ignore.
-	main_states_.AddTransition(send_reboot_status_state_,            se::Success,                    update_reboot_state_,                 tf::Immediate);
+	main_states_.AddTransition(send_reboot_status_state_,               se::Success,                     ss.reboot_enter_,                        tf::Immediate);
 
-	main_states_.AddTransition(update_reboot_state_,                 se::Success,                    update_verify_reboot_state_,          tf::Immediate);
-	main_states_.AddTransition(update_reboot_state_,                 se::Failure,                    update_check_rollback_state_,         tf::Immediate);
-	main_states_.AddTransition(update_reboot_state_,                 se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.reboot_enter_,                        se::Success,                     update_reboot_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.reboot_enter_,                        se::Failure,                     ss.reboot_error_,                        tf::Immediate);
 
-	main_states_.AddTransition(update_verify_reboot_state_,          se::Success,                    update_before_commit_state_,          tf::Immediate);
-	main_states_.AddTransition(update_verify_reboot_state_,          se::Failure,                    update_check_rollback_state_,         tf::Immediate);
-	main_states_.AddTransition(update_verify_reboot_state_,          se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_reboot_state_,                    se::Success,                     update_verify_reboot_state_,             tf::Immediate);
+	main_states_.AddTransition(update_reboot_state_,                    se::Failure,                     ss.reboot_error_,                        tf::Immediate);
+	main_states_.AddTransition(update_reboot_state_,                    se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(ss.reboot_error_,                        se::Success,                     update_check_rollback_state_,            tf::Immediate);
+	main_states_.AddTransition(ss.reboot_error_,                        se::Failure,                     update_check_rollback_state_,            tf::Immediate);
+
+	main_states_.AddTransition(update_verify_reboot_state_,             se::Success,                     ss.reboot_leave_,                        tf::Immediate);
+	main_states_.AddTransition(update_verify_reboot_state_,             se::Failure,                     ss.reboot_error_,                        tf::Immediate);
+	main_states_.AddTransition(update_verify_reboot_state_,             se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(ss.reboot_leave_,                        se::Success,                     update_before_commit_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.reboot_leave_,                        se::Failure,                     ss.reboot_error_,                        tf::Immediate);
 
 	// Cannot fail.
-	main_states_.AddTransition(update_before_commit_state_,          se::Success,                    send_commit_status_state_,            tf::Immediate);
+	main_states_.AddTransition(update_before_commit_state_,             se::Success,                     send_commit_status_state_,               tf::Immediate);
 
-	main_states_.AddTransition(send_commit_status_state_,            se::Success,                    update_commit_state_,                 tf::Immediate);
-	main_states_.AddTransition(send_commit_status_state_,            se::Failure,                    update_check_rollback_state_,         tf::Immediate);
+	main_states_.AddTransition(send_commit_status_state_,               se::Success,                     ss.commit_enter_,                        tf::Immediate);
+	main_states_.AddTransition(send_commit_status_state_,               se::Failure,                     update_check_rollback_state_,            tf::Immediate);
 
-	main_states_.AddTransition(update_commit_state_,                 se::Success,                    update_after_commit_state_,           tf::Immediate);
-	main_states_.AddTransition(update_commit_state_,                 se::Failure,                    update_check_rollback_state_,         tf::Immediate);
-	main_states_.AddTransition(update_commit_state_,                 se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.commit_enter_,                        se::Success,                     update_commit_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.commit_enter_,                        se::Failure,                     ss.commit_error_,                        tf::Immediate);
 
-	main_states_.AddTransition(update_after_commit_state_,           se::Success,                    update_save_provides_state_,          tf::Immediate);
-	main_states_.AddTransition(update_after_commit_state_,           se::Failure,                    update_save_provides_state_,          tf::Immediate);
-	main_states_.AddTransition(update_after_commit_state_,           se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.commit_error_,                        se::Success,                     update_check_rollback_state_,            tf::Immediate);
+	main_states_.AddTransition(ss.commit_error_,                        se::Failure,                     update_check_rollback_state_,            tf::Immediate);
 
-	main_states_.AddTransition(update_check_rollback_state_,         se::Success,                    update_rollback_state_,               tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_state_,         se::NothingToDo,                update_failure_state_,                tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_state_,         se::Failure,                    update_failure_state_,                tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_state_,         se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_commit_state_,                    se::Success,                     update_after_commit_state_,              tf::Immediate);
+	main_states_.AddTransition(update_commit_state_,                    se::Failure,                     ss.commit_error_,                        tf::Immediate);
+	main_states_.AddTransition(update_commit_state_,                    se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_rollback_state_,               se::Success,                    update_check_rollback_reboot_state_,  tf::Immediate);
-	main_states_.AddTransition(update_rollback_state_,               se::Failure,                    update_failure_state_,                tf::Immediate);
-	main_states_.AddTransition(update_rollback_state_,               se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_after_commit_state_,              se::Success,                     ss.commit_leave_,                        tf::Immediate);
+	main_states_.AddTransition(update_after_commit_state_,              se::Failure,                     ss.commit_error_save_provides_,          tf::Immediate);
+	main_states_.AddTransition(update_after_commit_state_,              se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_check_rollback_reboot_state_,  se::Success,                    update_rollback_reboot_state_,        tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_reboot_state_,  se::NothingToDo,                update_rollback_successful_state_,    tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_reboot_state_,  se::Failure,                    update_failure_state_,                tf::Immediate);
-	main_states_.AddTransition(update_check_rollback_reboot_state_,  se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.commit_leave_,                        se::Success,                     update_save_provides_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.commit_leave_,                        se::Failure,                     ss.commit_error_save_provides_,          tf::Immediate);
 
-	// No Failure transition for this state, see comments in handler.
-	main_states_.AddTransition(update_rollback_reboot_state_,        se::Success,                    update_verify_rollback_reboot_state_, tf::Immediate);
-	main_states_.AddTransition(update_rollback_reboot_state_,        se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.commit_error_save_provides_,          se::Success,                     update_save_provides_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.commit_error_save_provides_,          se::Failure,                     update_save_provides_state_,             tf::Immediate);
 
-	main_states_.AddTransition(update_verify_rollback_reboot_state_, se::Success,                    update_rollback_successful_state_,    tf::Immediate);
-	main_states_.AddTransition(update_verify_rollback_reboot_state_, se::Retry,                      update_rollback_reboot_state_,        tf::Immediate);
-	main_states_.AddTransition(update_verify_rollback_reboot_state_, se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_state_,            se::Success,                     ss.rollback_enter_,                      tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_state_,            se::NothingToDo,                 ss.failure_enter_,                       tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_state_,            se::Failure,                     ss.failure_enter_,                       tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_state_,            se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_rollback_successful_state_,    se::Success,                    update_failure_state_,                tf::Immediate);
+	main_states_.AddTransition(ss.rollback_enter_,                      se::Success,                     update_rollback_state_,                  tf::Immediate);
+	main_states_.AddTransition(ss.rollback_enter_,                      se::Failure,                     update_rollback_state_,                  tf::Immediate);
 
-	main_states_.AddTransition(update_failure_state_,                se::Success,                    update_save_provides_state_,          tf::Immediate);
-	main_states_.AddTransition(update_failure_state_,                se::Failure,                    update_save_provides_state_,          tf::Immediate);
-	main_states_.AddTransition(update_failure_state_,                se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_rollback_state_,                  se::Success,                     ss.rollback_leave_,                      tf::Immediate);
+	main_states_.AddTransition(update_rollback_state_,                  se::Failure,                     ss.rollback_leave_error_,                tf::Immediate);
+	main_states_.AddTransition(update_rollback_state_,                  se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_save_provides_state_,          se::Success,                    update_cleanup_state_,                tf::Immediate);
-	// Even if this fails, there is nothing we can do at this point.
-	main_states_.AddTransition(update_save_provides_state_,          se::Failure,                    update_cleanup_state_,                tf::Immediate);
-	main_states_.AddTransition(update_save_provides_state_,          se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(ss.rollback_leave_,                      se::Success,                     update_check_rollback_reboot_state_,     tf::Immediate);
+	main_states_.AddTransition(ss.rollback_leave_,                      se::Failure,                     update_check_rollback_reboot_state_,     tf::Immediate);
 
-	main_states_.AddTransition(update_rollback_not_needed_state_,    se::Success,                    update_cleanup_state_,                tf::Immediate);
+	main_states_.AddTransition(ss.rollback_leave_error_,                se::Success,                     ss.failure_enter_,                       tf::Immediate);
+	main_states_.AddTransition(ss.rollback_leave_error_,                se::Failure,                     ss.failure_enter_,                       tf::Immediate);
 
-	main_states_.AddTransition(update_cleanup_state_,                se::Success,                    send_final_status_state_,             tf::Immediate);
-	main_states_.AddTransition(update_cleanup_state_,                se::Failure,                    send_final_status_state_,             tf::Immediate);
-	main_states_.AddTransition(update_cleanup_state_,                se::StateLoopDetected,          state_loop_state_,                    tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_reboot_state_,     se::Success,                     ss.rollback_reboot_enter_,               tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_reboot_state_,     se::NothingToDo,                 update_rollback_successful_state_,       tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_reboot_state_,     se::Failure,                     ss.failure_enter_,                       tf::Immediate);
+	main_states_.AddTransition(update_check_rollback_reboot_state_,     se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(state_loop_state_,                    se::Success,                    send_final_status_state_,             tf::Immediate);
-	main_states_.AddTransition(state_loop_state_,                    se::Failure,                    send_final_status_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.rollback_reboot_enter_,               se::Success,                     update_rollback_reboot_state_,           tf::Immediate);
+	main_states_.AddTransition(ss.rollback_reboot_enter_,               se::Failure,                     update_rollback_reboot_state_,           tf::Immediate);
 
-	main_states_.AddTransition(send_final_status_state_,             se::Success,                    clear_artifact_data_state_,           tf::Immediate);
-	main_states_.AddTransition(send_final_status_state_,             se::Failure,                    clear_artifact_data_state_,           tf::Immediate);
+	main_states_.AddTransition(ss.rollback_reboot_error_,               se::Success,                     ss.failure_enter_,                       tf::Immediate);
+	main_states_.AddTransition(ss.rollback_reboot_error_,               se::Failure,                     ss.failure_enter_,                       tf::Immediate);
 
-	main_states_.AddTransition(clear_artifact_data_state_,           se::Success,                    end_of_deployment_state_,             tf::Immediate);
-	main_states_.AddTransition(clear_artifact_data_state_,           se::Failure,                    end_of_deployment_state_,             tf::Immediate);
+	// No Failure transition for this state see comments in handler.
+	main_states_.AddTransition(update_rollback_reboot_state_,           se::Success,                     update_verify_rollback_reboot_state_,    tf::Immediate);
+	main_states_.AddTransition(update_rollback_reboot_state_,           se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
-	main_states_.AddTransition(end_of_deployment_state_,             se::Success,                    submit_inventory_state_,              tf::Immediate);
+	main_states_.AddTransition(update_verify_rollback_reboot_state_,    se::Success,                     ss.rollback_reboot_leave_,               tf::Immediate);
+	main_states_.AddTransition(update_verify_rollback_reboot_state_,    se::Retry,                       update_rollback_reboot_state_,           tf::Immediate);
+	main_states_.AddTransition(update_verify_rollback_reboot_state_,    se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(ss.rollback_reboot_leave_,               se::Success,                     update_rollback_successful_state_,       tf::Immediate);
+	main_states_.AddTransition(ss.rollback_reboot_leave_,               se::Failure,                     ss.rollback_reboot_error_,               tf::Immediate);
+
+	main_states_.AddTransition(update_rollback_successful_state_,       se::Success,                     ss.failure_enter_,                       tf::Immediate);
+
+	main_states_.AddTransition(update_failure_state_,                   se::Success,                     ss.failure_leave_update_save_provides_,  tf::Immediate);
+	main_states_.AddTransition(update_failure_state_,                   se::Failure,                     ss.failure_leave_update_save_provides_,  tf::Immediate);
+  main_states_.AddTransition(update_failure_state_,                   se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(ss.failure_leave_update_save_provides_,  se::Success,                     update_save_provides_state_,             tf::Immediate);
+	main_states_.AddTransition(ss.failure_leave_update_save_provides_,  se::Failure,                     update_save_provides_state_,             tf::Immediate);
+
+	// Even if this fails there is nothing we can do at this point.
+	main_states_.AddTransition(update_save_provides_state_,             se::Success,                     update_cleanup_state_,                   tf::Immediate);
+	main_states_.AddTransition(update_save_provides_state_,             se::Failure,                     update_cleanup_state_,                   tf::Immediate);
+	main_states_.AddTransition(update_save_provides_state_,             se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(update_rollback_not_needed_state_,       se::Success,                     update_cleanup_state_,                   tf::Immediate);
+
+	main_states_.AddTransition(update_cleanup_state_,                   se::Success,                     send_final_status_state_,                tf::Immediate);
+	main_states_.AddTransition(update_cleanup_state_,                   se::Failure,                     send_final_status_state_,                tf::Immediate);
+	main_states_.AddTransition(update_cleanup_state_,                   se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+
+	main_states_.AddTransition(state_loop_state_,                       se::Success,                     send_final_status_state_,                tf::Immediate);
+	main_states_.AddTransition(state_loop_state_,                       se::Failure,                     send_final_status_state_,                tf::Immediate);
+
+	main_states_.AddTransition(send_final_status_state_,                se::Success,                     clear_artifact_data_state_,              tf::Immediate);
+	main_states_.AddTransition(send_final_status_state_,                se::Failure,                     clear_artifact_data_state_,              tf::Immediate);
+
+	main_states_.AddTransition(clear_artifact_data_state_,              se::Success,                     end_of_deployment_state_,                tf::Immediate);
+	main_states_.AddTransition(clear_artifact_data_state_,              se::Failure,                     end_of_deployment_state_,                tf::Immediate);
+
+	main_states_.AddTransition(end_of_deployment_state_,                se::Success,                     submit_inventory_state_,                 tf::Immediate);
 
 	auto &dt = deployment_tracking_;
 
-	dt.states_.AddTransition(dt.idle_state_,                         se::DeploymentStarted,          dt.no_failures_state_,                tf::Immediate);
+	dt.states_.AddTransition(dt.idle_state_,                            se::DeploymentStarted,           dt.no_failures_state_,                   tf::Immediate);
 
-	dt.states_.AddTransition(dt.no_failures_state_,                  se::Failure,                    dt.failure_state_,                    tf::Immediate);
-	dt.states_.AddTransition(dt.no_failures_state_,                  se::DeploymentEnded,            dt.idle_state_,                       tf::Immediate);
+	dt.states_.AddTransition(dt.no_failures_state_,                     se::Failure,                     dt.failure_state_,                       tf::Immediate);
+	dt.states_.AddTransition(dt.no_failures_state_,                     se::DeploymentEnded,             dt.idle_state_,                          tf::Immediate);
 
-	dt.states_.AddTransition(dt.failure_state_,                      se::RollbackStarted,            dt.rollback_attempted_state_,         tf::Immediate);
-	dt.states_.AddTransition(dt.failure_state_,                      se::DeploymentEnded,            dt.idle_state_,                       tf::Immediate);
+	dt.states_.AddTransition(dt.failure_state_,                         se::RollbackStarted,             dt.rollback_attempted_state_,            tf::Immediate);
+	dt.states_.AddTransition(dt.failure_state_,                         se::DeploymentEnded,             dt.idle_state_,                          tf::Immediate);
 
-	dt.states_.AddTransition(dt.rollback_attempted_state_,           se::Failure,                    dt.rollback_failed_state_,            tf::Immediate);
-	dt.states_.AddTransition(dt.rollback_attempted_state_,           se::DeploymentEnded,            dt.idle_state_,                       tf::Immediate);
+	dt.states_.AddTransition(dt.rollback_attempted_state_,              se::Failure,                     dt.rollback_failed_state_,               tf::Immediate);
+	dt.states_.AddTransition(dt.rollback_attempted_state_,              se::DeploymentEnded,             dt.idle_state_,                          tf::Immediate);
 
-	dt.states_.AddTransition(dt.rollback_failed_state_,              se::DeploymentEnded,            dt.idle_state_,                       tf::Immediate);
+	dt.states_.AddTransition(dt.rollback_failed_state_,                 se::DeploymentEnded,             dt.idle_state_,                          tf::Immediate);
 	// clang-format on
 }
 
@@ -240,7 +339,7 @@ void StateMachine::LoadStateFromDb() {
 
 	} else if (state == ctx_.kUpdateStateArtifactRollback) {
 		// Installation failed, but rollback could still succeed.
-		main_states_.SetState(update_rollback_state_);
+		main_states_.SetState(state_scripts_.rollback_enter_);
 		deployment_tracking_.states_.SetState(deployment_tracking_.rollback_attempted_state_);
 
 	} else if (
@@ -260,7 +359,7 @@ void StateMachine::LoadStateFromDb() {
 
 	} else if (state == ctx_.kUpdateStateArtifactFailure) {
 		// Re-run ArtifactFailure if spontaneously rebooted before finishing.
-		main_states_.SetState(update_failure_state_);
+		main_states_.SetState(state_scripts_.failure_enter_);
 		if (ctx_.deployment.state_data->update_info.all_rollbacks_successful) {
 			deployment_tracking_.states_.SetState(deployment_tracking_.rollback_attempted_state_);
 		} else {
@@ -283,6 +382,10 @@ void StateMachine::LoadStateFromDb() {
 	}
 
 	auto &payload_types = ctx_.deployment.state_data->update_info.artifact.payload_types;
+	if (payload_types.size() == 0) {
+		ctx_.deployment.update_module.reset();
+		return;
+	}
 	assert(payload_types.size() == 1);
 	ctx_.deployment.update_module.reset(
 		new update_module::UpdateModule(ctx_.mender_context, payload_types[0]));

--- a/mender-update/daemon/state_test.cpp
+++ b/mender-update/daemon/state_test.cpp
@@ -165,6 +165,7 @@ vector<StateTransitionsTestCase> idle_and_sync_test_cases {
 			},
 		.install_outcome = InstallOutcome::SuccessfulInstall,
 		.error_states = {"Idle_Leave_00"},
+		.generate_idle_sync_scripts = true,
 	},
 
 	StateTransitionsTestCase {
@@ -2695,7 +2696,6 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					// No states at all, because we don't even get to the point
 					// of calling update modules.
-					"Download_Enter_00",
 					"Download_Error_00",
 				},
 			.status_log =
@@ -2708,7 +2708,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 		},
 
 		StateTransitionsTestCase {
-			.case_name = "Non_writable_database_in_ArtifactInstall",
+			.case_name = "Non_writable_database_in_ArtifactInstall_Enter",
 			.state_chain =
 				{
 					"Download_Enter_00",
@@ -2733,8 +2733,8 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"installing",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::UnsuccessfulInstall,
-			.use_non_writable_db_after_n_writes = 2,
+			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.use_non_writable_db_after_n_writes = 3,
 		},
 
 		StateTransitionsTestCase {

--- a/mender-update/daemon/state_test.cpp
+++ b/mender-update/daemon/state_test.cpp
@@ -84,6 +84,169 @@ struct StateTransitionsTestCase {
 	int use_non_writable_db_after_n_writes {-1};
 	bool empty_payload_artifact;
 	bool device_type_mismatch {false};
+	bool generate_idle_sync_scripts {false};
+};
+
+
+vector<StateTransitionsTestCase> idle_and_sync_test_cases {
+	StateTransitionsTestCase {
+		.case_name = "Normal_flow_Idle_Sync_Idle",
+		.state_chain =
+			{
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Download_Enter_00",
+				"Download",
+				"Download_Leave_00",
+				"ArtifactInstall_Enter_00",
+				"ArtifactInstall",
+				"ArtifactInstall_Leave_00",
+				"ArtifactReboot_Enter_00",
+				"ArtifactReboot",
+				"ArtifactVerifyReboot",
+				"ArtifactReboot_Leave_00",
+				"ArtifactCommit_Enter_00",
+				"ArtifactCommit",
+				"ArtifactCommit_Leave_00",
+				"Cleanup", // Leave me, or clang-format is not nice
+			},
+		.status_log =
+			{
+				"downloading",
+				"installing",
+				"rebooting",
+				"installing",
+				"success",
+			},
+		.install_outcome = InstallOutcome::SuccessfulInstall,
+		.generate_idle_sync_scripts = true,
+	},
+
+	StateTransitionsTestCase {
+		.case_name = "Idle_Leave_Error",
+		.state_chain =
+			{
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Download_Enter_00",
+				"Download",
+				"Download_Leave_00",
+				"ArtifactInstall_Enter_00",
+				"ArtifactInstall",
+				"ArtifactInstall_Leave_00",
+				"ArtifactReboot_Enter_00",
+				"ArtifactReboot",
+				"ArtifactVerifyReboot",
+				"ArtifactReboot_Leave_00",
+				"ArtifactCommit_Enter_00",
+				"ArtifactCommit",
+				"ArtifactCommit_Leave_00",
+				"Cleanup", // Leave me, or clang-format is not nice
+			},
+		.status_log =
+			{
+				"downloading",
+				"installing",
+				"rebooting",
+				"installing",
+				"success",
+			},
+		.install_outcome = InstallOutcome::SuccessfulInstall,
+		.error_states = {"Idle_Leave_00"},
+	},
+
+	StateTransitionsTestCase {
+		.case_name = "Sync_Enter_Error",
+		.state_chain =
+			{
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Error_00",
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Download_Enter_00",
+				"Download",
+				"Download_Leave_00",
+				"ArtifactInstall_Enter_00",
+				"ArtifactInstall",
+				"ArtifactInstall_Leave_00",
+				"ArtifactReboot_Enter_00",
+				"ArtifactReboot",
+				"ArtifactVerifyReboot",
+				"ArtifactReboot_Leave_00",
+				"ArtifactCommit_Enter_00",
+				"ArtifactCommit",
+				"ArtifactCommit_Leave_00",
+				"Cleanup", // Leave me, or clang-format is not nice
+			},
+		.status_log =
+			{
+				"downloading",
+				"installing",
+				"rebooting",
+				"installing",
+				"success",
+			},
+		.install_outcome = InstallOutcome::SuccessfulInstall,
+		.error_states = {"Sync_Enter_00"},
+		.generate_idle_sync_scripts = true,
+	},
+
+	StateTransitionsTestCase {
+		.case_name = "Sync_Leave_Error",
+		.state_chain =
+			{
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00", // <- Only fails the first time, here
+				"Sync_Error_00",
+				"Idle_Enter_00",
+				"Idle_Leave_00",
+				"Sync_Enter_00",
+				"Sync_Leave_00",
+				"Download_Enter_00",
+				"Download",
+				"Download_Leave_00",
+				"ArtifactInstall_Enter_00",
+				"ArtifactInstall",
+				"ArtifactInstall_Leave_00",
+				"ArtifactReboot_Enter_00",
+				"ArtifactReboot",
+				"ArtifactVerifyReboot",
+				"ArtifactReboot_Leave_00",
+				"ArtifactCommit_Enter_00",
+				"ArtifactCommit",
+				"ArtifactCommit_Leave_00",
+				"Cleanup",
+			},
+		.status_log =
+			{
+				"downloading",
+				"installing",
+				"rebooting",
+				"installing",
+				"success",
+			},
+		.install_outcome = InstallOutcome::SuccessfulInstall,
+		.error_states = {"Sync_Leave_00"},
+		.generate_idle_sync_scripts = true,
+	},
 };
 
 vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
@@ -484,8 +647,8 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactVerifyReboot",
 					"ArtifactReboot_Error_00",
 					"ArtifactRollback_Enter_00",
-					"ArtifactRollback",
-					"ArtifactRollback_Leave_00",
+					"ArtifactRollback",          // <- Fails here
+					"ArtifactRollback_Leave_00", // <- No error scripts called here
 					"ArtifactFailure_Enter_00",
 					"ArtifactFailure",
 					"ArtifactFailure_Leave_00",
@@ -637,8 +800,6 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
 					"ArtifactRollbackReboot_Leave_00",
@@ -725,7 +886,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"installing",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactInstall", "ArtifactFailure"},
 		},
 
@@ -1055,7 +1216,11 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"Download_Enter_00",
 					"Download_Error_00",
 				},
-			.status_log = {""},
+			.status_log =
+				{
+					"downloading",
+					"failure",
+				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
 			.error_states = {"Download_Enter_00"},
 			.rollback_disabled = true,
@@ -1066,8 +1231,13 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.state_chain =
 				{
 					"Download_Enter_00",
+					// "Cleanup", <- No download, no update module to execute
 				},
-			.status_log = {""},
+			.status_log =
+				{
+					"downloading",
+					"failure",
+				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
 			.spont_reboot_states = {"Download_Enter_00"},
 			.rollback_disabled = true,
@@ -1090,6 +1260,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::UnsuccessfulInstall,
@@ -1101,14 +1272,17 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.case_name = "Error_in_ArtifactInstall_depends_check",
 			// This test never reaches the update module so there's nothing to
 			// record the state chain.
-			.state_chain = {},
+			.state_chain =
+				{
+					"Download_Enter_00",
+					"Download_Error_00",
+				},
 			.status_log =
 				{
 					"downloading",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
-			.error_states = {"ArtifactInstall_Enter_00"},
 			.device_type_mismatch = true,
 		},
 
@@ -1128,6 +1302,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::UnsuccessfulInstall,
@@ -1159,6 +1334,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1188,6 +1364,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1222,6 +1399,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					"downloading",
 					"installing",
+					"rebooting",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1250,6 +1428,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					"downloading",
 					"installing",
+					"rebooting",
 					"installing",
 					"success",
 				},
@@ -1290,7 +1469,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"rebooting",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactVerifyReboot", "ArtifactRollback_Enter_00"},
 		},
 
@@ -1366,7 +1545,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"rebooting",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactVerifyReboot", "ArtifactRollbackReboot_Enter_00"},
 		},
 
@@ -1435,7 +1614,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"installing",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactInstall", "ArtifactFailure_Enter_00"},
 		},
 
@@ -1506,6 +1685,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"downloading",
 					"installing",
 					"rebooting",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1544,6 +1724,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"downloading",
 					"installing",
 					"rebooting",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1574,6 +1755,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					"downloading",
 					"installing",
+					"installing",
 					"failure",
 				},
 			.install_outcome = InstallOutcome::SuccessfulRollback,
@@ -1603,6 +1785,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"installing",
 					"failure",
 				},
@@ -1876,7 +2059,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"rebooting",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactVerifyReboot", "ArtifactRollback_Leave_00"},
 		},
 
@@ -1942,6 +2125,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
 					"ArtifactRollbackReboot_Leave_00",
+					"ArtifactRollbackReboot_Error_00",
 					"ArtifactFailure_Enter_00",
 					"ArtifactFailure",
 					"ArtifactFailure_Leave_00",
@@ -1954,7 +2138,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"rebooting",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactVerifyReboot", "ArtifactRollbackReboot_Leave_00"},
 		},
 
@@ -2150,6 +2334,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					"downloading",
 					"installing",
+					"installing", // Really commit
 					"failure",
 				},
 			.install_outcome = InstallOutcome::UnsuccessfulInstall,
@@ -2176,6 +2361,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.status_log =
 				{
 					"downloading",
+					"installing",
 					"installing",
 					"success",
 				},
@@ -2204,50 +2390,48 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
+					"ArtifactRollbackReboot",
+
+					"ArtifactVerifyRollbackReboot",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
-					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
-					"ArtifactRollbackReboot_Leave_00",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
+					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot",
 					// Truncated after maximum number of state transitions.
 				},
 			.status_log =
@@ -2297,16 +2481,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactFailure",
 					"ArtifactFailure_Enter_00",
 					"ArtifactFailure",
-					"ArtifactFailure_Enter_00",
-					"ArtifactFailure",
-					"ArtifactFailure_Enter_00",
-					"ArtifactFailure",
-					"ArtifactFailure_Enter_00",
-					"ArtifactFailure",
-					"ArtifactFailure_Enter_00",
-					"ArtifactFailure",
 					// Truncated after maximum number of state transitions.
-					"ArtifactFailure_Leave_00",
 				},
 			.status_log =
 				{
@@ -2417,8 +2592,6 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"ArtifactReboot",
 					"ArtifactVerifyReboot",
 					"ArtifactReboot_Leave_00",
-					"ArtifactCommit_Enter_00",
-					"ArtifactCommit_Error_00",
 					"ArtifactRollback_Enter_00",
 					"ArtifactRollback",
 					"ArtifactRollback_Leave_00",
@@ -2522,6 +2695,8 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					// No states at all, because we don't even get to the point
 					// of calling update modules.
+					"Download_Enter_00",
+					"Download_Error_00",
 				},
 			.status_log =
 				{
@@ -2536,11 +2711,20 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 			.case_name = "Non_writable_database_in_ArtifactInstall",
 			.state_chain =
 				{
+					"Download_Enter_00",
 					"Download",
+					"Download_Leave_00",
+					"ArtifactInstall_Error_00",
+					"ArtifactRollback_Enter_00",
 					"ArtifactRollback",
+					"ArtifactRollback_Leave_00",
+					"ArtifactRollbackReboot_Enter_00",
 					"ArtifactRollbackReboot",
 					"ArtifactVerifyRollbackReboot",
+					"ArtifactRollbackReboot_Leave_00",
+					"ArtifactFailure_Enter_00",
 					"ArtifactFailure",
+					"ArtifactFailure_Leave_00",
 					"Cleanup",
 				},
 			.status_log =
@@ -2549,7 +2733,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"installing",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.use_non_writable_db_after_n_writes = 2,
 		},
 
@@ -2559,6 +2743,8 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 				{
 					// No states at all, because we don't even get to the point
 					// of calling update modules.
+					"Download_Enter_00",
+					"Download_Error_00",
 				},
 			.status_log =
 				{
@@ -2607,7 +2793,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"Download_Leave_00",
 					"ArtifactInstall_Enter_00",
 					"ArtifactInstall",
-					"ArtifactInstall_Leave_00",
+					"ArtifactInstall_Error_00",
 					"ArtifactFailure_Enter_00",
 					"ArtifactFailure",
 					"ArtifactFailure_Leave_00",
@@ -2691,6 +2877,15 @@ public:
 private:
 	mtesting::TemporaryDirectory tmpdir_;
 };
+
+INSTANTIATE_TEST_SUITE_P(
+	Regular_Non_Update_State_Tests,
+	StateDeathTest,
+	::testing::ValuesIn(idle_and_sync_test_cases),
+	[](const testing::TestParamInfo<StateTransitionsTestCase> &test_case) {
+		return test_case.param.case_name;
+	});
+
 
 INSTANTIATE_TEST_SUITE_P(
 	,
@@ -2793,6 +2988,10 @@ fi
 
 vector<string> MakeTestArtifactScripts(
 	const StateTransitionsTestCase &test_case, const string &tmpdir, const string &log_path) {
+	const auto rootfs_scripts_list = vector<string> {
+		"Idle",
+		"Sync",
+	};
 	auto state_script_list = vector<string> {
 		"Download",
 		"ArtifactInstall",
@@ -2803,7 +3002,12 @@ vector<string> MakeTestArtifactScripts(
 		"ArtifactFailure",
 	};
 
-	auto scripts_dir = path::Join(tmpdir, "scriptdir");
+	if (test_case.generate_idle_sync_scripts) {
+		state_script_list.insert(
+			state_script_list.end(), rootfs_scripts_list.cbegin(), rootfs_scripts_list.cend());
+	}
+
+	const auto scripts_dir = path::Join(tmpdir, "scripts");
 	error_code ec;
 	EXPECT_TRUE(fs::create_directories(scripts_dir, ec)) << ec.message();
 
@@ -2815,10 +3019,10 @@ vector<string> MakeTestArtifactScripts(
 
 	vector<string> artifact_scripts;
 
-	for (auto &state : state_script_list) {
-		for (auto &enter_leave : vector<string> {"Enter", "Leave", "Error"}) {
-			auto script_file = state + "_" + enter_leave + "_00";
-			auto script_path = path::Join(scripts_dir, script_file);
+	for (const auto &state : state_script_list) {
+		for (const auto &enter_leave : vector<string> {"Enter", "Leave", "Error"}) {
+			const auto script_file = state + "_" + enter_leave + "_00";
+			const auto script_path = path::Join(scripts_dir, script_file);
 			if (state != "Download") {
 				artifact_scripts.push_back(script_path);
 			}
@@ -2829,6 +3033,9 @@ vector<string> MakeTestArtifactScripts(
 echo )" << script_file
 			  << " >> " << log_path << R"(
 )";
+
+			f << R"(
+echo )" << script_file;
 
 			auto &error_states = test_case.error_states;
 			if (find(error_states.begin(), error_states.end(), script_file) != error_states.end()) {
@@ -2872,6 +3079,10 @@ exit 0
 )";
 
 			EXPECT_TRUE(f.good());
+
+			// Make the script executable
+			int ret {chmod(script_path.c_str(), S_IRUSR | S_IWUSR | S_IXUSR)};
+			EXPECT_EQ(ret, 0);
 		}
 	}
 
@@ -3064,6 +3275,8 @@ void StateTransitionsTestSubProcess(
 		conf::MenderConfig config {};
 		config.module_timeout_seconds = 2;
 		config.paths.SetDataStore(tmpdir);
+		config.paths.SetArtScriptsPath(path::Join(tmpdir, "scripts"));
+		config.paths.SetRootfsScriptsPath(path::Join(tmpdir, "scripts"));
 
 		string artifact_path;
 		if (test.GetParam().empty_payload_artifact) {
@@ -3148,26 +3361,8 @@ void DoSchemaUpdate(kv_db::KeyValueDatabase &db) {
 	ASSERT_EQ(err, error::NoError);
 }
 
-vector<string> StateScriptsWorkaround(const vector<string> &states) {
-	// MEN-6021: We do not check for successfully executed state scripts yet.
-	vector<string> ret;
-	for (auto &state : states) {
-		if (state.find("_Enter") == state.npos && state.find("_Leave") == state.npos
-			&& state.find("_Error") == state.npos) {
-			ret.push_back(state);
-		}
-	}
-	return ret;
-}
 
 TEST_P(StateDeathTest, StateTransitionsTest) {
-	// MEN-6021: Remove this to enable tests again.
-	auto &name = GetParam().case_name;
-	if (name.find("_Enter") != name.npos || name.find("_Leave") != name.npos
-		|| name.find("_Error") != name.npos) {
-		GTEST_SKIP() << "MEN-6021: Needs state script support";
-	}
-
 	// This test requires "fast" mode. The reason is that since we need to run a sub process
 	// multiple times, we have to use "fork", we cannot use the start-from-scratch approach that
 	// the "threadsafe" mode uses. Also, our temporary directory would not be the same across
@@ -3183,11 +3378,10 @@ TEST_P(StateDeathTest, StateTransitionsTest) {
 		ASSERT_TRUE(f.good());
 	}
 
-	string state_log_path = path::Join(tmpdir.Path(), "state.log");
-	string update_module_name = "test-module";
-	string update_module_path = path::Join(tmpdir.Path(), update_module_name);
-
-	string status_log_path = path::Join(tmpdir.Path(), "status.log");
+	const string state_log_path = path::Join(tmpdir.Path(), "state.log");
+	const string update_module_name = "test-module";
+	const string update_module_path = path::Join(tmpdir.Path(), update_module_name);
+	const string status_log_path = path::Join(tmpdir.Path(), "status.log");
 
 	{
 		// We don't care about existence, only content, so pre-create these files in order
@@ -3196,7 +3390,8 @@ TEST_P(StateDeathTest, StateTransitionsTest) {
 		ofstream status_log(status_log_path);
 	}
 
-	auto artifact_scripts = MakeTestArtifactScripts(GetParam(), tmpdir.Path(), state_log_path);
+	const auto artifact_scripts =
+		MakeTestArtifactScripts(GetParam(), tmpdir.Path(), state_log_path);
 	ASSERT_FALSE(::testing::Test::HasFailure());
 
 	MakeTestUpdateModule(GetParam(), update_module_path, state_log_path);
@@ -3255,7 +3450,7 @@ TEST_P(StateDeathTest, StateTransitionsTest) {
 		break;
 	}
 
-	auto content = common::JoinStrings(StateScriptsWorkaround(GetParam().state_chain), "\n") + "\n";
+	auto content = common::JoinStrings(GetParam().state_chain, "\n") + "\n";
 	if (content == "\n") {
 		content = "";
 	}


### PR DESCRIPTION
This adds the expected functionality for the daemon state scripts.

Still some things I'm wondering, have a close look at:

* LoadStateFromDB
* How to handle DB errors when running state scripts, and saving state
* The updated tests