### PR TITLE
fix: Use our custom false-initialized boolean in http::ClientConfig

### DIFF
--- a/artifact/v3/scripts/executor.hpp
+++ b/artifact/v3/scripts/executor.hpp
@@ -123,7 +123,6 @@ private:
 	string ScriptPath(State state);
 
 	events::EventLoop &loop_;
-	bool is_artifact_script_;
 	chrono::milliseconds script_timeout_;
 	chrono::milliseconds retry_interval_;
 	chrono::milliseconds retry_timeout_;

--- a/common/common.hpp
+++ b/common/common.hpp
@@ -41,6 +41,20 @@ namespace common {
 
 using namespace std;
 
+struct def_bool {
+	bool value;
+
+	def_bool() :
+		value {false} {};
+	def_bool(bool init_value) :
+		value {init_value} {
+	}
+
+	operator bool() const {
+		return value;
+	}
+};
+
 inline static vector<uint8_t> ByteVectorFromString(const char *str) {
 	return vector<uint8_t>(
 		reinterpret_cast<const uint8_t *>(str),

--- a/common/crypto_test.cpp
+++ b/common/crypto_test.cpp
@@ -28,7 +28,6 @@ using namespace std;
 
 namespace mtesting = mender::common::testing;
 using testing::HasSubstr;
-using testing::StartsWith;
 
 namespace error = mender::common::error;
 namespace path = mender::common::path;
@@ -53,7 +52,8 @@ TEST(CryptoTest, TestKeyFileNotFound) {
 	auto expected_signature = crypto::Sign(private_key_file, {});
 	ASSERT_FALSE(expected_signature);
 	EXPECT_THAT(
-		expected_signature.error().message, StartsWith("Failed to open the private key file"));
+		expected_signature.error().message,
+		::testing::StartsWith("Failed to open the private key file"));
 }
 
 TEST(CryptoTest, TestPublicKeyExtraction) {
@@ -70,7 +70,8 @@ TEST(CryptoTest, TestPublicKeyExtractionError) {
 	auto expected_public_key = crypto::ExtractPublicKey(private_key_file);
 	ASSERT_FALSE(expected_public_key);
 	EXPECT_THAT(
-		expected_public_key.error().message, StartsWith("Failed to open the private key file"));
+		expected_public_key.error().message,
+		::testing::StartsWith("Failed to open the private key file"));
 }
 
 TEST(CryptoTest, TestEncodeDecodeBase64) {

--- a/common/http.hpp
+++ b/common/http.hpp
@@ -32,6 +32,7 @@
 
 #include <config.h>
 
+#include <common/common.hpp>
 #include <common/error.hpp>
 #include <common/events.hpp>
 #include <common/expected.hpp>
@@ -61,6 +62,7 @@ namespace ssl = asio::ssl;
 using tcp = asio::ip::tcp;
 #endif // MENDER_USE_BOOST_BEAST
 
+namespace common = mender::common;
 namespace error = mender::common::error;
 namespace events = mender::common::events;
 namespace expected = mender::common::expected;
@@ -408,11 +410,12 @@ struct ClientConfig {
 	string server_cert_path;
 	string client_cert_path;
 	string client_cert_key_path;
-	// C++11 cannot mix default member initializers with designated initializers (named
-	// parameters). But the default of bools in C++ is always false regardless, so we still get
-	// intended behavior, it's just not explicit.
-	bool skip_verify;        // {false};
-	bool disable_keep_alive; // {false};
+
+	// C++11 cannot mix default member initializers with designated initializers
+	// (named parameters). However, bool doesn't have a guaranteed initial value
+	// so we need to use our custom type that defaults to false.
+	common::def_bool skip_verify;
+	common::def_bool disable_keep_alive;
 
 	string http_proxy;
 	string https_proxy;

--- a/common/http_test.cpp
+++ b/common/http_test.cpp
@@ -1877,8 +1877,6 @@ TEST(HttpsTest, CertificationWithWrongHostName) {
 }
 
 TEST(HttpsTest, NoCertificateError) {
-	GTEST_SKIP() << "MEN-6787";
-
 	TestEventLoop loop;
 
 	bool client_hit_header {false};

--- a/common/key_value_database/platform/lmdb/lmdb.cpp
+++ b/common/key_value_database/platform/lmdb/lmdb.cpp
@@ -80,8 +80,7 @@ error::Error LmdbTransaction::Remove(const string &key) {
 }
 
 KeyValueDatabaseLmdb::KeyValueDatabaseLmdb() :
-	env_ {make_unique<lmdb::env>(lmdb::env::create())},
-	successfully_opened_ {false} {
+	env_ {make_unique<lmdb::env>(lmdb::env::create())} {
 }
 
 KeyValueDatabaseLmdb::~KeyValueDatabaseLmdb() {

--- a/common/key_value_database_lmdb.hpp
+++ b/common/key_value_database_lmdb.hpp
@@ -51,7 +51,7 @@ public:
 
 private:
 	unique_ptr<lmdb::env> env_;
-	bool successfully_opened_;
+	bool successfully_opened_ {false};
 };
 
 } // namespace key_value_database


### PR DESCRIPTION
Turns out `bool` values are not guaranteed to be initialized to
`false` by default. However, if we explicitly initialize fields
in `http::ClientConfig`, we cannot use designated (named)
initializers. So we need a custom boolean type that acts like a
boolean, but is guaranteed to be initialized to `false` by
default.

Ticket: MEN-6787
Changelog: none
Signed-off-by: Vratislav Podzimek <v.podzimek@mykolab.com>

*Plus two small related changes.*