### PR TITLE
fix(mender-auth): Remember to pass in the needed params

### DIFF
--- a/mender-auth/cli/actions.cpp
+++ b/mender-auth/cli/actions.cpp
@@ -153,7 +153,10 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 
 	ipc::Server ipc_server {loop, config};
 
-	err = ipc_server.Listen();
+	err = ipc_server.Listen(
+		config.security.auth_private_key == "" ? config.paths.GetKeyFile()
+											   : config.security.auth_private_key,
+		config.paths.GetIdentityScript());
 	if (err != error::NoError) {
 		log::Error("Failed to start the listen loop");
 		log::Error(err.String());

--- a/mender-auth/ipc/server.hpp
+++ b/mender-auth/ipc/server.hpp
@@ -60,7 +60,7 @@ public:
 		dbus_server_ {loop, "io.mender.AuthenticationManager"} {};
 
 	error::Error Listen(
-		const string &identity_script_path = "", const string &private_key_path = "");
+		const string &private_key_path = "", const string &identity_script_path = "");
 
 	string GetServerURL() {
 		return this->cached_server_url_;


### PR DESCRIPTION
Just add the missing identity script, and private key params.

Ticket: MEN-6671
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>