### PR TITLE
fix: Fix possible missing `Sync` call at the very end of the update.

### DIFF
--- a/installer/block_device.go
+++ b/installer/block_device.go
@@ -433,3 +433,13 @@ func (fw *FlushingWriter) Sync() error {
 	fw.unflushedBytesWritten = 0
 	return err
 }
+
+func (fw *FlushingWriter) Close() error {
+	sync_err := fw.Sync()
+	close_err := fw.BlockDevicer.Close()
+	if sync_err != nil {
+		return sync_err
+	} else {
+		return close_err
+	}
+}


### PR DESCRIPTION
```
commit ff0db6042830bebc7e15b93da7c71eead153f3f9
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 23 10:42:22 2023

    fix: Fix possible missing `Sync` call at the very end of the update.
    
    We need to override the `Close` method so that we call `Sync` as the
    final thing before closing. Most boards are not affected by this,
    because the flushing interval is set to the native sector size of the
    board, which, AFAIK, is 512 for all normal block devices except raw
    Flash storage. I consider it very unlikely that a filesystem would not
    be a multiple of 512 (maybe squashfs?), which means that by the time
    we get to `Close()`, `Sync()` will usually have been called already
    because the last write was 512 bytes or bigger.
    
    But on raw Flash filesystems it can potentially happen, if the native
    sector size is big, and the filesystem is not a multiple of this
    number.
    
    Changelog: Fix a rare bug which could corrupt the very end of a
    rootfs-image update on a sudden powerloss. The circumstances where it
    could happen are quite specific: The filesystem size in the update
    need to *not* be a multiple of the native sector size, which is very
    uncommon. The sector size is typically 512 bytes almost everywhere,
    and hence filesystem also follow this block size, if not bigger. The
    exception is raw Flash/UBI devices, where the sector size can be much
    larger, and not a power of two, and hence these platforms may be more
    susceptible.
    
    Ticket: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```