### PR TITLE
chore: Add readiness log messages to each daemon.

### DIFF
--- a/src/mender-auth/cli/actions.cpp
+++ b/src/mender-auth/cli/actions.cpp
@@ -154,6 +154,11 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 		return error::MakeError(error::ExitWithFailureError, "");
 	}
 
+	loop.Post([]() {
+		log::Info(
+			"The authentication daemon is now ready to accept incoming authentication request");
+	});
+
 	loop.Run();
 
 	return error::NoError;

--- a/src/mender-update/cli/actions.cpp
+++ b/src/mender-update/cli/actions.cpp
@@ -249,6 +249,11 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 	if (err != error::NoError) {
 		return err;
 	}
+
+	event_loop.Post([]() {
+		log::Info("The update client daemon is now ready to handle incoming deployments");
+	});
+
 	return state_machine.Run();
 }
 


### PR DESCRIPTION
While it can be useful for users, this is primarily to make it easier to test for readiness in tests.
