### PR TITLE
chore: Drop a TODO about access(X_OK) in DiscoverUpdateModules()

### DIFF
--- a/common/http.hpp
+++ b/common/http.hpp
@@ -609,9 +609,9 @@ private:
 };
 using ClientPtr = shared_ptr<Client>;
 
-// Master object that servers are made from. Configure TLS options on this object before listening.
+// Master object that servers are made from.
 struct ServerConfig {
-	// TODO: Empty for now, but will contain TLS configuration options later.
+	// Empty for now, but will probably contain configuration options later.
 };
 
 class Server;

--- a/mender-update/update_module/v3/platform/c++17/fs_operations.cpp
+++ b/mender-update/update_module/v3/platform/c++17/fs_operations.cpp
@@ -264,7 +264,6 @@ expected::ExpectedStringVector DiscoverUpdateModules(const conf::MenderConfig &c
 				continue;
 			}
 
-			// TODO: should check access(X_OK)?
 			ret.push_back(file_path_str);
 		}
 	} catch (const fs::filesystem_error &e) {


### PR DESCRIPTION
We make sure that the update module file has some executable permissions bits set. It doesn't mean executing it will be allowed, but it's a good enough filter. If the actual execution fails, it will be handled properly.

Ticket: none
Changelog: none

Plus one more.
