### PR TITLE
chore: Add info log line on successful authentication

### DIFF
--- a/mender-auth/ipc/server.cpp
+++ b/mender-auth/ipc/server.cpp
@@ -90,6 +90,7 @@ void AuthenticatingForwarder::FetchJwtTokenHandler(auth_client::APIResponse &res
 			Cache(resp.value().token, resp.value().server_url);
 		}
 
+		log::Info("Successfully received new authorization data");
 		dbus_server_.EmitSignal<dbus::StringPair>(
 			"/io/mender/AuthenticationManager",
 			"io.mender.Authentication1",


### PR DESCRIPTION
On regular operation, `mender-auth` will log errors until accepted by the server and then it will just keep silent. This log should not be very noisy and will give the user a confirmation that the device is has been accepted.