### PR TITLE
chore: Take Update Control into account when upgrading.

### DIFF
--- a/mender-update/daemon/state_machine/state_machine.cpp
+++ b/mender-update/daemon/state_machine/state_machine.cpp
@@ -12,11 +12,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <mender-update/daemon/state_machine.hpp>
+
 #include <common/conf.hpp>
 #include <common/log.hpp>
 
 #include <mender-update/daemon/states.hpp>
-#include <mender-update/daemon/state_machine.hpp>
 
 namespace mender {
 namespace update {


### PR DESCRIPTION
Since we don't support it, fail instead.

Ticket: MEN-6647
Changelog: Update Control support has been removed from the client.