### PR TITLE
feat: Change Authenticator to fetch authentication data over DBus

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(api_auth PUBLIC
   common_crypto
   common_json
   common_conf
+  common_dbus
   common_http
   common_events
   common_io

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(client_test PUBLIC
 )
 gtest_discover_tests(client_test
   ${MENDER_TEST_FLAGS}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/api/auth/testdata/
   NO_PRETTY_VALUES
 )
 add_dependencies(tests client_test)

--- a/api/auth/auth.cpp
+++ b/api/auth/auth.cpp
@@ -71,6 +71,8 @@ string AuthClientErrorCategoryClass::message(int code) const {
 		return "API error";
 	case UnauthorizedError:
 		return "Unauthorized error";
+	case AuthenticationError:
+		return "Authentication error";
 	default:
 		return "Unknown";
 	}
@@ -232,47 +234,189 @@ error::Error FetchJWTToken(
 
 void Authenticator::ExpireToken() {
 	token_ = nullopt;
+	server_url_ = nullopt;
+
+	if (!token_fetch_in_progress_) {
+		RequestNewToken(nullopt);
+	}
 }
 
-void Authenticator::RunPendingActions(ExpectedToken ex_token) {
+error::Error Authenticator::StartWatchingTokenSignal() {
+	auto err = dbus_client_.RegisterSignalHandler<dbus::ExpectedStringPair>(
+		"io.mender.Authentication1",
+		"JwtTokenStateChange",
+		[this](dbus::ExpectedStringPair ex_auth_dbus_data) {
+			auth_timeout_timer_.Cancel();
+			token_fetch_in_progress_ = false;
+			ExpectedAuthData ex_auth_data;
+			if (!ex_auth_dbus_data) {
+				mlog::Error(
+					"Error from the JwtTokenStateChange DBus signal: "
+					+ ex_auth_dbus_data.error().String());
+				ex_auth_data = ExpectedAuthData(expected::unexpected(ex_auth_dbus_data.error()));
+			} else {
+				token_ = ex_auth_dbus_data.value().first;
+				server_url_ = ex_auth_dbus_data.value().second;
+				AuthData auth_data {*server_url_, *token_};
+				ex_auth_data = ExpectedAuthData(std::move(auth_data));
+			}
+			PostPendingActions(ex_auth_data);
+		});
+
+	watching_token_signal_ = (err == error::NoError);
+	return err;
+}
+
+void Authenticator::PostPendingActions(ExpectedAuthData &ex_auth_data) {
 	for (auto action : pending_actions_) {
-		loop_.Post([action, ex_token]() { action(ex_token); });
+		loop_.Post([action, ex_auth_data]() { action(ex_auth_data); });
 	}
 	pending_actions_.clear();
 }
 
+error::Error Authenticator::RequestNewToken(optional<AuthenticatedAction> opt_action) {
+	if (token_fetch_in_progress_) {
+		// Just make sure the action (if any) is called once the token is
+		// obtained.
+		if (opt_action) {
+			pending_actions_.push_back(*opt_action);
+		}
+		return error::NoError;
+	}
+
+	auto err = dbus_client_.CallMethod<expected::ExpectedBool>(
+		"io.mender.AuthenticationManager",
+		"/io/mender/AuthenticationManager",
+		"io.mender.Authentication1",
+		"FetchJwtToken",
+		[this](expected::ExpectedBool ex_value) {
+			if (!ex_value) {
+				token_fetch_in_progress_ = false;
+				mlog::Error("Failed to request new token fetching: " + ex_value.error().String());
+				ExpectedAuthData ex_auth_data = expected::unexpected(ex_value.error());
+				PostPendingActions(ex_auth_data);
+			} else if (!ex_value.value()) {
+				// mender-auth encountered an error not sent over DBus (should never happen)
+				token_fetch_in_progress_ = false;
+				mlog::Error(
+					"Failed to request new token fetching (see mender-auth logs for details)");
+				ExpectedAuthData ex_auth_data = expected::unexpected(MakeError(
+					AuthenticationError, "Failed to request new token fetching from mender-auth"));
+				PostPendingActions(ex_auth_data);
+			}
+		});
+	if (err != error::NoError) {
+		// A sync DBus error.
+		mlog::Error("Failed to request new token fetching: " + err.String());
+		token_fetch_in_progress_ = false;
+		ExpectedAuthData ex_auth_data = expected::unexpected(err);
+		PostPendingActions(ex_auth_data);
+		if (opt_action) {
+			(*opt_action)(ex_auth_data);
+		}
+		return err;
+	}
+	// else everything went OK
+
+	token_fetch_in_progress_ = true;
+
+	// Make sure the action (if any) is called once the token is
+	// obtained.
+	if (opt_action) {
+		pending_actions_.push_back(*opt_action);
+	}
+
+	// Make sure we don't wait for the token forever.
+	auth_timeout_timer_.AsyncWait(auth_timeout_, [this](error::Error err) {
+		if (err.code == make_error_condition(errc::operation_canceled)) {
+			return;
+		} else if (err == error::NoError) {
+			mlog::Warning("Timed-out waiting for a new token");
+			token_fetch_in_progress_ = false;
+			ExpectedAuthData ex_auth_data = expected::unexpected(
+				MakeError(AuthenticationError, "Timed-out waiting for a new token"));
+			PostPendingActions(ex_auth_data);
+		} else {
+			// should never happen
+			assert(false);
+			mlog::Error("Authentication timer error: " + err.String());
+
+			// In case it did happen, run the stacked up actions and unset the
+			// in_progress_ flag or things may got stuck.
+			token_fetch_in_progress_ = false;
+			ExpectedAuthData ex_auth_data = expected::unexpected(err);
+			PostPendingActions(ex_auth_data);
+		}
+	});
+	return error::NoError;
+}
+
 error::Error Authenticator::WithToken(AuthenticatedAction action) {
-	if (token_) {
-		string token = *token_;
-		action(ExpectedToken(token));
+	if (!watching_token_signal_) {
+		auto err = StartWatchingTokenSignal();
+		if (err != error::NoError) {
+			// Should never fail. We rely on the signal heavily so let's fail
+			// hard if it does.
+			action(expected::unexpected(err));
+			return err;
+		}
+	}
+
+	if (token_ && server_url_) {
+		AuthData auth_data {*server_url_, *token_};
+		action(ExpectedAuthData(std::move(auth_data)));
 		return error::NoError;
 	}
 	// else => no token
-	if (auth_in_progress_) {
+
+	if (token_fetch_in_progress_) {
+		// Already waiting for a new token, just make sure the action is called
+		// once it arrives (or once the wait times out).
 		pending_actions_.push_back(action);
 		return error::NoError;
 	}
 	// else => should fetch the token, cache it and call all pending actions
-	auth_in_progress_ = true;
+	// Try to get token from mender-auth
+	auto err = dbus_client_.CallMethod<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"/io/mender/AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[this, action](dbus::ExpectedStringPair ex_auth_dbus_data) {
+			token_fetch_in_progress_ = false;
+			auth_timeout_timer_.Cancel();
+			if (ex_auth_dbus_data && (ex_auth_dbus_data.value().first != "")
+				&& (ex_auth_dbus_data.value().second != "")) {
+				// Got a valid token, let's save it and then call action and any
+				// previously-pending actions (if any) with it.
+				token_ = ex_auth_dbus_data.value().first;
+				server_url_ = ex_auth_dbus_data.value().second;
+				AuthData auth_data {*server_url_, *token_};
 
-	error::Error err = FetchJWTToken(
-		client_,
-		server_url_,
-		private_key_path_,
-		device_identity_script_path_,
-		[this, action](APIResponse resp) {
-			if (resp) {
-				token_ = resp.value();
+				// Post/schedule pending actions before running the given action
+				// because the action can actually add more actions or even
+				// expire the token, etc. So post actions stacked up before we
+				// got here with the current token and only then give action a
+				// chance to mess with things.
+				ExpectedAuthData ex_auth_data {std::move(auth_data)};
+				PostPendingActions(ex_auth_data);
+				action(ex_auth_data);
+			} else {
+				// No valid token, let's request fetching of a new one
+				RequestNewToken(action);
 			}
-			auth_in_progress_ = false;
-			action(resp);
-			RunPendingActions(resp);
-		},
-		tenant_token_);
+		});
 	if (err != error::NoError) {
-		auth_in_progress_ = false;
+		// No token and failed to try to get one (should never happen).
+		ExpectedAuthData ex_auth_data = expected::unexpected(err);
+		PostPendingActions(ex_auth_data);
+		action(ex_auth_data);
+		return err;
 	}
-	return err;
+	// else record that token is already being fetched (by GetJwtToken()).
+	token_fetch_in_progress_ = true;
+
+	return error::NoError;
 }
 
 } // namespace auth

--- a/api/auth_test.cpp
+++ b/api/auth_test.cpp
@@ -19,18 +19,29 @@
 
 #include <gtest/gtest.h>
 
+#include <common/error.hpp>
+#include <common/events.hpp>
+#include <common/expected.hpp>
+#include <common/dbus.hpp>
 #include <common/http.hpp>
 #include <common/io.hpp>
+#include <common/log.hpp>
 #include <common/path.hpp>
+#include <common/processes.hpp>
 #include <common/testing.hpp>
 
 using namespace std;
 
 namespace auth = mender::api::auth;
+namespace dbus = mender::common::dbus;
 namespace error = mender::common::error;
+namespace events = mender::common::events;
+namespace expected = mender::common::expected;
 namespace http = mender::http;
 namespace io = mender::common::io;
+namespace mlog = mender::common::log;
 namespace path = mender::common::path;
+namespace procs = mender::common::processes;
 namespace mtesting = mender::common::testing;
 
 using TestEventLoop = mender::common::testing::TestEventLoop;
@@ -60,6 +71,55 @@ exit 0
 		ASSERT_EQ(ret, 0);
 	}
 };
+
+class AuthDBusTests : public testing::Test {
+protected:
+	// Have to use static setup/teardown/data because libdbus doesn't seem to
+	// respect changing value of DBUS_SYSTEM_BUS_ADDRESS environment variable
+	// and keeps connecting to the first address specified.
+	static void SetUpTestSuite() {
+		// avoid debug noise from process handling
+		mlog::SetLevel(mlog::LogLevel::Warning);
+
+		string dbus_sock_path = "unix:path=" + tmp_dir_.Path() + "/dbus.sock";
+		dbus_daemon_proc_.reset(
+			new procs::Process {{"dbus-daemon", "--session", "--address", dbus_sock_path}});
+		dbus_daemon_proc_->Start();
+		// give the DBus daemon time to start and initialize
+		std::this_thread::sleep_for(chrono::seconds {1});
+
+		// TIP: Uncomment the code below (and dbus_monitor_proc_
+		//      declaration+definition and termination further below) to see
+		//      what's going on in the DBus world.
+		// dbus_monitor_proc_.reset(
+		// 	new procs::Process {{"dbus-monitor", "--address", dbus_sock_path}});
+		// dbus_monitor_proc_->Start();
+		// // give the DBus monitor time to start and initialize
+		// std::this_thread::sleep_for(chrono::seconds {1});
+
+		setenv("DBUS_SYSTEM_BUS_ADDRESS", dbus_sock_path.c_str(), 1);
+	};
+
+	static void TearDownTestSuite() {
+		dbus_daemon_proc_->EnsureTerminated();
+		// dbus_monitor_proc_->EnsureTerminated();
+		unsetenv("DBUS_SYSTEM_BUS_ADDRESS");
+	};
+
+	void SetUp() override {
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+		GTEST_SKIP() << "Thread sanitizer doesn't like what libdbus is doing with locks";
+#endif
+#endif
+	}
+	static mtesting::TemporaryDirectory tmp_dir_;
+	static unique_ptr<procs::Process> dbus_daemon_proc_;
+	// static unique_ptr<procs::Process> dbus_monitor_proc_;
+};
+mtesting::TemporaryDirectory AuthDBusTests::tmp_dir_;
+unique_ptr<procs::Process> AuthDBusTests::dbus_daemon_proc_;
+// unique_ptr<procs::Process> AuthDBusTests::dbus_monitor_proc_;
 
 TEST_F(AuthTests, FetchJWTTokenTest) {
 	const string JWT_TOKEN = "FOOBARJWTTOKEN";
@@ -115,58 +175,34 @@ TEST_F(AuthTests, FetchJWTTokenTest) {
 	ASSERT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
 }
 
-TEST_F(AuthTests, AuthenticatorBasicTest) {
+TEST_F(AuthDBusTests, AuthenticatorBasicTest) {
 	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
 
 	TestEventLoop loop;
 
-	// Setup a test server
-	const string server_url {"http://127.0.0.1:" + TEST_PORT};
-	http::ServerConfig server_config;
-	http::Server server(server_config, loop);
-	bool replied_once = false;
-	server.AsyncServeUrl(
-		server_url,
-		[](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-			exp_req.value()->SetBodyWriter(make_shared<io::Discard>());
-		},
-		[JWT_TOKEN, &replied_once](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-
-			// there should only be one request for the token
-			EXPECT_FALSE(replied_once);
-			replied_once = true;
-
-			auto result = exp_req.value()->MakeResponse();
-			ASSERT_TRUE(result);
-			auto resp = result.value();
-
-			resp->SetStatusCodeAndMessage(200, "OK");
-			resp->SetBodyReader(make_shared<io::StringReader>(JWT_TOKEN));
-			resp->SetHeader("Content-Length", to_string(JWT_TOKEN.size()));
-			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
+	// Setup fake mender-auth simply returning auth data
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[JWT_TOKEN, SERVER_URL]() {
+			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
+	dbus_server.AdvertiseObject(dbus_obj);
 
-	string private_key_path = "./private_key.pem";
-	string server_certificate_path {};
-
-	http::ClientConfig client_config {server_certificate_path};
-	auth::Authenticator authenticator {
-		loop,
-		client_config,
-		server_url,
-		private_key_path,
-		test_device_identity_script,
-	};
+	auth::Authenticator authenticator {loop};
 
 	bool action_called = false;
-	auto err =
-		authenticator.WithToken([JWT_TOKEN, &action_called, &loop](auth::ExpectedToken ex_tok) {
+	auto err = authenticator.WithToken(
+		[JWT_TOKEN, SERVER_URL, &action_called, &loop](auth::ExpectedAuthData ex_auth_data) {
 			action_called = true;
-			ASSERT_TRUE(ex_tok);
+			ASSERT_TRUE(ex_auth_data);
 
-			EXPECT_EQ(ex_tok.value(), JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
 			loop.Stop();
 		});
 	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
@@ -175,75 +211,53 @@ TEST_F(AuthTests, AuthenticatorBasicTest) {
 	EXPECT_TRUE(action_called);
 }
 
-TEST_F(AuthTests, AuthenticatorTwoActionsTest) {
+TEST_F(AuthDBusTests, AuthenticatorTwoActionsTest) {
 	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
 
 	TestEventLoop loop;
 
-	// Setup a test server
-	const string server_url {"http://127.0.0.1:" + TEST_PORT};
-	http::ServerConfig server_config;
-	http::Server server(server_config, loop);
-	bool replied_once = false;
-	server.AsyncServeUrl(
-		server_url,
-		[](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-			exp_req.value()->SetBodyWriter(make_shared<io::Discard>());
-		},
-		[JWT_TOKEN, &replied_once](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-
-			// there should only be one request for the token
-			EXPECT_FALSE(replied_once);
-			replied_once = true;
-
-			auto result = exp_req.value()->MakeResponse();
-			ASSERT_TRUE(result);
-			auto resp = result.value();
-
-			resp->SetStatusCodeAndMessage(200, "OK");
-			resp->SetBodyReader(make_shared<io::StringReader>(JWT_TOKEN));
-			resp->SetHeader("Content-Length", to_string(JWT_TOKEN.size()));
-			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
+	// Setup fake mender-auth simply returning auth data
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[JWT_TOKEN, SERVER_URL]() {
+			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
+	dbus_server.AdvertiseObject(dbus_obj);
 
-	string private_key_path = "./private_key.pem";
-	string server_certificate_path {};
-
-	http::ClientConfig client_config {server_certificate_path};
-	auth::Authenticator authenticator {
-		loop,
-		client_config,
-		server_url,
-		private_key_path,
-		test_device_identity_script,
-	};
+	auth::Authenticator authenticator {loop};
 
 	bool action1_called = false;
 	bool action2_called = false;
-	auto err = authenticator.WithToken(
-		[JWT_TOKEN, &action1_called, &action2_called, &loop](auth::ExpectedToken ex_tok) {
+	auto err =
+		authenticator.WithToken([JWT_TOKEN, SERVER_URL, &action1_called, &action2_called, &loop](
+									auth::ExpectedAuthData ex_auth_data) {
 			action1_called = true;
-			ASSERT_TRUE(ex_tok);
+			ASSERT_TRUE(ex_auth_data);
 
-			EXPECT_EQ(ex_tok.value(), JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
 			if (action1_called && action2_called) {
 				loop.Stop();
 			}
 		});
 	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
 
-	err = authenticator.WithToken(
-		[JWT_TOKEN, &action1_called, &action2_called, &loop](auth::ExpectedToken ex_tok) {
-			action2_called = true;
-			ASSERT_TRUE(ex_tok);
+	err = authenticator.WithToken([JWT_TOKEN, SERVER_URL, &action1_called, &action2_called, &loop](
+									  auth::ExpectedAuthData ex_auth_data) {
+		action2_called = true;
+		ASSERT_TRUE(ex_auth_data);
 
-			EXPECT_EQ(ex_tok.value(), JWT_TOKEN);
-			if (action1_called && action2_called) {
-				loop.Stop();
-			}
-		});
+		EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+		EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
+		if (action1_called && action2_called) {
+			loop.Stop();
+		}
+	});
 	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
 
 	loop.Run();
@@ -251,70 +265,65 @@ TEST_F(AuthTests, AuthenticatorTwoActionsTest) {
 	EXPECT_TRUE(action2_called);
 }
 
-TEST_F(AuthTests, AuthenticatorTwoActionsWithTokenClearTest) {
+TEST_F(AuthDBusTests, AuthenticatorTwoActionsWithTokenClearTest) {
 	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
 
 	TestEventLoop loop;
 
-	// Setup a test server
-	const string server_url {"http://127.0.0.1:" + TEST_PORT};
-	http::ServerConfig server_config;
-	http::Server server(server_config, loop);
-	size_t n_replies = 0;
-	server.AsyncServeUrl(
-		server_url,
-		[](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-			exp_req.value()->SetBodyWriter(make_shared<io::Discard>());
-		},
-		[JWT_TOKEN, &n_replies](http::ExpectedIncomingRequestPtr exp_req) {
-			ASSERT_TRUE(exp_req) << exp_req.error().String();
-
+	// Setup fake mender-auth simply returning auth data
+	int n_replies = 0;
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[JWT_TOKEN, SERVER_URL, &n_replies]() {
 			n_replies++;
-			EXPECT_LE(n_replies, 2);
-
-			auto result = exp_req.value()->MakeResponse();
-			ASSERT_TRUE(result);
-			auto resp = result.value();
-
-			resp->SetStatusCodeAndMessage(200, "OK");
-			resp->SetBodyReader(make_shared<io::StringReader>(JWT_TOKEN));
-			resp->SetHeader("Content-Length", to_string(JWT_TOKEN.size()));
-			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
+			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
+	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"FetchJwtToken",
+		[&n_replies, &dbus_server, JWT_TOKEN, SERVER_URL]() {
+			n_replies++;
+			dbus_server.EmitSignal<dbus::StringPair>(
+				"/io/mender/AuthenticationManager",
+				"io.mender.Authentication1",
+				"JwtTokenStateChange",
+				dbus::StringPair {JWT_TOKEN + "2", SERVER_URL + "2"});
 
-	string private_key_path = "./private_key.pem";
-	string server_certificate_path {};
+			return true;
+		});
+	dbus_server.AdvertiseObject(dbus_obj);
 
-	http::ClientConfig client_config {server_certificate_path};
-	auth::Authenticator authenticator {
-		loop,
-		client_config,
-		server_url,
-		private_key_path,
-		test_device_identity_script,
-	};
+	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	bool action1_called = false;
 	bool action2_called = false;
 	auto err = authenticator.WithToken(
-		[JWT_TOKEN, &action1_called, &action2_called, &loop, &authenticator](
-			auth::ExpectedToken ex_tok) {
+		[JWT_TOKEN, SERVER_URL, &action1_called, &action2_called, &loop, &authenticator](
+			auth::ExpectedAuthData ex_auth_data) {
 			action1_called = true;
-			ASSERT_TRUE(ex_tok);
+			ASSERT_TRUE(ex_auth_data);
 
-			EXPECT_EQ(ex_tok.value(), JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
 
 			authenticator.ExpireToken();
 
-			auto err = authenticator.WithToken(
-				[JWT_TOKEN, &action2_called, &loop](auth::ExpectedToken ex_tok) {
-					action2_called = true;
-					ASSERT_TRUE(ex_tok);
+			auto err = authenticator.WithToken([JWT_TOKEN, SERVER_URL, &action2_called, &loop](
+												   auth::ExpectedAuthData ex_auth_data) {
+				action2_called = true;
+				ASSERT_TRUE(ex_auth_data);
 
-					EXPECT_EQ(ex_tok.value(), JWT_TOKEN);
-					loop.Stop();
-				});
+				EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN + "2");
+				EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL + "2");
+
+				loop.Stop();
+			});
 			EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
 		});
 	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
@@ -323,4 +332,198 @@ TEST_F(AuthTests, AuthenticatorTwoActionsWithTokenClearTest) {
 	EXPECT_EQ(n_replies, 2);
 	EXPECT_TRUE(action1_called);
 	EXPECT_TRUE(action2_called);
+}
+
+TEST_F(AuthDBusTests, AuthenticatorTwoActionsWithTokenClearAndTimeoutTest) {
+	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
+
+	TestEventLoop loop;
+
+	// Setup fake mender-auth simply returning auth data, but never announcing a
+	// new token with a signal
+	int n_replies = 0;
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+			n_replies++;
+			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
+		});
+	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"FetchJwtToken",
+		[&n_replies]() {
+			n_replies++;
+			// no JwtTokenStateChange signal emitted here
+			return true;
+		});
+	dbus_server.AdvertiseObject(dbus_obj);
+
+	auth::Authenticator authenticator {loop, chrono::seconds {2}};
+
+	bool action1_called = false;
+	bool action2_called = false;
+	auto err = authenticator.WithToken(
+		[JWT_TOKEN, SERVER_URL, &action1_called, &action2_called, &loop, &authenticator](
+			auth::ExpectedAuthData ex_auth_data) {
+			action1_called = true;
+			ASSERT_TRUE(ex_auth_data);
+
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
+
+			authenticator.ExpireToken();
+
+			auto err = authenticator.WithToken([JWT_TOKEN, SERVER_URL, &action2_called, &loop](
+												   auth::ExpectedAuthData ex_auth_data) {
+				action2_called = true;
+				ASSERT_FALSE(ex_auth_data);
+
+				loop.Stop();
+			});
+			EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
+		});
+	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
+	loop.Run();
+
+	EXPECT_EQ(n_replies, 2);
+	EXPECT_TRUE(action1_called);
+	EXPECT_TRUE(action2_called);
+}
+
+TEST_F(AuthDBusTests, AuthenticatorBasicRealLifeTest) {
+	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
+
+	TestEventLoop loop;
+
+	// Setup fake mender-auth first returning empty data
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager", "io.mender.Authentication1", "GetJwtToken", []() {
+			// no token initially
+			return dbus::StringPair {"", ""};
+		});
+	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"FetchJwtToken",
+		[&dbus_server, JWT_TOKEN, SERVER_URL]() {
+			dbus_server.EmitSignal<dbus::StringPair>(
+				"/io/mender/AuthenticationManager",
+				"io.mender.Authentication1",
+				"JwtTokenStateChange",
+				dbus::StringPair {JWT_TOKEN, SERVER_URL});
+
+			return true;
+		});
+	dbus_server.AdvertiseObject(dbus_obj);
+
+	auth::Authenticator authenticator {loop, chrono::seconds {2}};
+
+	bool action_called = false;
+	auto err = authenticator.WithToken(
+		[JWT_TOKEN, SERVER_URL, &action_called, &loop](auth::ExpectedAuthData ex_auth_data) {
+			action_called = true;
+			ASSERT_TRUE(ex_auth_data);
+
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
+			loop.Stop();
+		});
+	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
+
+	loop.Run();
+	EXPECT_TRUE(action_called);
+}
+
+TEST_F(AuthDBusTests, AuthenticatorExternalTokenUpdateTest) {
+	const string JWT_TOKEN = "FOOBARJWTTOKEN";
+	const string SERVER_URL = "some.server";
+
+	TestEventLoop loop;
+
+	// Setup fake mender-auth returning auth data
+	int n_replies = 0;
+	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
+	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
+	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"GetJwtToken",
+		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+			n_replies++;
+			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
+		});
+	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
+		"io.mender.AuthenticationManager",
+		"io.mender.Authentication1",
+		"FetchJwtToken",
+		[&dbus_server, JWT_TOKEN, SERVER_URL]() {
+			dbus_server.EmitSignal<dbus::StringPair>(
+				"/io/mender/AuthenticationManager",
+				"io.mender.Authentication1",
+				"JwtTokenStateChange",
+				dbus::StringPair {JWT_TOKEN + "2", SERVER_URL + "2"});
+
+			return true;
+		});
+	dbus_server.AdvertiseObject(dbus_obj);
+
+	dbus::DBusClient dbus_client {loop};
+	auth::Authenticator authenticator {loop, chrono::seconds {2}};
+
+	events::Timer ext_token_fetch_timer {loop};
+	events::Timer second_with_token_timer {loop};
+	bool action1_called = false;
+	bool action2_called = false;
+	auto err = authenticator.WithToken(
+		[JWT_TOKEN, SERVER_URL, &action1_called](auth::ExpectedAuthData ex_auth_data) {
+			action1_called = true;
+			ASSERT_TRUE(ex_auth_data);
+
+			EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN);
+			EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL);
+		});
+	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
+	ext_token_fetch_timer.AsyncWait(chrono::seconds {1}, [&dbus_client](error::Error err) {
+		dbus_client.CallMethod<expected::ExpectedBool>(
+			"io.mender.AuthenticationManager",
+			"/io/mender/AuthenticationManager",
+			"io.mender.Authentication1",
+			"FetchJwtToken",
+			[](expected::ExpectedBool ex_value) {
+				ASSERT_TRUE(ex_value);
+				ASSERT_TRUE(ex_value.value());
+			});
+	});
+	second_with_token_timer.AsyncWait(
+		chrono::seconds {2},
+		[JWT_TOKEN, SERVER_URL, &authenticator, &action2_called, &loop](error::Error err) {
+			auto lerr = authenticator.WithToken([JWT_TOKEN, SERVER_URL, &action2_called, &loop](
+													auth::ExpectedAuthData ex_auth_data) {
+				action2_called = true;
+				ASSERT_TRUE(ex_auth_data);
+
+				EXPECT_EQ(ex_auth_data.value().token, JWT_TOKEN + "2");
+				EXPECT_EQ(ex_auth_data.value().server_url, SERVER_URL + "2");
+
+				loop.Stop();
+			});
+			EXPECT_EQ(lerr, error::NoError) << "Unexpected error: " << lerr.message;
+		});
+	loop.Run();
+	EXPECT_TRUE(action1_called);
+	EXPECT_TRUE(action2_called);
+
+	// GetJwtToken() should have only been called once, by the first
+	// WithToken(), the second WithToken() should use the token delivered by the
+	// DBus signal.
+	EXPECT_EQ(n_replies, 1);
 }

--- a/api/client.hpp
+++ b/api/client.hpp
@@ -33,24 +33,16 @@ namespace http = mender::http;
 using namespace std;
 
 // Inheritance here allows us to avoid re-implementing things like SetHeader(),
-// SetMethod() (and getters that come from the Request class) and we can just
-// use APIRequest instances where OutgoingRequest is needed (i.e. for HTTP).
-class APIRequest : public http::OutgoingRequest {
+// SetMethod() (and getters that come from the Request class).
+class APIRequest : public http::BaseOutgoingRequest {
 public:
 	APIRequest() {};
-
-	error::Error SetAddress(const string &address) override {
-		// SetPath() followed by SetAuthData() should be used instead.
-		return error::MakeError(
-			error::ProgrammingError,
-			"Can't set full address on an API request, only path can be set");
-	}
 
 	void SetPath(const string &path) {
 		address_.path = path;
 	}
 
-	error::Error SetAuthData(const auth::AuthData &auth_data);
+	http::ExpectedOutgoingRequestPtr WithAuthData(const auth::AuthData &auth_data);
 };
 using APIRequestPtr = shared_ptr<APIRequest>;
 

--- a/api/client_test.cpp
+++ b/api/client_test.cpp
@@ -27,10 +27,9 @@
 #include <common/expected.hpp>
 #include <common/http.hpp>
 #include <common/io.hpp>
-#include <common/log.hpp>
 #include <common/path.hpp>
-#include <common/processes.hpp>
 #include <common/testing.hpp>
+#include <common/testing_dbus.hpp>
 
 using namespace std;
 
@@ -43,59 +42,23 @@ namespace events = mender::common::events;
 namespace expected = mender::common::expected;
 namespace http = mender::http;
 namespace io = mender::common::io;
-namespace mlog = mender::common::log;
 namespace path = mender::common::path;
-namespace procs = mender::common::processes;
 namespace mtesting = mender::common::testing;
+namespace testing_dbus = mender::common::testing::dbus;
 
 using TestEventLoop = mender::common::testing::TestEventLoop;
 
 const string TEST_PORT = "8088";
 
-class APIClientTests : public testing::Test {
+class APIClientTests : public testing_dbus::DBusTests {
 protected:
 	mtesting::TemporaryDirectory tmpdir;
 	const string test_device_identity_script = path::Join(tmpdir.Path(), "mender-device-identity");
 	const string auth_uri = "/api/devices/v1/authentication/auth_requests";
 
-	// Have to use static setup/teardown/data because libdbus doesn't seem to
-	// respect changing value of DBUS_SYSTEM_BUS_ADDRESS environment variable
-	// and keeps connecting to the first address specified.
-	static void SetUpTestSuite() {
-		// avoid debug noise from process handling
-		mlog::SetLevel(mlog::LogLevel::Warning);
-
-		string dbus_sock_path = "unix:path=" + tmp_dir_.Path() + "/dbus.sock";
-		dbus_daemon_proc_.reset(
-			new procs::Process {{"dbus-daemon", "--session", "--address", dbus_sock_path}});
-		dbus_daemon_proc_->Start();
-		// give the DBus daemon time to start and initialize
-		std::this_thread::sleep_for(chrono::seconds {1});
-
-		// TIP: Uncomment the code below (and dbus_monitor_proc_
-		//      declaration+definition and termination further below) to see
-		//      what's going on in the DBus world.
-		// dbus_monitor_proc_.reset(
-		// 	new procs::Process {{"dbus-monitor", "--address", dbus_sock_path}});
-		// dbus_monitor_proc_->Start();
-		// // give the DBus monitor time to start and initialize
-		// std::this_thread::sleep_for(chrono::seconds {1});
-
-		setenv("DBUS_SYSTEM_BUS_ADDRESS", dbus_sock_path.c_str(), 1);
-	};
-
-	static void TearDownTestSuite() {
-		dbus_daemon_proc_->EnsureTerminated();
-		// dbus_monitor_proc_->EnsureTerminated();
-		unsetenv("DBUS_SYSTEM_BUS_ADDRESS");
-	};
-
 	void SetUp() override {
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-		GTEST_SKIP() << "Thread sanitizer doesn't like what libdbus is doing with locks";
-#endif
-#endif
+		testing_dbus::DBusTests::SetUp();
+
 		// Create the device-identity script
 		string script = R"(#!/bin/sh
 echo "key1=value1"
@@ -112,13 +75,7 @@ exit 0
 		int ret = chmod(test_device_identity_script.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
 		ASSERT_EQ(ret, 0);
 	}
-	static mtesting::TemporaryDirectory tmp_dir_;
-	static unique_ptr<procs::Process> dbus_daemon_proc_;
-	// static unique_ptr<procs::Process> dbus_monitor_proc_;
 };
-mtesting::TemporaryDirectory APIClientTests::tmp_dir_;
-unique_ptr<procs::Process> APIClientTests::dbus_daemon_proc_;
-// unique_ptr<procs::Process> APIClientTests::dbus_monitor_proc_;
 
 TEST_F(APIClientTests, ClientBasicTest) {
 	const string JWT_TOKEN = "FOOBARJWTTOKEN";

--- a/api/client_test.cpp
+++ b/api/client_test.cpp
@@ -172,9 +172,9 @@ TEST_F(APIClientTests, ClientBasicTest) {
 	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	http::ClientConfig client_config {""};
-	api::Client client {client_config, loop, authenticator};
+	api::HTTPClient client {client_config, loop, authenticator};
 
-	auto req = make_shared<http::OutgoingRequest>();
+	auto req = make_shared<api::APIRequest>();
 	req->SetMethod(http::Method::GET);
 	req->SetPath(test_uri);
 
@@ -278,9 +278,9 @@ TEST_F(APIClientTests, TwoClientsTest) {
 	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	http::ClientConfig client_config {""};
-	api::Client client1 {client_config, loop, authenticator};
+	api::HTTPClient client1 {client_config, loop, authenticator};
 
-	auto req1 = make_shared<http::OutgoingRequest>();
+	auto req1 = make_shared<api::APIRequest>();
 	req1->SetPath(test_uri1);
 	req1->SetMethod(http::Method::GET);
 
@@ -312,9 +312,9 @@ TEST_F(APIClientTests, TwoClientsTest) {
 
 	EXPECT_EQ(err, error::NoError) << "Unexpected error: " << err.message;
 
-	api::Client client2 {client_config, loop, authenticator};
+	api::HTTPClient client2 {client_config, loop, authenticator};
 
-	auto req2 = make_shared<http::OutgoingRequest>();
+	auto req2 = make_shared<api::APIRequest>();
 	req2->SetPath(test_uri2);
 	req2->SetMethod(http::Method::GET);
 
@@ -456,9 +456,9 @@ TEST_F(APIClientTests, ClientReauthenticationTest) {
 	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	http::ClientConfig client_config {""};
-	api::Client client {client_config, loop, authenticator};
+	api::HTTPClient client {client_config, loop, authenticator};
 
-	auto req1 = make_shared<http::OutgoingRequest>();
+	auto req1 = make_shared<api::APIRequest>();
 	req1->SetPath(test_uri1);
 	req1->SetMethod(http::Method::GET);
 
@@ -466,7 +466,7 @@ TEST_F(APIClientTests, ClientReauthenticationTest) {
 	bool header_handler_called1 = false;
 	bool body_handler_called1 = false;
 
-	auto req2 = make_shared<http::OutgoingRequest>();
+	auto req2 = make_shared<api::APIRequest>();
 	req2->SetPath(test_uri2);
 	req2->SetMethod(http::Method::GET);
 
@@ -556,9 +556,9 @@ TEST_F(APIClientTests, ClientEarlyAuthErrorTest) {
 	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	http::ClientConfig client_config {""};
-	api::Client client {client_config, loop, authenticator};
+	api::HTTPClient client {client_config, loop, authenticator};
 
-	auto req = make_shared<http::OutgoingRequest>();
+	auto req = make_shared<api::APIRequest>();
 	req->SetPath(test_uri);
 	req->SetMethod(http::Method::GET);
 
@@ -667,9 +667,9 @@ TEST_F(APIClientTests, ClientReauthenticationFailureTest) {
 	auth::Authenticator authenticator {loop, chrono::seconds {2}};
 
 	http::ClientConfig client_config {""};
-	api::Client client {client_config, loop, authenticator};
+	api::HTTPClient client {client_config, loop, authenticator};
 
-	auto req1 = make_shared<http::OutgoingRequest>();
+	auto req1 = make_shared<api::APIRequest>();
 	req1->SetPath(test_uri1);
 	req1->SetMethod(http::Method::GET);
 
@@ -677,7 +677,7 @@ TEST_F(APIClientTests, ClientReauthenticationFailureTest) {
 	bool header_handler_called1 = false;
 	bool body_handler_called1 = false;
 
-	auto req2 = make_shared<http::OutgoingRequest>();
+	auto req2 = make_shared<api::APIRequest>();
 	req2->SetPath(test_uri2);
 	req2->SetMethod(http::Method::GET);
 

--- a/common/dbus_test.cpp
+++ b/common/dbus_test.cpp
@@ -25,6 +25,7 @@
 #include <common/expected.hpp>
 #include <common/processes.hpp>
 #include <common/testing.hpp>
+#include <common/testing_dbus.hpp>
 
 namespace dbus = mender::common::dbus;
 namespace error = mender::common::error;
@@ -32,60 +33,12 @@ namespace events = mender::common::events;
 namespace expected = mender::common::expected;
 namespace procs = mender::common::processes;
 namespace mtesting = mender::common::testing;
+namespace testing_dbus = mender::common::testing::dbus;
 
 using namespace std;
 
-class DBusTests : public testing::Test {
-public:
-	// Have to use static setup/teardown/data because libdbus doesn't seem to
-	// respect changing value of DBUS_SYSTEM_BUS_ADDRESS environment variable
-	// and keeps connecting to the first address specified.
-	static void SetUpTestSuite() {
-		string dbus_sock_path = "unix:path=" + tmp_dir_.Path() + "/dbus.sock";
-		dbus_daemon_proc_.reset(
-			new procs::Process {{"dbus-daemon", "--session", "--address", dbus_sock_path}});
-		dbus_daemon_proc_->Start();
-		// give the DBus daemon time to start and initialize
-		std::this_thread::sleep_for(chrono::seconds {1});
-
-		// TIP: Uncomment the code below (and dbus_monitor_proc_
-		//      declaration+definition and termination further below) to see
-		//      what's going on in the DBus world.
-		// dbus_monitor_proc_.reset(
-		// 	new procs::Process {{"dbus-monitor", "--address", dbus_sock_path}});
-		// dbus_monitor_proc_->Start();
-		// // give the DBus monitor time to start and initialize
-		// std::this_thread::sleep_for(chrono::seconds {1});
-
-		setenv("DBUS_SYSTEM_BUS_ADDRESS", dbus_sock_path.c_str(), 1);
-	};
-
-	static void TearDownTestSuite() {
-		dbus_daemon_proc_->EnsureTerminated();
-		// dbus_monitor_proc_->EnsureTerminated();
-		unsetenv("DBUS_SYSTEM_BUS_ADDRESS");
-	};
-
-	void SetUp() override {
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-		GTEST_SKIP() << "Thread sanitizer doesn't like what libdbus is doing with locks";
-#endif
-#endif
-	}
-
-protected:
-	static mtesting::TemporaryDirectory tmp_dir_;
-	static unique_ptr<procs::Process> dbus_daemon_proc_;
-	// static unique_ptr<procs::Process> dbus_monitor_proc_;
-};
-
-mtesting::TemporaryDirectory DBusTests::tmp_dir_;
-unique_ptr<procs::Process> DBusTests::dbus_daemon_proc_;
-// unique_ptr<procs::Process> DBusTests::dbus_monitor_proc_;
-
-class DBusClientTests : public DBusTests {};
-class DBusServerTests : public DBusTests {};
+class DBusClientTests : public testing_dbus::DBusTests {};
+class DBusServerTests : public testing_dbus::DBusTests {};
 
 TEST_F(DBusClientTests, DBusClientTrivialTest) {
 	mtesting::TestEventLoop loop;

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -251,8 +251,7 @@ public:
 	}
 
 	void SetMethod(Method method);
-	void SetPath(const string &path);
-	error::Error SetAddress(const string &address);
+	virtual error::Error SetAddress(const string &address);
 	void SetHeader(const string &name, const string &value);
 
 	// Set to a function which will generate the body. Make sure that the Content-Length set in
@@ -261,6 +260,8 @@ public:
 	// unsets the other.
 	void SetBodyGenerator(BodyGenerator body_gen);
 	void SetAsyncBodyGenerator(AsyncBodyGenerator body_gen);
+
+	virtual ~OutgoingRequest() {};
 
 private:
 	// Original address.

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -245,13 +245,13 @@ enum class BodyWriterErrorMode {
 	KeepAlive,
 };
 
-class OutgoingRequest : public Request {
+class BaseOutgoingRequest : public Request {
 public:
-	OutgoingRequest() {
+	BaseOutgoingRequest() {
 	}
+	BaseOutgoingRequest(const BaseOutgoingRequest &other) = default;
 
 	void SetMethod(Method method);
-	virtual error::Error SetAddress(const string &address);
 	void SetHeader(const string &name, const string &value);
 
 	// Set to a function which will generate the body. Make sure that the Content-Length set in
@@ -261,12 +261,11 @@ public:
 	void SetBodyGenerator(BodyGenerator body_gen);
 	void SetAsyncBodyGenerator(AsyncBodyGenerator body_gen);
 
-	virtual ~OutgoingRequest() {};
-
-private:
+protected:
 	// Original address.
 	string orig_address_;
 
+private:
 	BodyGenerator body_gen_;
 	io::ReaderPtr body_reader_;
 	AsyncBodyGenerator async_body_gen_;
@@ -274,6 +273,16 @@ private:
 
 	friend class Client;
 };
+
+class OutgoingRequest : public BaseOutgoingRequest {
+public:
+	OutgoingRequest() {
+	}
+	OutgoingRequest(const BaseOutgoingRequest &req) :
+		BaseOutgoingRequest(req) {};
+	error::Error SetAddress(const string &address);
+};
+
 
 class Stream;
 

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -183,6 +183,9 @@ public:
 	Request() {
 	}
 
+	string GetHost() const;
+	string GetProtocol() const;
+	int GetPort() const;
 	Method GetMethod() const;
 	string GetPath() const;
 

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -251,6 +251,7 @@ public:
 	}
 
 	void SetMethod(Method method);
+	void SetPath(const string &path);
 	error::Error SetAddress(const string &address);
 	void SetHeader(const string &name, const string &value);
 

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -225,6 +225,10 @@ void OutgoingRequest::SetMethod(Method method) {
 	method_ = method;
 }
 
+void OutgoingRequest::SetPath(const string &path) {
+	address_.path = path;
+}
+
 void OutgoingRequest::SetHeader(const string &name, const string &value) {
 	headers_[name] = value;
 }

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -225,10 +225,6 @@ void OutgoingRequest::SetMethod(Method method) {
 	method_ = method;
 }
 
-void OutgoingRequest::SetPath(const string &path) {
-	address_.path = path;
-}
-
 void OutgoingRequest::SetHeader(const string &name, const string &value) {
 	headers_[name] = value;
 }

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -193,6 +193,18 @@ expected::ExpectedString Transaction::GetHeader(const string &name) const {
 	return headers_.at(name);
 }
 
+string Request::GetHost() const {
+	return address_.host;
+}
+
+string Request::GetProtocol() const {
+	return address_.protocol;
+}
+
+int Request::GetPort() const {
+	return address_.port;
+}
+
 Method Request::GetMethod() const {
 	return method_;
 }

--- a/common/http/http.cpp
+++ b/common/http/http.cpp
@@ -221,30 +221,30 @@ string Response::GetStatusMessage() const {
 	return status_message_;
 }
 
-void OutgoingRequest::SetMethod(Method method) {
+void BaseOutgoingRequest::SetMethod(Method method) {
 	method_ = method;
 }
 
-void OutgoingRequest::SetHeader(const string &name, const string &value) {
+void BaseOutgoingRequest::SetHeader(const string &name, const string &value) {
 	headers_[name] = value;
+}
+
+void BaseOutgoingRequest::SetBodyGenerator(BodyGenerator body_gen) {
+	async_body_gen_ = nullptr;
+	async_body_reader_ = nullptr;
+	body_gen_ = body_gen;
+}
+
+void BaseOutgoingRequest::SetAsyncBodyGenerator(AsyncBodyGenerator body_gen) {
+	body_gen_ = nullptr;
+	body_reader_ = nullptr;
+	async_body_gen_ = body_gen;
 }
 
 error::Error OutgoingRequest::SetAddress(const string &address) {
 	orig_address_ = address;
 
 	return BreakDownUrl(address, address_);
-}
-
-void OutgoingRequest::SetBodyGenerator(BodyGenerator body_gen) {
-	async_body_gen_ = nullptr;
-	async_body_reader_ = nullptr;
-	body_gen_ = body_gen;
-}
-
-void OutgoingRequest::SetAsyncBodyGenerator(AsyncBodyGenerator body_gen) {
-	body_gen_ = nullptr;
-	body_reader_ = nullptr;
-	async_body_gen_ = body_gen;
 }
 
 IncomingRequest::~IncomingRequest() {

--- a/common/testing_dbus.hpp
+++ b/common/testing_dbus.hpp
@@ -1,0 +1,91 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_TESTING_DBUS
+#define MENDER_COMMON_TESTING_DBUS
+
+#include <gtest/gtest.h>
+
+#include <common/dbus.hpp>
+#include <common/log.hpp>
+#include <common/processes.hpp>
+#include <common/testing.hpp>
+
+namespace mender {
+namespace common {
+namespace testing {
+namespace dbus {
+
+using namespace std;
+
+namespace dbus = mender::common::dbus;
+namespace procs = mender::common::processes;
+namespace mlog = mender::common::log;
+namespace mtesting = mender::common::testing;
+
+class DBusTests : public ::testing::Test {
+protected:
+	// Have to use static setup/teardown/data because libdbus doesn't seem to
+	// respect changing value of DBUS_SYSTEM_BUS_ADDRESS environment variable
+	// and keeps connecting to the first address specified.
+	static void SetUpTestSuite() {
+		// avoid debug noise from process handling
+		mlog::SetLevel(mlog::LogLevel::Warning);
+
+		string dbus_sock_path = "unix:path=" + tmp_dir_.Path() + "/dbus.sock";
+		dbus_daemon_proc_.reset(
+			new procs::Process {{"dbus-daemon", "--session", "--address", dbus_sock_path}});
+		dbus_daemon_proc_->Start();
+		// give the DBus daemon time to start and initialize
+		std::this_thread::sleep_for(chrono::seconds {1});
+
+		// TIP: Uncomment the code below (and dbus_monitor_proc_
+		//      declaration+definition and termination further below) to see
+		//      what's going on in the DBus world.
+		// dbus_monitor_proc_.reset(
+		// 	new procs::Process {{"dbus-monitor", "--address", dbus_sock_path}});
+		// dbus_monitor_proc_->Start();
+		// // give the DBus monitor time to start and initialize
+		// std::this_thread::sleep_for(chrono::seconds {1});
+
+		setenv("DBUS_SYSTEM_BUS_ADDRESS", dbus_sock_path.c_str(), 1);
+	};
+
+	static void TearDownTestSuite() {
+		dbus_daemon_proc_->EnsureTerminated();
+		// dbus_monitor_proc_->EnsureTerminated();
+		unsetenv("DBUS_SYSTEM_BUS_ADDRESS");
+	};
+
+	void SetUp() override {
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+		GTEST_SKIP() << "Thread sanitizer doesn't like what libdbus is doing with locks";
+#endif
+#endif
+	}
+	static mtesting::TemporaryDirectory tmp_dir_;
+	static unique_ptr<procs::Process> dbus_daemon_proc_;
+	// static unique_ptr<procs::Process> dbus_monitor_proc_;
+};
+mtesting::TemporaryDirectory DBusTests::tmp_dir_;
+unique_ptr<procs::Process> DBusTests::dbus_daemon_proc_;
+// unique_ptr<procs::Process> DBusTests::dbus_monitor_proc_;
+
+} // namespace dbus
+} // namespace testing
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_TESTING_DBUS

--- a/mender-update/CMakeLists.txt
+++ b/mender-update/CMakeLists.txt
@@ -26,6 +26,7 @@ add_dependencies(tests context_test)
 add_library(mender_deployments STATIC deployments/deployments.cpp)
 target_include_directories(mender_deployments PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 target_link_libraries(mender_deployments PUBLIC
+  api_client
   mender_context
   common_error
   common_events
@@ -53,6 +54,7 @@ add_dependencies(tests deployments_test)
 add_library(mender_inventory STATIC inventory.cpp)
 target_include_directories(mender_inventory PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 target_link_libraries(mender_inventory PUBLIC
+  api_client
   common_error
   common_events
   common_http

--- a/mender-update/daemon/context.cpp
+++ b/mender-update/daemon/context.cpp
@@ -165,13 +165,7 @@ Context::Context(
 	const http::ClientConfig &http_config) :
 	mender_context(mender_context),
 	event_loop(event_loop),
-	authenticator(
-		event_loop,
-		http_config,
-		mender_context.GetConfig().server_url,
-		mender_context.GetConfig().paths.GetKeyFile(),
-		mender_context.GetConfig().paths.GetIdentityScript(),
-		mender_context.GetConfig().tenant_token),
+	authenticator(event_loop),
 	http_client(http_config, event_loop, authenticator),
 	download_client(make_shared<http_resumer::DownloadResumerClient>(http_config, event_loop)),
 	deployment_client(make_shared<deployments::DeploymentClient>()),

--- a/mender-update/daemon/context.hpp
+++ b/mender-update/daemon/context.hpp
@@ -169,7 +169,7 @@ private:
 
 public:
 	// For polling, and for making status updates.
-	api::Client http_client;
+	api::HTTPClient http_client;
 	// For the artifact download.
 	shared_ptr<http::ClientInterface> download_client;
 

--- a/mender-update/daemon/state_test.cpp
+++ b/mender-update/daemon/state_test.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <api/client.hpp>
 #include <common/common.hpp>
 #include <common/conf.hpp>
 #include <common/error.hpp>
@@ -43,6 +44,7 @@ namespace daemon {
 
 namespace fs = std::filesystem;
 
+namespace api = mender::api;
 namespace common = mender::common;
 namespace conf = mender::common::conf;
 namespace error = mender::common::error;
@@ -3361,7 +3363,7 @@ class NoopInventoryClient : virtual public inventory::InventoryAPI {
 	error::Error PushData(
 		const string &inventory_generators_dir,
 		events::EventLoop &loop,
-		http::Client &client,
+		api::Client &client,
 		inventory::APIResponseHandler api_handler) override {
 		api_handler(error::NoError);
 		return error::NoError;
@@ -3372,7 +3374,7 @@ class NoopDeploymentClient : virtual public deployments::DeploymentAPI {
 public:
 	error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		http::Client &client,
+		api::Client &client,
 		deployments::CheckUpdatesAPIResponseHandler api_handler) override {
 		api_handler(nullopt);
 		return error::NoError;
@@ -3382,7 +3384,7 @@ public:
 		const string &deployment_id,
 		deployments::DeploymentStatus status,
 		const string &substate,
-		http::Client &client,
+		api::Client &client,
 		deployments::StatusAPIResponseHandler api_handler) override {
 		api_handler(error::NoError);
 		return error::NoError;
@@ -3391,7 +3393,7 @@ public:
 	error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		http::Client &client,
+		api::Client &client,
 		deployments::LogsAPIResponseHandler api_handler) override {
 		api_handler(error::NoError);
 		return error::NoError;
@@ -3418,7 +3420,7 @@ public:
 
 	error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		http::Client &client,
+		api::Client &client,
 		deployments::CheckUpdatesAPIResponseHandler api_handler) override {
 		event_loop_.Post([this, api_handler]() {
 			auto exp = json::Load(R"({
@@ -3442,7 +3444,7 @@ public:
 		const string &deployment_id,
 		deployments::DeploymentStatus status,
 		const string &substate,
-		http::Client &client,
+		api::Client &client,
 		deployments::StatusAPIResponseHandler api_handler) override {
 		event_loop_.Post([this, status, api_handler]() {
 			if (fail_status_report_status_ == status && fail_status_report_count_ > 0) {
@@ -3475,7 +3477,7 @@ public:
 	error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		http::Client &client,
+		api::Client &client,
 		deployments::LogsAPIResponseHandler api_handler) override {
 		// Just save the log file name so they can be checked later.
 		log_files.push_back(log_file_path);
@@ -3900,7 +3902,7 @@ TEST(SubmitInventoryTests, SubmitInventoryStateTest) {
 		error::Error PushData(
 			const string &inventory_generators_dir,
 			events::EventLoop &loop,
-			http::Client &client,
+			api::Client &client,
 			inventory::APIResponseHandler api_handler) override {
 			recorder_++;
 			api_handler(error::NoError);

--- a/mender-update/daemon/states.cpp
+++ b/mender-update/daemon/states.cpp
@@ -115,7 +115,6 @@ void SubmitInventoryState::DoSubmitInventory(Context &ctx, sm::EventPoster<State
 
 	auto err = ctx.inventory_client->PushData(
 		ctx.mender_context.GetConfig().paths.GetInventoryScriptsDir(),
-		ctx.mender_context.GetConfig().server_url,
 		ctx.event_loop,
 		ctx.http_client,
 		handler);
@@ -166,7 +165,6 @@ void PollForDeploymentState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &
 
 	auto err = ctx.deployment_client->CheckNewDeployments(
 		ctx.mender_context,
-		ctx.mender_context.GetConfig().server_url,
 		ctx.http_client,
 		[&ctx, &poster](mender::update::deployments::CheckUpdatesAPIResponse response) {
 			if (!response) {
@@ -518,7 +516,6 @@ void SendStatusUpdateState::DoStatusUpdate(Context &ctx, sm::EventPoster<StateEv
 		ctx.deployment.state_data->update_info.id,
 		status,
 		"",
-		ctx.mender_context.GetConfig().server_url,
 		ctx.http_client,
 		[result_handler, &ctx](error::Error err) {
 			// If there is an error, we don't submit logs now, but call the handler,
@@ -534,7 +531,6 @@ void SendStatusUpdateState::DoStatusUpdate(Context &ctx, sm::EventPoster<StateEv
 			err = ctx.deployment_client->PushLogs(
 				ctx.deployment.state_data->update_info.id,
 				ctx.deployment.logger->LogFilePath(),
-				ctx.mender_context.GetConfig().server_url,
 				ctx.http_client,
 				result_handler);
 

--- a/mender-update/deployments.hpp
+++ b/mender-update/deployments.hpp
@@ -102,20 +102,17 @@ public:
 
 	virtual error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		const string &server_url,
 		http::Client &client,
 		CheckUpdatesAPIResponseHandler api_handler) = 0;
 	virtual error::Error PushStatus(
 		const string &deployment_id,
 		DeploymentStatus status,
 		const string &substate,
-		const string &server_url,
 		http::Client &client,
 		StatusAPIResponseHandler api_handler) = 0;
 	virtual error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		const string &server_url,
 		http::Client &client,
 		LogsAPIResponseHandler api_handler) = 0;
 };
@@ -124,20 +121,17 @@ class DeploymentClient : virtual public DeploymentAPI {
 public:
 	error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		const string &server_url,
 		http::Client &client,
 		CheckUpdatesAPIResponseHandler api_handler) override;
 	error::Error PushStatus(
 		const string &deployment_id,
 		DeploymentStatus status,
 		const string &substate,
-		const string &server_url,
 		http::Client &client,
 		StatusAPIResponseHandler api_handler) override;
 	error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		const string &server_url,
 		http::Client &client,
 		LogsAPIResponseHandler api_handler) override;
 };

--- a/mender-update/deployments.hpp
+++ b/mender-update/deployments.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include <api/client.hpp>
 #include <common/error.hpp>
 #include <common/events.hpp>
 #include <common/expected.hpp>
@@ -45,6 +46,7 @@ using namespace std;
 namespace sinks = boost::log::sinks;
 #endif // MENDER_LOG_BOOST
 
+namespace api = mender::api;
 namespace context = mender::update::context;
 namespace error = mender::common::error;
 namespace events = mender::common::events;
@@ -102,18 +104,18 @@ public:
 
 	virtual error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		http::Client &client,
+		api::Client &client,
 		CheckUpdatesAPIResponseHandler api_handler) = 0;
 	virtual error::Error PushStatus(
 		const string &deployment_id,
 		DeploymentStatus status,
 		const string &substate,
-		http::Client &client,
+		api::Client &client,
 		StatusAPIResponseHandler api_handler) = 0;
 	virtual error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		http::Client &client,
+		api::Client &client,
 		LogsAPIResponseHandler api_handler) = 0;
 };
 
@@ -121,18 +123,18 @@ class DeploymentClient : virtual public DeploymentAPI {
 public:
 	error::Error CheckNewDeployments(
 		context::MenderContext &ctx,
-		http::Client &client,
+		api::Client &client,
 		CheckUpdatesAPIResponseHandler api_handler) override;
 	error::Error PushStatus(
 		const string &deployment_id,
 		DeploymentStatus status,
 		const string &substate,
-		http::Client &client,
+		api::Client &client,
 		StatusAPIResponseHandler api_handler) override;
 	error::Error PushLogs(
 		const string &deployment_id,
 		const string &log_file_path,
-		http::Client &client,
+		api::Client &client,
 		LogsAPIResponseHandler api_handler) override;
 };
 

--- a/mender-update/deployments/deployments.cpp
+++ b/mender-update/deployments/deployments.cpp
@@ -77,10 +77,7 @@ static const string check_updates_v1_uri = "/api/devices/v1/deployments/device/d
 static const string check_updates_v2_uri = "/api/devices/v2/deployments/device/deployments/next";
 
 error::Error DeploymentClient::CheckNewDeployments(
-	context::MenderContext &ctx,
-	const string &server_url,
-	http::Client &client,
-	CheckUpdatesAPIResponseHandler api_handler) {
+	context::MenderContext &ctx, http::Client &client, CheckUpdatesAPIResponseHandler api_handler) {
 	auto ex_dev_type = ctx.GetDeviceType();
 	if (!ex_dev_type) {
 		return ex_dev_type.error();
@@ -115,7 +112,7 @@ error::Error DeploymentClient::CheckNewDeployments(
 
 	// TODO: APIRequest
 	auto v2_req = make_shared<http::OutgoingRequest>();
-	v2_req->SetAddress(http::JoinUrl(server_url, check_updates_v2_uri));
+	v2_req->SetPath(check_updates_v2_uri);
 	v2_req->SetMethod(http::Method::POST);
 	v2_req->SetHeader("Content-Type", "application/json");
 	v2_req->SetHeader("Content-Length", to_string(v2_payload.size()));
@@ -125,7 +122,7 @@ error::Error DeploymentClient::CheckNewDeployments(
 	string v1_args = "artifact_name=" + http::URLEncode(provides["artifact_name"])
 					 + "&device_type=" + http::URLEncode(device_type);
 	auto v1_req = make_shared<http::OutgoingRequest>();
-	v1_req->SetAddress(http::JoinUrl(server_url, check_updates_v1_uri) + "?" + v1_args);
+	v1_req->SetPath(check_updates_v1_uri + "?" + v1_args);
 	v1_req->SetMethod(http::Method::GET);
 	v1_req->SetHeader("Accept", "application/json");
 
@@ -255,7 +252,6 @@ error::Error DeploymentClient::PushStatus(
 	const string &deployment_id,
 	DeploymentStatus status,
 	const string &substate,
-	const string &server_url,
 	http::Client &client,
 	StatusAPIResponseHandler api_handler) {
 	string payload = R"({"status":")" + DeploymentStatusString(status) + "\"";
@@ -269,8 +265,7 @@ error::Error DeploymentClient::PushStatus(
 	};
 
 	auto req = make_shared<http::OutgoingRequest>();
-	req->SetAddress(
-		http::JoinUrl(server_url, deployments_uri_prefix, deployment_id, status_uri_suffix));
+	req->SetPath(http::JoinUrl(deployments_uri_prefix, deployment_id, status_uri_suffix));
 	req->SetMethod(http::Method::PUT);
 	req->SetHeader("Content-Type", "application/json");
 	req->SetHeader("Content-Length", to_string(payload.size()));
@@ -418,7 +413,6 @@ static const string logs_uri_suffix = "/log";
 error::Error DeploymentClient::PushLogs(
 	const string &deployment_id,
 	const string &log_file_path,
-	const string &server_url,
 	http::Client &client,
 	LogsAPIResponseHandler api_handler) {
 	auto ex_size = GetLogFileDataSize(log_file_path);
@@ -432,8 +426,7 @@ error::Error DeploymentClient::PushLogs(
 	auto logs_reader = make_shared<JsonLogMessagesReader>(file_reader, data_size);
 
 	auto req = make_shared<http::OutgoingRequest>();
-	req->SetAddress(
-		http::JoinUrl(server_url, deployments_uri_prefix, deployment_id, logs_uri_suffix));
+	req->SetPath(http::JoinUrl(deployments_uri_prefix, deployment_id, logs_uri_suffix));
 	req->SetMethod(http::Method::PUT);
 	req->SetHeader("Content-Type", "application/json");
 	req->SetHeader("Content-Length", to_string(JsonLogMessagesReader::TotalDataSize(data_size)));

--- a/mender-update/deployments_test.cpp
+++ b/mender-update/deployments_test.cpp
@@ -64,8 +64,11 @@ public:
 		api::APIRequestPtr req,
 		http::ResponseHandler header_handler,
 		http::ResponseHandler body_handler) override {
-		req->SetAuthData({TEST_SERVER, ""});
-		return http_client_.AsyncCall(req, header_handler, body_handler);
+		auto ex_req = req->WithAuthData({TEST_SERVER, ""});
+		if (!ex_req) {
+			return ex_req.error();
+		}
+		return http_client_.AsyncCall(ex_req.value(), header_handler, body_handler);
 	}
 
 private:

--- a/mender-update/inventory.cpp
+++ b/mender-update/inventory.cpp
@@ -72,7 +72,6 @@ const string uri = "/api/devices/v1/inventory/device/attributes";
 
 error::Error PushInventoryData(
 	const string &inventory_generators_dir,
-	const string &server_url,
 	events::EventLoop &loop,
 	http::Client &client,
 	size_t &last_data_hash,
@@ -121,7 +120,7 @@ error::Error PushInventoryData(
 	};
 
 	auto req = make_shared<http::OutgoingRequest>();
-	req->SetAddress(http::JoinUrl(server_url, uri));
+	req->SetPath(uri);
 	req->SetMethod(http::Method::PUT);
 	req->SetHeader("Content-Type", "application/json");
 	req->SetHeader("Content-Length", to_string(payload.size()));

--- a/mender-update/inventory.cpp
+++ b/mender-update/inventory.cpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include <api/api.hpp>
+#include <api/client.hpp>
 #include <common/common.hpp>
 #include <common/error.hpp>
 #include <common/events.hpp>
@@ -73,7 +74,7 @@ const string uri = "/api/devices/v1/inventory/device/attributes";
 error::Error PushInventoryData(
 	const string &inventory_generators_dir,
 	events::EventLoop &loop,
-	http::Client &client,
+	api::Client &client,
 	size_t &last_data_hash,
 	APIResponseHandler api_handler) {
 	auto ex_inv_data = inv_parser::GetInventoryData(inventory_generators_dir);
@@ -119,7 +120,7 @@ error::Error PushInventoryData(
 		return make_shared<io::StringReader>(payload);
 	};
 
-	auto req = make_shared<http::OutgoingRequest>();
+	auto req = make_shared<api::APIRequest>();
 	req->SetPath(uri);
 	req->SetMethod(http::Method::PUT);
 	req->SetHeader("Content-Type", "application/json");

--- a/mender-update/inventory.hpp
+++ b/mender-update/inventory.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <api/client.hpp>
 #include <common/error.hpp>
 #include <common/events.hpp>
 #include <common/expected.hpp>
@@ -30,6 +31,7 @@ namespace inventory {
 
 using namespace std;
 
+namespace api = mender::api;
 namespace error = mender::common::error;
 namespace events = mender::common::events;
 namespace expected = mender::common::expected;
@@ -54,7 +56,7 @@ using APIResponseHandler = function<void(APIResponse)>;
 error::Error PushInventoryData(
 	const string &inventory_generators_dir,
 	events::EventLoop &loop,
-	http::Client &client,
+	api::Client &client,
 	size_t &last_data_hash,
 	APIResponseHandler api_handler);
 
@@ -66,7 +68,7 @@ public:
 	virtual error::Error PushData(
 		const string &inventory_generators_dir,
 		events::EventLoop &loop,
-		http::Client &client,
+		api::Client &client,
 		APIResponseHandler api_handler) = 0;
 };
 
@@ -75,7 +77,7 @@ public:
 	error::Error PushData(
 		const string &inventory_generators_dir,
 		events::EventLoop &loop,
-		http::Client &client,
+		api::Client &client,
 		APIResponseHandler api_handler) override {
 		return PushInventoryData(
 			inventory_generators_dir, loop, client, last_data_hash_, api_handler);

--- a/mender-update/inventory.hpp
+++ b/mender-update/inventory.hpp
@@ -53,7 +53,6 @@ using APIResponseHandler = function<void(APIResponse)>;
 
 error::Error PushInventoryData(
 	const string &inventory_generators_dir,
-	const string &server_url,
 	events::EventLoop &loop,
 	http::Client &client,
 	size_t &last_data_hash,
@@ -66,7 +65,6 @@ public:
 
 	virtual error::Error PushData(
 		const string &inventory_generators_dir,
-		const string &server_url,
 		events::EventLoop &loop,
 		http::Client &client,
 		APIResponseHandler api_handler) = 0;
@@ -76,12 +74,11 @@ class InventoryClient : public InventoryAPI {
 public:
 	error::Error PushData(
 		const string &inventory_generators_dir,
-		const string &server_url,
 		events::EventLoop &loop,
 		http::Client &client,
 		APIResponseHandler api_handler) override {
 		return PushInventoryData(
-			inventory_generators_dir, server_url, loop, client, last_data_hash_, api_handler);
+			inventory_generators_dir, loop, client, last_data_hash_, api_handler);
 	};
 
 private:

--- a/mender-update/inventory_test.cpp
+++ b/mender-update/inventory_test.cpp
@@ -50,8 +50,11 @@ public:
 		api::APIRequestPtr req,
 		http::ResponseHandler header_handler,
 		http::ResponseHandler body_handler) override {
-		req->SetAuthData({TEST_SERVER, ""});
-		return http_client_.AsyncCall(req, header_handler, body_handler);
+		auto ex_req = req->WithAuthData({TEST_SERVER, ""});
+		if (!ex_req) {
+			return ex_req.error();
+		}
+		return http_client_.AsyncCall(ex_req.value(), header_handler, body_handler);
 	}
 
 private:


### PR DESCRIPTION
**Hint for review**: check the commit overview first so that you know what is made nicer in future commits :wink: 

TODO:
- [x] change `api::Client` to respect `server_url` passed by the Authenticator
- [x] require empty `server_url` on `api::Client::AsyncCall()` requests
- [x] adapt the `api::Client` tests (should `Authenticator` be an interface with a mock implementation in the API client tests?)
- [x] adapt the code using `api::Client` to give it an `OutgoingRequest` with only path set
- [x] (suggestion) define `api::Client` as a new interface together with `APIRequest`
- [x] deduplicate code for tests requiring DBus

Ticket: MEN-6656
Changelog: none
