### PR TITLE
fix(mender-auth): Make FetchJwtToken() a noop if authentication in progress

### DIFF
--- a/mender-auth/ipc/server.hpp
+++ b/mender-auth/ipc/server.hpp
@@ -90,6 +90,7 @@ private:
 
 	string cached_jwt_token_;
 	string cached_server_url_;
+	bool auth_in_progress_ = false;
 
 	const string server_url_;
 	const string tenant_token_;


### PR DESCRIPTION
If the `FetchJwtToken()` DBus method is called multiple times in a row while authentication is in progress, only one authentication request to the server should be made.

Ticket: none
Changelog: none
