### PR TITLE
chore: Exclude `main.cmake` from Git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ build/
 **/CMakeFiles/
 /_deps/
 *.cmake
+!main.cmake
 !/cmake/*.cmake
 /Testing
 /install_manifest*.txt


### PR DESCRIPTION
Introduced in 84c13e9fe047d1c47a2b7cc93ea9f49eef53aacf