### PR TITLE
fix: Fix several fallback config parsing bugs.

### DIFF
--- a/src/common/conf/conf.cpp
+++ b/src/common/conf/conf.cpp
@@ -225,13 +225,13 @@ expected::ExpectedSize MenderConfig::ProcessCmdlineArgs(
 		SetLevel(ex_log_level.value());
 	}
 
-	auto err = LoadConfigFile_(paths.GetConfFile(), explicit_config_path);
+	auto err = LoadConfigFile_(paths.GetFallbackConfFile(), explicit_fallback_config_path);
 	if (error::NoError != err) {
 		this->Reset();
 		return expected::unexpected(err);
 	}
 
-	err = LoadConfigFile_(paths.GetFallbackConfFile(), explicit_fallback_config_path);
+	err = LoadConfigFile_(paths.GetConfFile(), explicit_config_path);
 	if (error::NoError != err) {
 		this->Reset();
 		return expected::unexpected(err);

--- a/src/common/config_parser.hpp
+++ b/src/common/config_parser.hpp
@@ -180,6 +180,10 @@ public:
 	ExpectedBool LoadFile(const string &path);
 
 	void Reset();
+
+private:
+	bool artifact_verify_keys_field_used_ {false};
+	bool servers_field_used_ {false};
 };
 
 } // namespace config_parser

--- a/src/common/config_parser/config_parser.cpp
+++ b/src/common/config_parser/config_parser.cpp
@@ -206,6 +206,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 
 	e_cfg_value = cfg_json.Get("ArtifactVerifyKeys");
 	if (e_cfg_value) {
+		this->artifact_verify_keys.clear();
 		const json::Json value_array = e_cfg_value.value();
 		const json::ExpectedSize e_n_items = value_array.GetArraySize();
 		if (e_n_items) {
@@ -227,6 +228,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 				}
 			}
 		}
+		artifact_verify_keys_field_used_ = true;
 	}
 
 	e_cfg_value = cfg_json.Get("ArtifactVerifyKey");
@@ -234,12 +236,14 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		const json::Json value_json = e_cfg_value.value();
 		const json::ExpectedString e_cfg_string = value_json.GetString();
 		if (e_cfg_string) {
-			if (artifact_verify_keys.size() != 0) {
+			if (artifact_verify_keys_field_used_) {
 				auto err = MakeError(
 					ConfigParserErrorCode::ValidationError,
 					"Both 'ArtifactVerifyKey' and 'ArtifactVerifyKeys' are set");
 				return expected::unexpected(err);
 			}
+			assert(artifact_verify_keys.size() <= 1);
+			this->artifact_verify_keys.clear();
 			this->artifact_verify_keys.push_back(e_cfg_string.value());
 			applied = true;
 		}
@@ -247,6 +251,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 
 	e_cfg_value = cfg_json.Get("Servers");
 	if (e_cfg_value) {
+		this->servers.clear();
 		const json::Json value_array = e_cfg_value.value();
 		const json::ExpectedSize e_n_items = value_array.GetArraySize();
 		if (e_n_items) {
@@ -268,6 +273,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 				}
 			}
 		}
+		servers_field_used_ = true;
 	}
 
 	e_cfg_value = cfg_json.Get("ServerURL");
@@ -275,12 +281,14 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		const json::Json value_json = e_cfg_value.value();
 		const json::ExpectedString e_cfg_string = value_json.GetString();
 		if (e_cfg_string) {
-			if (servers.size() != 0) {
+			if (servers_field_used_) {
 				auto err = MakeError(
 					ConfigParserErrorCode::ValidationError,
 					"Both 'Servers' AND 'ServerURL given in the configuration. Please set only one of these fields");
 				return expected::unexpected(err);
 			}
+			assert(servers.size() <= 1);
+			this->servers.clear();
 			this->servers.push_back(e_cfg_string.value());
 			applied = true;
 		}

--- a/src/common/config_parser_test.cpp
+++ b/src/common/config_parser_test.cpp
@@ -497,17 +497,12 @@ TEST_F(ConfigParserTests, LoadOverridesExtraArrayItems) {
 	EXPECT_EQ(mc.state_script_retry_interval_seconds, 9);
 	EXPECT_EQ(mc.module_timeout_seconds, 10);
 
-	EXPECT_EQ(mc.artifact_verify_keys.size(), 5);
-	EXPECT_EQ(mc.artifact_verify_keys[0], "key1");
-	EXPECT_EQ(mc.artifact_verify_keys[1], "key2");
-	EXPECT_EQ(mc.artifact_verify_keys[2], "key3");
-	EXPECT_EQ(mc.artifact_verify_keys[3], "key4");
-	EXPECT_EQ(mc.artifact_verify_keys[4], "key5");
+	EXPECT_EQ(mc.artifact_verify_keys.size(), 2);
+	EXPECT_EQ(mc.artifact_verify_keys[0], "key4");
+	EXPECT_EQ(mc.artifact_verify_keys[1], "key5");
 
-	EXPECT_EQ(mc.servers.size(), 3);
-	EXPECT_EQ(mc.servers[0], "server1");
-	EXPECT_EQ(mc.servers[1], "server2");
-	EXPECT_EQ(mc.servers[2], "server3");
+	EXPECT_EQ(mc.servers.size(), 1);
+	EXPECT_EQ(mc.servers[0], "server3");
 
 	EXPECT_EQ(mc.https_client.certificate, "Certificate_value");
 	EXPECT_EQ(mc.https_client.key, "Key_value");


### PR DESCRIPTION
First of all, reverse the order of loading. If the fallback is to have least precedence, then it must be loaded first for the other one to override it.

Then, to match the behavior of the Golang client, we need to change two things:

* We need to allow `ArtifactVerifyKey` and `ServerURL` to appear in both files. This was not previously possible because they were automatically put into the list variant and would trigger an error that you can't use both at the same time.

* The list variants, `ArtifactVerifyKeys` and `Servers` need to override the specified lists in the fallback config file, not add to them.

Changelog: None
Ticket: None
