### PR TITLE
fix(https): Enable server host name verification in TLS handshake

### DIFF
--- a/common/http_proxy_test.cpp
+++ b/common/http_proxy_test.cpp
@@ -533,8 +533,6 @@ TEST_F(HttpProxyHttpsTest, WrongProxySet) {
 }
 
 TEST_F(HttpProxyHttpsTest, WrongHostNameForTarget) {
-	GTEST_SKIP() << "MEN-6788";
-
 	bool client_hit_header = false;
 
 	http::ClientConfig client_config {
@@ -703,8 +701,6 @@ TEST_F(HttpsProxyHttpTest, WrongProxySet) {
 }
 
 TEST_F(HttpsProxyHttpTest, WrongHostNameForProxy) {
-	GTEST_SKIP() << "MEN-6788";
-
 	bool client_hit_header = false;
 
 	http::ClientConfig client_config {
@@ -904,8 +900,6 @@ TEST_F(HttpsProxyHttpsTest, WrongTarget) {
 }
 
 TEST_F(HttpsProxyHttpsTest, WrongHostNameForProxy) {
-	GTEST_SKIP() << "MEN-6788";
-
 	bool client_hit_header = false;
 
 	http::ClientConfig client_config {
@@ -935,8 +929,6 @@ TEST_F(HttpsProxyHttpsTest, WrongHostNameForProxy) {
 }
 
 TEST_F(HttpsProxyHttpsTest, WrongHostNameForTarget) {
-	GTEST_SKIP() << "MEN-6788";
-
 	bool client_hit_header = false;
 
 	http::ClientConfig client_config {

--- a/common/http_test.cpp
+++ b/common/http_test.cpp
@@ -1825,8 +1825,6 @@ TEST(HttpsTest, WrongSelfSignedCertificateError) {
 }
 
 TEST(HttpsTest, CertificationWithWrongHostName) {
-	GTEST_SKIP() << "MEN-6788";
-
 	TestEventLoop loop;
 
 	bool client_hit_header {false};


### PR DESCRIPTION
It's not done automatically and we need to use a callback for
this. However, it's a common thing so Boost has the callback
(functor object) ready for us.

Ticket: MEN-6788
Changelog: none
Signed-off-by: Vratislav Podzimek <v.podzimek@mykolab.com>