### PR TITLE
chore: Alias mender-authd.service -> mender-client.service

### DIFF
--- a/support/mender-authd.service
+++ b/support/mender-authd.service
@@ -14,3 +14,4 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
+Alias=mender-client.service


### PR DESCRIPTION
This aliases the systemd.service for `mender-authd` to `mender-client`, so that
other existing third-party services relying on it will still work transparently.

Ticket: MEN-6812

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

-------