### PR TITLE
fix: Omit service/destination from method handling spec

### DIFF
--- a/api/auth_test.cpp
+++ b/api/auth_test.cpp
@@ -263,10 +263,7 @@ TEST_F(AuthDBusTests, AuthenticatorBasicTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL]() {
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_server.AdvertiseObject(dbus_obj);
@@ -299,10 +296,7 @@ TEST_F(AuthDBusTests, AuthenticatorTwoActionsTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL]() {
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_server.AdvertiseObject(dbus_obj);
@@ -354,15 +348,11 @@ TEST_F(AuthDBusTests, AuthenticatorTwoActionsWithTokenClearTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL, &n_replies]() {
 			n_replies++;
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
 		"io.mender.Authentication1",
 		"FetchJwtToken",
 		[&n_replies, &dbus_server, JWT_TOKEN, SERVER_URL]() {
@@ -424,18 +414,12 @@ TEST_F(AuthDBusTests, AuthenticatorTwoActionsWithTokenClearAndTimeoutTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL, &n_replies]() {
 			n_replies++;
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"FetchJwtToken",
-		[&n_replies]() {
+		"io.mender.Authentication1", "FetchJwtToken", [&n_replies]() {
 			n_replies++;
 			// no JwtTokenStateChange signal emitted here
 			return true;
@@ -484,15 +468,12 @@ TEST_F(AuthDBusTests, AuthenticatorBasicRealLifeTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager", "io.mender.Authentication1", "GetJwtToken", []() {
+		"io.mender.Authentication1", "GetJwtToken", []() {
 			// no token initially
 			return dbus::StringPair {"", ""};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"FetchJwtToken",
-		[&dbus_server, JWT_TOKEN, SERVER_URL]() {
+		"io.mender.Authentication1", "FetchJwtToken", [&dbus_server, JWT_TOKEN, SERVER_URL]() {
 			dbus_server.EmitSignal<dbus::StringPair>(
 				"/io/mender/AuthenticationManager",
 				"io.mender.Authentication1",
@@ -532,18 +513,12 @@ TEST_F(AuthDBusTests, AuthenticatorExternalTokenUpdateTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL, &n_replies]() {
 			n_replies++;
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"FetchJwtToken",
-		[&dbus_server, JWT_TOKEN, SERVER_URL]() {
+		"io.mender.Authentication1", "FetchJwtToken", [&dbus_server, JWT_TOKEN, SERVER_URL]() {
 			dbus_server.EmitSignal<dbus::StringPair>(
 				"/io/mender/AuthenticationManager",
 				"io.mender.Authentication1",

--- a/api/client_test.cpp
+++ b/api/client_test.cpp
@@ -118,10 +118,7 @@ TEST_F(APIClientTests, ClientBasicTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL]() {
 			return dbus::StringPair {JWT_TOKEN, SERVER_URL};
 		});
 	dbus_server.AdvertiseObject(dbus_obj);
@@ -221,10 +218,7 @@ TEST_F(APIClientTests, TwoClientsTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN, SERVER_URL, &n_replies]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN, SERVER_URL, &n_replies]() {
 			// auth data should only be requested once
 			n_replies++;
 			EXPECT_LE(n_replies, 1);
@@ -389,17 +383,11 @@ TEST_F(APIClientTests, ClientReauthenticationTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN1, SERVER_URL]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN1, SERVER_URL]() {
 			return dbus::StringPair {JWT_TOKEN1, SERVER_URL};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"FetchJwtToken",
-		[&dbus_server, JWT_TOKEN2, SERVER_URL]() {
+		"io.mender.Authentication1", "FetchJwtToken", [&dbus_server, JWT_TOKEN2, SERVER_URL]() {
 			dbus_server.EmitSignal<dbus::StringPair>(
 				"/io/mender/AuthenticationManager",
 				"io.mender.Authentication1",
@@ -608,14 +596,11 @@ TEST_F(APIClientTests, ClientReauthenticationFailureTest) {
 	dbus::DBusServer dbus_server {loop, "io.mender.AuthenticationManager"};
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager",
-		"io.mender.Authentication1",
-		"GetJwtToken",
-		[JWT_TOKEN1, SERVER_URL]() {
+		"io.mender.Authentication1", "GetJwtToken", [JWT_TOKEN1, SERVER_URL]() {
 			return dbus::StringPair {JWT_TOKEN1, SERVER_URL};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager", "io.mender.Authentication1", "FetchJwtToken", []() {
+		"io.mender.Authentication1", "FetchJwtToken", []() {
 			// no signal emitted here
 			return true;
 		});

--- a/common/dbus.hpp
+++ b/common/dbus.hpp
@@ -167,10 +167,7 @@ public:
 
 	template <typename ReturnType>
 	void AddMethodHandler(
-		const string &service,
-		const string &interface,
-		const string &method,
-		DBusMethodHandler<ReturnType> handler);
+		const string &interface, const string &method, DBusMethodHandler<ReturnType> handler);
 
 	friend DBusHandlerResult HandleMethodCall(
 		DBusConnection *connection, DBusMessage *message, void *data);

--- a/common/dbus/platform/asio_libdbus/dbus.cpp
+++ b/common/dbus/platform/asio_libdbus/dbus.cpp
@@ -575,38 +575,32 @@ DBusHandlerResult MsgFilter(DBusConnection *connection, DBusMessage *message, vo
 	}
 }
 
-static inline string GetMethodSpec(
-	const string &service, const string &interface, const string &method) {
-	return service + "::" + interface + "." + method;
+static inline string GetMethodSpec(const string &interface, const string &method) {
+	return interface + "." + method;
 }
 
 template <>
 void DBusObject::AddMethodHandler(
-	const string &service,
 	const string &interface,
 	const string &method,
 	DBusMethodHandler<expected::ExpectedString> handler) {
-	string spec = GetMethodSpec(service, interface, method);
+	string spec = GetMethodSpec(interface, method);
 	method_handlers_string_[spec] = handler;
 }
 
 template <>
 void DBusObject::AddMethodHandler(
-	const string &service,
-	const string &interface,
-	const string &method,
-	DBusMethodHandler<ExpectedStringPair> handler) {
-	string spec = GetMethodSpec(service, interface, method);
+	const string &interface, const string &method, DBusMethodHandler<ExpectedStringPair> handler) {
+	string spec = GetMethodSpec(interface, method);
 	method_handlers_string_pair_[spec] = handler;
 }
 
 template <>
 void DBusObject::AddMethodHandler(
-	const string &service,
 	const string &interface,
 	const string &method,
 	DBusMethodHandler<expected::ExpectedBool> handler) {
-	string spec = GetMethodSpec(service, interface, method);
+	string spec = GetMethodSpec(interface, method);
 	method_handlers_bool_[spec] = handler;
 }
 
@@ -719,10 +713,8 @@ bool AddReturnDataToDBusMessage(DBusMessage *message, bool data) {
 DBusHandlerResult HandleMethodCall(DBusConnection *connection, DBusMessage *message, void *data) {
 	DBusObject *obj = static_cast<DBusObject *>(data);
 
-	string spec = GetMethodSpec(
-		dbus_message_get_destination(message),
-		dbus_message_get_interface(message),
-		dbus_message_get_member(message));
+	string spec =
+		GetMethodSpec(dbus_message_get_interface(message), dbus_message_get_member(message));
 
 	auto opt_string_handler = obj->GetMethodHandler<expected::ExpectedString>(spec);
 	auto opt_string_pair_handler = obj->GetMethodHandler<ExpectedStringPair>(spec);

--- a/common/dbus_test.cpp
+++ b/common/dbus_test.cpp
@@ -158,7 +158,7 @@ TEST_F(DBusServerTests, DBusServerBasicMethodHandlingTest) {
 	bool method_handler_called {false};
 	dbus::DBusObject obj {"/io/mender/Test/Obj"};
 	obj.AddMethodHandler<expected::ExpectedString>(
-		"io.mender.Test", "io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
+		"io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
 			method_handler_called = true;
 			return "test return value";
 		});
@@ -194,7 +194,7 @@ TEST_F(DBusServerTests, DBusServerErrorMethodHandlingTest) {
 	bool method_handler_called {false};
 	dbus::DBusObject obj {"/io/mender/Test/Obj"};
 	obj.AddMethodHandler<expected::ExpectedString>(
-		"io.mender.Test", "io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
+		"io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
 			method_handler_called = true;
 			return expected::unexpected(
 				error::MakeError(error::GenericError, "testing error handling"));
@@ -231,7 +231,7 @@ TEST_F(DBusServerTests, DBusServerBoolMethodHandlingTest) {
 	bool method_handler_called {false};
 	dbus::DBusObject obj {"/io/mender/Test/Obj"};
 	obj.AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.Test", "io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
+		"io.mender.Test.TestIface", "TestMethod", [&method_handler_called]() {
 			method_handler_called = true;
 			return true;
 		});

--- a/mender-auth/ipc/server.cpp
+++ b/mender-auth/ipc/server.cpp
@@ -43,11 +43,10 @@ error::Error AuthenticatingForwarder::Listen(
 
 	auto dbus_obj = make_shared<dbus::DBusObject>("/io/mender/AuthenticationManager");
 	dbus_obj->AddMethodHandler<dbus::ExpectedStringPair>(
-		"io.mender.AuthenticationManager", "io.mender.Authentication1", "GetJwtToken", [this]() {
+		"io.mender.Authentication1", "GetJwtToken", [this]() {
 			return dbus::StringPair {GetJWTToken(), GetServerURL()};
 		});
 	dbus_obj->AddMethodHandler<expected::ExpectedBool>(
-		"io.mender.AuthenticationManager",
 		"io.mender.Authentication1",
 		"FetchJwtToken",
 		[this, private_key_path, identity_script_path]() {


### PR DESCRIPTION
If the method call arrives to the particular `DBusServer` instance, it must have the matching destination set.

Ticket: MEN-6808
Changelog: none
