### PR TITLE
chore: Fix inability to capture log output.

### DIFF
--- a/src/artifact/lexer.hpp
+++ b/src/artifact/lexer.hpp
@@ -52,8 +52,12 @@ public:
 	Token &Next() {
 		auto entry = tar_reader_->Next();
 		if (!entry) {
-			log::Trace("Error reading the next tar entry: " + entry.error().message);
-			this->current = Token {Type::EOFToken};
+			if (entry.error().code == tar::MakeError(tar::TarEOFError, "").code) {
+				this->current = Token {Type::EOFToken};
+			} else {
+				log::Error("Error reading the next tar entry: " + entry.error().String());
+				this->current = Token {Type::Unrecognized};
+			}
 			return this->current;
 		}
 		log::Trace("Entry name: " + entry.value().Name());

--- a/src/artifact/parser.cpp
+++ b/src/artifact/parser.cpp
@@ -114,7 +114,7 @@ ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig config) {
 	if (!expected_manifest) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
-			"Failed to parse the manifest: " + expected_manifest.error().message));
+			"Failed to parse the manifest: " + expected_manifest.error().String()));
 	}
 	auto manifest = expected_manifest.value();
 

--- a/src/artifact/parser.cpp
+++ b/src/artifact/parser.cpp
@@ -56,26 +56,25 @@ ExpectedArtifact VerifyEmptyPayloadArtifact(
 	}
 	// TODO - When augmented sections are added - check for these also
 	log::Trace("Empty payload Artifact: Verifying empty payload");
-	auto tok = lexer.Next();
-	if (tok.type == token::Type::Payload) {
+	auto expected_payload = artifact.Next();
+	if (expected_payload) {
 		// If a payload is present, verify that it is empty
-		auto expected_payload = artifact.Next();
-		if (!expected_payload) {
-			auto err = expected_payload.error();
-			if (err.code.value() != parser_error::Code::NoMorePayloadFilesError) {
-				return expected::unexpected(parser_error::MakeError(
-					parser_error::Code::ParseError,
-					"This should never happen, we have a payload token / programmer error"));
-			}
-			return artifact;
-		}
 		auto payload = expected_payload.value();
 		auto expected_payload_file = payload.Next();
 		if (expected_payload_file) {
 			return expected::unexpected(parser_error::MakeError(
 				parser_error::Code::ParseError, "Empty Payload Artifacts cannot have a payload"));
-		}
-	}
+		} else if (
+			expected_payload_file.error().code
+			!= parser_error::MakeError(parser_error::Code::NoMorePayloadFilesError, "").code) {
+			return expected::unexpected(
+				expected_payload.error().WithContext("While verifying empty payload"));
+		} // else fall through
+	} else if (
+		expected_payload.error().code != parser_error::MakeError(parser_error::EOFError, "").code) {
+		return expected::unexpected(
+			expected_payload.error().WithContext("While verifying empty payload"));
+	} // else fall through
 	return artifact;
 }
 
@@ -186,24 +185,34 @@ ExpectedArtifact Parse(io::Reader &reader, config::ParserConfig config) {
 		return artifact;
 	}
 
-	log::Trace("Parsing the payload");
-	tok = lexer.Next();
+	return artifact;
+};
+
+
+ExpectedPayload Artifact::Next() {
+	token::Token tok = lexer_.Next();
+	if (payload_index_ != 0) {
+		// Currently only one payload supported
+		switch (tok.type) {
+		case token::Type::EOFToken:
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::EOFError, "Reached the end of the Artifact"));
+		case token::Type::Payload:
+			return expected::unexpected(error::Error(
+				make_error_condition(errc::not_supported), "Only one artifact payload supported"));
+		default:
+			return expected::unexpected(parser_error::MakeError(
+				parser_error::Code::ParseError, "Unexpected token: " + tok.TypeToString()));
+		}
+	}
+
 	if (tok.type != token::Type::Payload) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Got unexpected token " + tok.TypeToString() + " expected 'data/0000.tar"));
 	}
 
-	return artifact;
-};
-
-
-ExpectedPayload Artifact::Next() {
-	// Currently only one payload supported
-	if (payload_index_ != 0) {
-		return expected::unexpected(parser_error::MakeError(
-			parser_error::Code::EOFError, "Reached the end of the Artifact"));
-	}
+	log::Trace("Parsing the payload");
 	payload_index_++;
 	return payload::Payload(*(this->lexer_.current.value), manifest);
 }

--- a/src/artifact/parser_test.cpp
+++ b/src/artifact/parser_test.cpp
@@ -161,7 +161,7 @@ TEST(ParserTest, TestParseMumboJumbo) {
 	auto artifact = mender::artifact::parser::Parse(sr);
 
 	ASSERT_FALSE(artifact) << artifact.error().message << std::endl;
-	ASSERT_EQ(artifact.error().message, "Got unexpected token : 'EOF' expected 'version'");
+	ASSERT_EQ(artifact.error().message, "Got unexpected token : 'Unrecognized' expected 'version'");
 }
 
 TEST_F(ParserTestEnv, TestParseMultipleFilesInPayload) {

--- a/src/artifact/tar/CMakeLists.txt
+++ b/src/artifact/tar/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(common_tar PUBLIC
   common_io
 )
 target_sources(common_tar PRIVATE
+  tar_errors.cpp
   platform/libarchive/tar.cpp
   platform/libarchive/wrapper.cpp
 )

--- a/src/artifact/tar/platform/libarchive/tar.cpp
+++ b/src/artifact/tar/platform/libarchive/tar.cpp
@@ -66,6 +66,10 @@ ExpectedEntry Reader::Next() {
 
 	int r = archive_read_next_header(archive_handle_.Get(), &current_entry);
 	if (r == ARCHIVE_EOF) {
+		auto err = archive_handle_.EnsureEOF();
+		if (err != error::NoError) {
+			return expected::unexpected(err.WithContext("Reached the end of the archive"));
+		}
 		return expected::unexpected(MakeError(TarEOFError, "Reached the end of the archive"));
 	}
 	if (r != ARCHIVE_OK) {

--- a/src/artifact/tar/platform/libarchive/tar.cpp
+++ b/src/artifact/tar/platform/libarchive/tar.cpp
@@ -32,36 +32,6 @@ namespace log = mender::common::log;
 namespace expected = mender::common::expected;
 namespace error = mender::common::error;
 
-using Error = error::Error;
-using ExpectedSize = expected::ExpectedSize;
-
-const ErrorCategoryClass ErrorCategory {};
-
-const char *ErrorCategoryClass::name() const noexcept {
-	return "TarErrorCategory";
-}
-
-string ErrorCategoryClass::message(int code) const {
-	switch (code) {
-	case NoError:
-		return "Success";
-	case TarReaderError:
-		return "Error reading the tar stream";
-	case TarShortReadError:
-		return "Short read error";
-	case TarEntryError:
-		return "Error reading the tar entry";
-	case TarEOFError:
-		return "Archive EOF reached";
-	}
-	assert(false);
-	return "Unknown";
-}
-
-Error MakeError(ErrorCode code, const string &msg) {
-	return error::Error(error_condition(code, ErrorCategory), msg);
-}
-
 ExpectedSize Entry::Read(vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) {
 	ExpectedSize read_bytes = reader_.Read(start, end);
 

--- a/src/artifact/tar/platform/libarchive/wrapper.cpp
+++ b/src/artifact/tar/platform/libarchive/wrapper.cpp
@@ -18,6 +18,8 @@
 
 #include <common/log.hpp>
 
+#include <artifact/tar/tar_errors.hpp>
+
 namespace mender {
 namespace libarchive {
 namespace wrapper {

--- a/src/artifact/tar/platform/libarchive/wrapper.hpp
+++ b/src/artifact/tar/platform/libarchive/wrapper.hpp
@@ -64,6 +64,8 @@ private:
 	 further read from */
 	ReaderContainer reader_container_;
 
+	vector<uint8_t> small_buf_;
+
 public:
 	Handle(io::Reader &reader);
 
@@ -79,6 +81,8 @@ public:
 
 	expected::ExpectedSize Read(
 		vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) override;
+
+	error::Error EnsureEOF();
 };
 
 } // namespace wrapper

--- a/src/artifact/tar/tar.hpp
+++ b/src/artifact/tar/tar.hpp
@@ -24,6 +24,8 @@
 #include <common/expected.hpp>
 #include <common/error.hpp>
 
+#include <artifact/tar/tar_errors.hpp>
+
 #ifdef MENDER_TAR_LIBARCHIVE
 #include <libarchive/wrapper.hpp>
 #endif
@@ -39,24 +41,6 @@ namespace io = mender::common::io;
 
 using Error = error::Error;
 using ExpectedSize = expected::ExpectedSize;
-
-enum ErrorCode {
-	NoError = 0,
-	TarReaderError,
-	TarShortReadError,
-	TarEntryError,
-	TarEOFError,
-};
-
-class ErrorCategoryClass : public std::error_category {
-public:
-	const char *name() const noexcept override;
-	string message(int code) const override;
-};
-
-extern const ErrorCategoryClass ErrorCategory;
-
-Error MakeError(ErrorCode code, const string &msg);
 
 class Entry : public io::Reader {
 private:

--- a/src/artifact/tar/tar_errors.cpp
+++ b/src/artifact/tar/tar_errors.cpp
@@ -37,6 +37,8 @@ string ErrorCategoryClass::message(int code) const {
 		return "Error reading the tar entry";
 	case TarEOFError:
 		return "Archive EOF reached";
+	case TarExtraDataError:
+		return "Superfluous data at the end of the archive";
 	}
 	assert(false);
 	return "Unknown";

--- a/src/artifact/tar/tar_errors.cpp
+++ b/src/artifact/tar/tar_errors.cpp
@@ -1,0 +1,50 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <artifact/tar/tar_errors.hpp>
+
+#include <cassert>
+
+namespace mender {
+namespace tar {
+
+const ErrorCategoryClass ErrorCategory {};
+
+const char *ErrorCategoryClass::name() const noexcept {
+	return "TarErrorCategory";
+}
+
+string ErrorCategoryClass::message(int code) const {
+	switch (code) {
+	case NoError:
+		return "Success";
+	case TarReaderError:
+		return "Error reading the tar stream";
+	case TarShortReadError:
+		return "Short read error";
+	case TarEntryError:
+		return "Error reading the tar entry";
+	case TarEOFError:
+		return "Archive EOF reached";
+	}
+	assert(false);
+	return "Unknown";
+}
+
+Error MakeError(ErrorCode code, const string &msg) {
+	return error::Error(error_condition(code, ErrorCategory), msg);
+}
+
+} // namespace tar
+} // namespace mender

--- a/src/artifact/tar/tar_errors.hpp
+++ b/src/artifact/tar/tar_errors.hpp
@@ -32,6 +32,7 @@ enum ErrorCode {
 	TarShortReadError,
 	TarEntryError,
 	TarEOFError,
+	TarExtraDataError,
 };
 
 class ErrorCategoryClass : public std::error_category {

--- a/src/artifact/tar/tar_errors.hpp
+++ b/src/artifact/tar/tar_errors.hpp
@@ -1,0 +1,49 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_TAR_ERRORS_HPP
+#define MENDER_COMMON_TAR_ERRORS_HPP
+
+#include <common/error.hpp>
+
+namespace mender {
+namespace tar {
+
+using namespace std;
+
+namespace error = mender::common::error;
+
+using Error = error::Error;
+
+enum ErrorCode {
+	NoError = 0,
+	TarReaderError,
+	TarShortReadError,
+	TarEntryError,
+	TarEOFError,
+};
+
+class ErrorCategoryClass : public std::error_category {
+public:
+	const char *name() const noexcept override;
+	string message(int code) const override;
+};
+
+extern const ErrorCategoryClass ErrorCategory;
+
+Error MakeError(ErrorCode code, const string &msg);
+} // namespace tar
+} // namespace mender
+
+#endif // MENDER_COMMON_TAR_ERRORS_HPP

--- a/src/artifact/v3/version/version_test.cpp
+++ b/src/artifact/v3/version/version_test.cpp
@@ -25,7 +25,7 @@ using namespace std;
 using namespace mender;
 
 
-TEST(ParserTest, TestParseVersion) {
+TEST(VersionTest, TestParseVersion) {
 	std::string json_data = R"(
   {
     "version": 3,
@@ -47,7 +47,7 @@ TEST(ParserTest, TestParseVersion) {
 	EXPECT_EQ(version_unwrapped.format, "mender");
 }
 
-TEST(ParserTest, TestParseWrongVersion) {
+TEST(VersionTest, TestParseWrongVersion) {
 	// We don't support version 2
 	std::string json_data = R"(
   {
@@ -70,7 +70,7 @@ TEST(ParserTest, TestParseWrongVersion) {
 }
 
 
-TEST(ParserTest, TestParseWrongFormat) {
+TEST(VersionTest, TestParseWrongFormat) {
 	// We don't support other formats than mender atm
 	std::string json_data = R"(
   {
@@ -93,7 +93,7 @@ TEST(ParserTest, TestParseWrongFormat) {
 	EXPECT_EQ(version.error().message, expected_error_message);
 }
 
-TEST(ParserTest, TestParseMumboJumbo) {
+TEST(VersionTest, TestParseMumboJumbo) {
 	std::string json_data = R"(
 foobarbaz
 )";
@@ -112,7 +112,7 @@ foobarbaz
 }
 
 
-TEST(ParserTest, TestParseMalformedInput) {
+TEST(VersionTest, TestParseMalformedInput) {
 	// Missing ending {
 	std::string json_data = R"(
   {

--- a/src/common/log/platform/boost/boost_log.cpp
+++ b/src/common/log/platform/boost/boost_log.cpp
@@ -125,7 +125,7 @@ static void SetupLoggerSinks() {
 
 	{
 		text_sink::locked_backend_ptr pBackend = sink->locked_backend();
-		boost::shared_ptr<std::ostream> pStream(&std::clog, boost::null_deleter());
+		boost::shared_ptr<std::ostream> pStream(&std::cerr, boost::null_deleter());
 		pBackend->add_stream(pStream);
 	}
 

--- a/src/mender-update/cli/cli_test.cpp
+++ b/src/mender-update/cli/cli_test.cpp
@@ -41,6 +41,23 @@ namespace processes = mender::common::processes;
 
 using namespace std;
 
+bool VerifyOnlyMessages(const string &output, const vector<string> &messages) {
+	auto lines = common::SplitString(output, "\n");
+	for (const auto &line : lines) {
+		if (line == "") {
+			continue;
+		}
+
+		EXPECT_TRUE(any_of(
+			messages.begin(),
+			messages.end(),
+			[&line](const string &msg) { return line.find(msg) != string::npos; }))
+			<< line << " is an unexpected message";
+	}
+
+	return !testing::Test::HasFailure();
+}
+
 TEST(CliTest, NoAction) {
 	mtesting::TemporaryDirectory tmpdir;
 
@@ -238,8 +255,11 @@ TEST(CliTest, ShowProvidesErrors) {
 void SetTestDir(const string &dir, context::MenderContext &ctx) {
 	ctx.GetConfig().paths.SetModulesPath(dir);
 	ctx.GetConfig().paths.SetModulesWorkPath(dir);
-	ctx.GetConfig().paths.SetArtScriptsPath(dir);
-	ctx.GetConfig().paths.SetRootfsScriptsPath(dir);
+
+	string scripts_dir = path::Join(dir, "scripts");
+	ASSERT_EQ(path::CreateDirectories(scripts_dir), error::NoError);
+	ctx.GetConfig().paths.SetArtScriptsPath(scripts_dir);
+	ctx.GetConfig().paths.SetRootfsScriptsPath(scripts_dir);
 }
 
 bool PrepareSimpleArtifact(
@@ -709,7 +729,9 @@ exit 0
 		EXPECT_EQ(output.GetCout(), R"(Installing artifact...
 Installation failed. Rolled back modifications.
 )");
-		EXPECT_EQ(output.GetCerr(), "");
+		EXPECT_TRUE(VerifyOnlyMessages(
+			output.GetCerr(),
+			{"Installation failed: Process returned non-zero exit status: ArtifactInstall: Process exited with status 1"}));
 	}
 
 	EXPECT_TRUE(mtesting::FileContainsExactly(
@@ -961,7 +983,7 @@ TEST(CliTest, CommitNoExistingUpdate) {
 
 		EXPECT_EQ(output.GetCout(), R"(No update in progress.
 )");
-		EXPECT_EQ(output.GetCerr(), "");
+		EXPECT_TRUE(VerifyOnlyMessages(output.GetCerr(), {"No update in progress: Cannot commit"}));
 	}
 
 	EXPECT_TRUE(VerifyProvides(tmpdir.Path(), R"(rootfs-image.version=previous
@@ -1367,7 +1389,8 @@ artifact_name=test_INCONSISTENT
 
 		EXPECT_EQ(output.GetCout(), R"(No update in progress.
 )");
-		EXPECT_EQ(output.GetCerr(), "");
+		EXPECT_TRUE(
+			VerifyOnlyMessages(output.GetCerr(), {"No update in progress: Cannot roll back"}));
 	}
 }
 
@@ -2294,7 +2317,8 @@ INSTANTIATE_TEST_SUITE_P(
 		return test_case.param.case_name;
 	});
 
-void CreateArtifactScript(const string &dir, const pair<string, int> &script) {
+void CreateArtifactScript(
+	const string &dir, const string &log_dir, const pair<string, int> &script) {
 	const string name {script.first};
 	const int exit_code {script.second};
 	const string script_name {path::Join(dir, name)};
@@ -2302,7 +2326,7 @@ void CreateArtifactScript(const string &dir, const pair<string, int> &script) {
 	ASSERT_TRUE(of);
 	of << "#! /bin/sh" << endl;
 	of << "echo " << name << endl;
-	of << "echo " << name << " >> " << dir << "/call.log" << endl;
+	of << "echo " << name << " >> " << log_dir << "/call.log" << endl;
 	of << "exit " << exit_code << endl;
 	EXPECT_EQ(chmod(script_name.c_str(), 0755), 0);
 }
@@ -2312,7 +2336,7 @@ TEST_P(StandaloneStateScriptTest, AllScriptSuccess) {
 	tmpdir.CreateSubDirectory("scripts");
 	const string script_tmpdir {path::Join(tmpdir.Path(), "scripts")};
 	for (const auto &script : GetParam().scripts) {
-		CreateArtifactScript(tmpdir_path, script);
+		CreateArtifactScript(script_tmpdir, tmpdir_path, script);
 	}
 	string artifact = path::Join(tmpdir_path, "artifact.mender");
 	ASSERT_TRUE(PrepareSimpleArtifact(tmpdir_path, artifact));

--- a/src/mender-update/cli/cli_test.cpp
+++ b/src/mender-update/cli/cli_test.cpp
@@ -2346,7 +2346,6 @@ exit 0
 			artifact,
 		};
 
-		mtesting::RedirectStreamOutputs output;
 		int exit_status = cli::Main(
 			args, [tmpdir_path](context::MenderContext &ctx) { SetTestDir(tmpdir_path, ctx); });
 		EXPECT_EQ(exit_status, GetParam().expected_exit_code) << exit_status;
@@ -2360,7 +2359,6 @@ exit 0
 				"rollback",
 			};
 
-			mtesting::RedirectStreamOutputs output;
 			int exit_status = cli::Main(
 				args, [tmpdir_path](context::MenderContext &ctx) { SetTestDir(tmpdir_path, ctx); });
 			EXPECT_EQ(exit_status, 0) << exit_status;

--- a/src/mender-update/http_resumer.hpp
+++ b/src/mender-update/http_resumer.hpp
@@ -83,6 +83,8 @@ private:
 
 	shared_ptr<bool> cancelled_;
 
+	bool eof_ {false};
+
 	log::Logger logger_;
 
 	weak_ptr<DownloadResumerClient> resumer_client_;


### PR DESCRIPTION
The `clog` stream has some peculiar properties, and can't be captured properly, neither using stdout nor stderr. We don't really need it, so just switch to `cout` instead.
