### PR TITLE
test: Fix suboptimal job count when building.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ test:
     - chmod +x /usr/local/bin/mender-artifact
   script:
     - cmake -D COVERAGE=ON .
-    - make -j --load-average=$(nproc --all) --keep-going coverage
+    - make --jobs=$(nproc --all) --keep-going coverage
   tags:
     - mender-qa-worker-generic
   artifacts:
@@ -63,7 +63,7 @@ test:backward-compat:
     - apt update & apt install -yyq --allow-unauthenticated cmake
   script:
     - cmake .
-    - make -j --load-average=$(nproc --all) --keep-going
+    - make --jobs=$(nproc --all) --keep-going
   tags:
     - mender-qa-worker-generic
 
@@ -90,7 +90,7 @@ test:backward-compat:
     - cmake
       -D CMAKE_BUILD_TYPE=${BUILD_TYPE}
       .
-    - make -j --load-average=$(nproc --all) --keep-going check
+    - make --jobs=$(nproc --all) --keep-going check
   tags:
     - mender-qa-worker-generic
 


### PR DESCRIPTION
`--load-average` causes it to oscillate between full capacity (which rapidly raises load average) and far below capacity (which lowers load average again). This causes the overall execution time to be much slower than just using all the CPUs constantly.

Probably this was a typo, and using all CPUs is what was intended all along.
