### PR TITLE
Cancel() triggers "operation canceled"

### DIFF
--- a/common/events/platform/boost/events.cpp
+++ b/common/events/platform/boost/events.cpp
@@ -49,7 +49,8 @@ void EventLoop::Post(std::function<void()> func) {
 }
 
 Timer::Timer(EventLoop &loop) :
-	timer_(GetAsioIoContext(loop)) {
+	timer_(GetAsioIoContext(loop)),
+	destroying_(make_shared<bool>(false)) {
 }
 
 void Timer::Cancel() {

--- a/common/events_io.hpp
+++ b/common/events_io.hpp
@@ -56,7 +56,7 @@ public:
 private:
 #ifdef MENDER_USE_BOOST_ASIO
 	asio::posix::stream_descriptor pipe_;
-	shared_ptr<bool> cancelled_;
+	shared_ptr<bool> destroying_;
 #endif // MENDER_USE_BOOST_ASIO
 };
 using AsyncFileDescriptorReaderPtr = shared_ptr<AsyncFileDescriptorReader>;
@@ -79,7 +79,7 @@ public:
 private:
 #ifdef MENDER_USE_BOOST_ASIO
 	asio::posix::stream_descriptor pipe_;
-	shared_ptr<bool> cancelled_;
+	shared_ptr<bool> destroying_;
 #endif // MENDER_USE_BOOST_ASIO
 };
 using AsyncFileDescriptorWriterPtr = shared_ptr<AsyncFileDescriptorWriter>;

--- a/common/events_test.cpp
+++ b/common/events_test.cpp
@@ -23,6 +23,8 @@
 
 #include <common/error.hpp>
 
+using namespace std;
+
 namespace error = mender::common::error;
 namespace events = mender::common::events;
 
@@ -63,7 +65,9 @@ TEST(Events, Timers) {
 			events::EventLoop loop;
 			events::Timer timer(loop);
 
-			timer.AsyncWait(long_wait, [](error::Error err) {});
+			timer.AsyncWait(long_wait, [](error::Error err) {
+				EXPECT_EQ(err.code, make_error_condition(errc::operation_canceled));
+			});
 			timer.Cancel();
 			loop.Run();
 			EXPECT_LT(steady_clock::now(), check_point + long_wait);

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -203,6 +203,7 @@ using OutgoingResponsePtr = shared_ptr<OutgoingResponse>;
 using ExpectedOutgoingResponsePtr = expected::expected<OutgoingResponsePtr, error::Error>;
 
 using RequestHandler = function<void(ExpectedIncomingRequestPtr)>;
+using IdentifiedRequestHandler = function<void(IncomingRequestPtr, error::Error)>;
 using ResponseHandler = function<void(ExpectedIncomingResponsePtr)>;
 
 using ReplyFinishedHandler = function<void(error::Error)>;
@@ -518,6 +519,10 @@ private:
 	void CallErrorHandler(const error_code &ec, const RequestPtr &req, RequestHandler handler);
 	void CallErrorHandler(const error::Error &err, const RequestPtr &req, RequestHandler handler);
 	void CallErrorHandler(
+		const error_code &ec, const IncomingRequestPtr &req, IdentifiedRequestHandler handler);
+	void CallErrorHandler(
+		const error::Error &err, const IncomingRequestPtr &req, IdentifiedRequestHandler handler);
+	void CallErrorHandler(
 		const error_code &ec, const RequestPtr &req, ReplyFinishedHandler handler);
 	void CallErrorHandler(
 		const error::Error &err, const RequestPtr &req, ReplyFinishedHandler handler);
@@ -548,6 +553,11 @@ public:
 
 	error::Error AsyncServeUrl(
 		const string &url, RequestHandler header_handler, RequestHandler body_handler);
+	// Same as the above, except that the body handler has the `IncomingRequestPtr` included
+	// even when there is an error, so that the request can be matched with the request which
+	// was received in the header handler.
+	error::Error AsyncServeUrl(
+		const string &url, RequestHandler header_handler, IdentifiedRequestHandler body_handler);
 	void Cancel();
 
 	// Use this to get a response that can be used to reply to the request. Due to the
@@ -566,7 +576,7 @@ private:
 	BrokenDownUrl address_;
 
 	RequestHandler header_handler_;
-	RequestHandler body_handler_;
+	IdentifiedRequestHandler body_handler_;
 
 	friend class IncomingRequest;
 	friend class Stream;

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -343,16 +343,20 @@ struct ClientConfig {
 	string server_cert_path;
 };
 
-enum class BodyReadingStatus {
+enum class TransactionStatus {
 	None,
+	HeaderHandlerCalled,
 	ReaderCreated,
-	InProgress,
+	BodyReadingInProgress,
 	ReachedEnd,
 	Done,
 };
+static inline bool AtLeast(TransactionStatus status, TransactionStatus expected_status) {
+	return static_cast<int>(status) >= static_cast<int>(expected_status);
+}
 
 // Object which manages one connection, and its requests and responses (one at a time).
-class Client : public events::EventLoopObject {
+class Client : public events::EventLoopObject, virtual public io::Canceller {
 public:
 	Client(
 		const ClientConfig &client,
@@ -366,7 +370,7 @@ public:
 	// whole body has arrived.
 	virtual error::Error AsyncCall(
 		OutgoingRequestPtr req, ResponseHandler header_handler, ResponseHandler body_handler);
-	void Cancel();
+	void Cancel() override;
 
 	// Use this to get an async reader for the body. If there is no body, it returns a
 	// `BodyMissingError`; it's safe to continue afterwards, but without a reader.
@@ -421,7 +425,9 @@ private:
 	shared_ptr<http::response_parser<http::buffer_body>> http_response_parser_;
 	size_t response_body_length_;
 	size_t response_body_read_;
-	BodyReadingStatus body_status_ {BodyReadingStatus::None};
+	TransactionStatus status_ {TransactionStatus::None};
+
+	void DoCancel();
 
 	void CallHandler(ResponseHandler handler);
 	void CallErrorHandler(
@@ -511,10 +517,12 @@ private:
 	vector<uint8_t> body_buffer_;
 	size_t request_body_length_;
 	size_t request_body_read_;
-	BodyReadingStatus body_status_ {BodyReadingStatus::None};
+	TransactionStatus status_ {TransactionStatus::None};
 
 	shared_ptr<http::response<http::buffer_body>> http_response_;
 	shared_ptr<http::response_serializer<http::buffer_body>> http_response_serializer_;
+
+	void DoCancel();
 
 	void CallErrorHandler(const error_code &ec, const RequestPtr &req, RequestHandler handler);
 	void CallErrorHandler(const error::Error &err, const RequestPtr &req, RequestHandler handler);
@@ -544,7 +552,7 @@ private:
 #endif // MENDER_USE_BOOST_BEAST
 };
 
-class Server : public events::EventLoopObject {
+class Server : public events::EventLoopObject, virtual public io::Canceller {
 public:
 	Server(const ServerConfig &server, events::EventLoop &event_loop);
 	~Server();
@@ -558,7 +566,7 @@ public:
 	// was received in the header handler.
 	error::Error AsyncServeUrl(
 		const string &url, RequestHandler header_handler, IdentifiedRequestHandler body_handler);
-	void Cancel();
+	void Cancel() override;
 
 	// Use this to get a response that can be used to reply to the request. Due to the
 	// asynchronous nature, this can be done immediately or some time later.
@@ -590,6 +598,8 @@ private:
 	asio::ip::tcp::acceptor acceptor_;
 
 	unordered_set<StreamPtr> streams_;
+
+	void DoCancel();
 
 	void PrepareNewStream();
 	void AsyncAccept(StreamPtr stream);

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -234,7 +234,10 @@ void OutgoingRequest::SetAsyncBodyGenerator(AsyncBodyGenerator body_gen) {
 }
 
 IncomingRequest::~IncomingRequest() {
-	Cancel();
+	auto stream = stream_.lock();
+	if (stream) {
+		stream->server_.RemoveStream(stream);
+	}
 }
 
 void IncomingRequest::Cancel() {
@@ -316,7 +319,10 @@ void IncomingResponse::SetBodyWriter(io::WriterPtr writer) {
 }
 
 OutgoingResponse::~OutgoingResponse() {
-	Cancel();
+	auto stream = stream_.lock();
+	if (stream) {
+		stream->server_.RemoveStream(stream);
+	}
 }
 
 void OutgoingResponse::Cancel() {

--- a/common/processes.hpp
+++ b/common/processes.hpp
@@ -152,6 +152,8 @@ private:
 
 	chrono::seconds max_termination_time_;
 
+	void DoCancel();
+
 	io::ExpectedAsyncReaderPtr GetProcessReader(events::EventLoop &loop, int &pipe_ref);
 
 	void SetupAsyncWait();

--- a/mender-update/update_module/v3/update_module.cpp
+++ b/mender-update/update_module/v3/update_module.cpp
@@ -56,11 +56,6 @@ UpdateModule::UpdateModule(MenderContext &ctx, const string &payload_type) :
 		ctx.GetConfig().paths.GetModulesWorkPath(), "modules", "v3", "payloads", "0000", "tree");
 }
 
-void UpdateModule::Cancel() {
-	download_.reset();
-	state_runner_.reset();
-}
-
 UpdateModule::DownloadData::DownloadData(
 	events::EventLoop &event_loop, artifact::Payload &payload) :
 	payload_ {payload},

--- a/mender-update/update_module/v3/update_module.hpp
+++ b/mender-update/update_module/v3/update_module.hpp
@@ -246,6 +246,24 @@ private:
 
 ExpectedStringVector DiscoverUpdateModules(const conf::MenderConfig &config);
 
+class AsyncFifoOpener : virtual public io::Canceller {
+public:
+	AsyncFifoOpener(events::EventLoop &loop);
+	~AsyncFifoOpener();
+
+	error::Error AsyncOpen(const string &path, ExpectedWriterHandler handler);
+
+	void Cancel() override;
+
+private:
+	events::EventLoop &event_loop_;
+	string path_;
+	ExpectedWriterHandler handler_;
+	thread thread_;
+	shared_ptr<bool> cancelled_;
+	shared_ptr<bool> destroying_;
+};
+
 } // namespace v3
 } // namespace update_module
 } // namespace update

--- a/mender-update/update_module/v3/update_module.hpp
+++ b/mender-update/update_module/v3/update_module.hpp
@@ -75,11 +75,9 @@ using ExpectedRebootAction = expected::expected<RebootAction, error::Error>;
 
 using ExpectedWriterHandler = function<void(io::ExpectedAsyncWriterPtr)>;
 
-class UpdateModule : virtual public io::Canceller {
+class UpdateModule {
 public:
 	UpdateModule(MenderContext &ctx, const string &payload_type);
-
-	void Cancel() override;
 
 	string GetUpdateModulePath() {
 		return update_module_path_;

--- a/mender-update/update_module/v3/update_module_test.cpp
+++ b/mender-update/update_module/v3/update_module_test.cpp
@@ -17,6 +17,8 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <string>
+#include <sstream>
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -30,8 +32,6 @@
 #include <common/path.hpp>
 
 #include <mender-update/context.hpp>
-#include <string>
-#include <sstream>
 
 namespace io = mender::common::io;
 namespace error = mender::common::error;


### PR DESCRIPTION
This should "fix" most `Cancel()` calls to return `operation_canceled` in their handlers, unless it is during destruction.

One notable omission is the signal handlers. Boost does produce an error even in this case, but because a signal handler is installed permanently, and does not wait for any specific event, it seems more acceptable to not call them with `operation_canceled`. And the handlers are not taking errors in their arguments currently, so it would need to change the call sites.