### PR TITLE
chore: Proxy HTTP requests from clients through mender-auth.

### DIFF
--- a/mender-auth/http_forwarder.hpp
+++ b/mender-auth/http_forwarder.hpp
@@ -69,6 +69,9 @@ public:
 
 	uint16_t GetPort() const;
 	string GetUrl() const;
+	const string &GetTargetUrl() const {
+		return target_url_;
+	}
 
 private:
 	void RequestHeaderHandler(http::ExpectedIncomingRequestPtr exp_req);

--- a/mender-auth/ipc/CMakeLists.txt
+++ b/mender-auth/ipc/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(mender_auth_ipc_server PUBLIC
   common_io
   common_http
   api_auth
+  mender_http_forwarder
 )
 
 add_executable(mender_auth_ipc_server_test EXCLUDE_FROM_ALL server_test.cpp)

--- a/mender-auth/ipc/server.cpp
+++ b/mender-auth/ipc/server.cpp
@@ -36,7 +36,8 @@ namespace dbus = mender::common::dbus;
 using namespace std;
 
 // Register DBus object handling auth methods and signals
-error::Error Caching::Listen(const string &private_key_path, const string &identity_script_path) {
+error::Error AuthenticatingForwarder::Listen(
+	const string &private_key_path, const string &identity_script_path) {
 	// Cannot serve new tokens when not knowing where to fetch them from.
 	AssertOrReturnError(servers_.size() > 0);
 
@@ -72,7 +73,7 @@ error::Error Caching::Listen(const string &private_key_path, const string &ident
 	return dbus_server_.AdvertiseObject(dbus_obj);
 }
 
-void Caching::FetchJwtTokenHandler(auth_client::APIResponse &resp) {
+void AuthenticatingForwarder::FetchJwtTokenHandler(auth_client::APIResponse &resp) {
 	auth_in_progress_ = false;
 
 	forwarder_.Cancel();

--- a/mender-auth/ipc/server.hpp
+++ b/mender-auth/ipc/server.hpp
@@ -49,9 +49,9 @@ namespace auth_client = mender::api::auth;
 
 namespace http_forwarder = mender::auth::http_forwarder;
 
-class Caching {
+class AuthenticatingForwarder {
 public:
-	Caching(events::EventLoop &loop, const conf::MenderConfig &config) :
+	AuthenticatingForwarder(events::EventLoop &loop, const conf::MenderConfig &config) :
 		servers_ {config.servers},
 		tenant_token_ {config.tenant_token},
 		client_ {config.GetHttpClientConfig(), loop},
@@ -98,7 +98,7 @@ private:
 	dbus::DBusServer dbus_server_;
 };
 
-using Server = Caching;
+using Server = AuthenticatingForwarder;
 
 } // namespace ipc
 } // namespace auth

--- a/mender-auth/ipc/server.hpp
+++ b/mender-auth/ipc/server.hpp
@@ -29,6 +29,8 @@
 #include <api/api.hpp>
 #include <api/auth.hpp>
 
+#include <mender-auth/http_forwarder.hpp>
+
 namespace mender {
 namespace auth {
 namespace ipc {
@@ -36,7 +38,6 @@ namespace ipc {
 
 using namespace std;
 
-namespace auth_client = mender::api::auth;
 namespace conf = mender::common::conf;
 namespace dbus = mender::common::dbus;
 namespace error = mender::common::error;
@@ -44,12 +45,17 @@ namespace events = mender::common::events;
 namespace log = mender::common::log;
 namespace path = mender::common::path;
 
+namespace auth_client = mender::api::auth;
+
+namespace http_forwarder = mender::auth::http_forwarder;
+
 class Caching {
 public:
 	Caching(events::EventLoop &loop, const conf::MenderConfig &config) :
 		servers_ {config.servers},
 		tenant_token_ {config.tenant_token},
 		client_ {config.GetHttpClientConfig(), loop},
+		forwarder_ {http::ServerConfig {}, config.GetHttpClientConfig(), loop},
 		default_identity_script_path_ {config.paths.GetIdentityScript()},
 		dbus_server_ {loop, "io.mender.AuthenticationManager"} {};
 
@@ -69,18 +75,16 @@ public:
 		this->cached_server_url_ = url;
 	}
 
+	const http_forwarder::Server &GetForwarder() const {
+		return forwarder_;
+	}
+
 private:
 	void ClearCache() {
 		Cache("", "");
 	}
 
-	void CacheAPIResponse(const auth_client::APIResponse &resp) {
-		if (resp) {
-			Cache(resp.value().token, resp.value().server_url);
-			return;
-		}
-		ClearCache();
-	};
+	void FetchJwtTokenHandler(auth_client::APIResponse &resp);
 
 	string cached_jwt_token_;
 	string cached_server_url_;
@@ -89,6 +93,7 @@ private:
 	const vector<string> &servers_;
 	const string tenant_token_;
 	http::Client client_;
+	http_forwarder::Server forwarder_;
 	string default_identity_script_path_;
 	dbus::DBusServer dbus_server_;
 };


### PR DESCRIPTION
Also, in the tests, `TEST_PORT_2` seems to not be necessary (never used together with `TEST_PORT`), so just use the latter.

Ticket: MEN-6664
