### PR TITLE
MEN-6813: Serialize identity keys as single strings when possible

### DIFF
--- a/src/api/auth/auth.cpp
+++ b/src/api/auth/auth.cpp
@@ -115,13 +115,8 @@ error::Error FetchJWTToken(
 	if (!expected_identity_data) {
 		return expected_identity_data.error();
 	}
-	expected::ExpectedString expected_identity_data_json =
-		json::Dump(expected_identity_data.value());
-	if (!expected_identity_data_json) {
-		mlog::Error("Failed to dump the identity data to JSON");
-		return expected_identity_data_json.error();
-	}
-	auto identity_data_json = expected_identity_data_json.value();
+
+	auto identity_data_json = identity_parser::DumpIdentityData(expected_identity_data.value());
 	mlog::Debug("Got identity data: " + identity_data_json);
 
 	// Create the request body

--- a/src/artifact/v3/header/type_info.cpp
+++ b/src/artifact/v3/header/type_info.cpp
@@ -89,7 +89,7 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	//
 
 	auto expected_artifact_provides =
-		type_info_json.Get("artifact_provides").and_then(json::ToKeyValuesMap);
+		type_info_json.Get("artifact_provides").and_then(json::ToKeyValueMap);
 	if (!expected_artifact_provides
 		&& expected_artifact_provides.error().code.value() != json::KeyError) {
 		return expected::unexpected(parser_error::MakeError(
@@ -110,7 +110,7 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	log::Trace("type-info: Parsing the artifact_depends");
 
 	auto expected_artifact_depends =
-		type_info_json.Get("artifact_depends").and_then(json::ToKeyValuesMap);
+		type_info_json.Get("artifact_depends").and_then(json::ToKeyValueMap);
 	if (!expected_artifact_depends
 		&& expected_artifact_depends.error().code.value() != json::KeyError) {
 		return expected::unexpected(parser_error::MakeError(

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -219,7 +219,7 @@ add_dependencies(tests key_value_parser_test)
 
 
 add_library(common_identity_parser STATIC identity_parser/identity_parser.cpp)
-target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes)
+target_link_libraries(common_identity_parser PUBLIC common_key_value_parser common_processes common_json)
 
 add_executable(identity_parser_test EXCLUDE_FROM_ALL identity_parser_test.cpp)
 target_link_libraries(identity_parser_test PUBLIC common_identity_parser main_test)

--- a/src/common/identity_parser.hpp
+++ b/src/common/identity_parser.hpp
@@ -26,6 +26,8 @@ namespace kvp = mender::common::key_value_parser;
 
 kvp::ExpectedKeyValuesMap GetIdentityData(const string &identity_data_generator);
 
+string DumpIdentityData(const kvp::KeyValuesMap &identity_data);
+
 } // namespace identity_parser
 } // namespace common
 } // namespace mender

--- a/src/common/json.hpp
+++ b/src/common/json.hpp
@@ -136,7 +136,7 @@ using KeyValueMap = unordered_map<string, string>;
 using ExpectedKeyValueMap = expected::expected<KeyValueMap, error::Error>;
 
 ExpectedStringVector ToStringVector(const json::Json &j);
-ExpectedKeyValueMap ToKeyValuesMap(const json::Json &j);
+ExpectedKeyValueMap ToKeyValueMap(const json::Json &j);
 ExpectedString ToString(const json::Json &j);
 ExpectedInt64 ToInt(const json::Json &j);
 ExpectedBool ToBool(const json::Json &j);

--- a/src/common/json/json.cpp
+++ b/src/common/json/json.cpp
@@ -51,7 +51,7 @@ error::Error MakeError(JsonErrorCode code, const string &msg) {
 
 template <>
 expected::expected<KeyValueMap, error::Error> Json::Get<KeyValueMap>() const {
-	return ToKeyValuesMap(*this);
+	return ToKeyValueMap(*this);
 }
 
 template <>
@@ -122,7 +122,7 @@ ExpectedStringVector ToStringVector(const json::Json &j) {
 	return vector_elements;
 }
 
-ExpectedKeyValueMap ToKeyValuesMap(const json::Json &j) {
+ExpectedKeyValueMap ToKeyValueMap(const json::Json &j) {
 	if (!j.IsObject()) {
 		return expected::unexpected(
 			MakeError(JsonErrorCode::ParseError, "The JSON is not an object"));

--- a/src/mender-update/daemon/context.cpp
+++ b/src/mender-update/daemon/context.cpp
@@ -424,7 +424,7 @@ static error::Error UnmarshalJsonStateData(const json::Json &json, StateData &st
 	exp_string = json_artifact.Get("ArtifactGroup").and_then(json::ToString);
 	SetOrReturnIfError(artifact.artifact_group, exp_string);
 
-	auto exp_string_map = json_artifact.Get("TypeInfoProvides").and_then(json::ToKeyValuesMap);
+	auto exp_string_map = json_artifact.Get("TypeInfoProvides").and_then(json::ToKeyValueMap);
 	DefaultOrSetOrReturnIfError(artifact.type_info_provides, exp_string_map, {});
 
 	exp_string_vector = json_artifact.Get("ClearsArtifactProvides").and_then(json::ToStringVector);


### PR DESCRIPTION
Use the same logic than for inventory keys: if the vector has one
element serialize as string, else submit as a list of strings.