### PR TITLE
MEN-6671: Emit D-Bus signal both on authentication and unauthentication

### DIFF
--- a/src/mender-auth/ipc/server.cpp
+++ b/src/mender-auth/ipc/server.cpp
@@ -92,15 +92,16 @@ void AuthenticatingForwarder::FetchJwtTokenHandler(auth_client::APIResponse &res
 		}
 
 		log::Info("Successfully received new authorization data");
-		dbus_server_.EmitSignal<dbus::StringPair>(
-			"/io/mender/AuthenticationManager",
-			"io.mender.Authentication1",
-			"JwtTokenStateChange",
-			dbus::StringPair {cached_jwt_token_, cached_server_url_});
 	} else {
 		ClearCache();
 		log::Error("Failed to fetch new token: " + resp.error().String());
 	}
+	// Emit signal either with valid token and server url or with empty strings
+	dbus_server_.EmitSignal<dbus::StringPair>(
+		"/io/mender/AuthenticationManager",
+		"io.mender.Authentication1",
+		"JwtTokenStateChange",
+		dbus::StringPair {cached_jwt_token_, cached_server_url_});
 }
 
 } // namespace ipc


### PR DESCRIPTION
The old client behaved this way and it seems like `mender-monitor` relies on this behavior to detect being online or offline. Other 3rd party software could also be relying on it.

This fixes the related integration tests.