### PR TITLE
chore: Get rid of direct comparisons with `Error::code`.

### DIFF
--- a/src/artifact/parser_test.cpp
+++ b/src/artifact/parser_test.cpp
@@ -207,7 +207,8 @@ TEST_F(ParserTestEnv, TestParseMultipleFilesInPayload) {
 	expected_payload_file = payload.Next();
 	ASSERT_FALSE(expected_payload_file);
 	EXPECT_EQ(
-		expected_payload_file.error().code.value(), parser_error::Code::NoMorePayloadFilesError);
+		expected_payload_file.error().code,
+		parser_error::MakeError(parser_error::Code::NoMorePayloadFilesError, "").code);
 }
 
 TEST_F(ParserTestEnv, TestParseEmptyPayloadArtifact) {
@@ -234,7 +235,7 @@ TEST_F(ParserTestEnv, TestParseEmptyPayloadArtifact) {
 
 	auto p = artifact.Next();
 	EXPECT_FALSE(p);
-	EXPECT_EQ(p.error().code.value(), parser_error::Code::EOFError);
+	EXPECT_EQ(p.error().code, parser_error::MakeError(parser_error::Code::EOFError, "").code);
 
 	//  TODO -  data do not contain augmented artifacts nor their headers.
 }

--- a/src/artifact/v3/header/header_info.cpp
+++ b/src/artifact/v3/header/header_info.cpp
@@ -129,7 +129,8 @@ ExpectedHeaderInfo Parse(io::Reader &reader) {
 	// provides:artifact_group (optional)
 	log::Trace("Parsing the header-info provides:artifact_group (if any)");
 	auto artifact_group = provides.value().Get("artifact_group").and_then(json::ToString);
-	if (!artifact_group && artifact_group.error().code.value() != json::KeyError) {
+	if (!artifact_group
+		&& artifact_group.error().code != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the header-info artifact_group provides JSON: "
@@ -163,7 +164,8 @@ ExpectedHeaderInfo Parse(io::Reader &reader) {
 	// depends::artifact_name (optional)
 	auto artifact_name_depends =
 		depends.value().Get("artifact_name").and_then(json::ToStringVector);
-	if (!artifact_name_depends && artifact_name_depends.error().code.value() != json::KeyError) {
+	if (!artifact_name_depends
+		&& artifact_name_depends.error().code != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the header-info artifact_name depends JSON: "
@@ -176,7 +178,8 @@ ExpectedHeaderInfo Parse(io::Reader &reader) {
 	// depends::artifact_group (optional)
 	auto artifact_group_depends =
 		depends.value().Get("artifact_group").and_then(json::ToStringVector);
-	if (!artifact_group_depends && artifact_group_depends.error().code.value() != json::KeyError) {
+	if (!artifact_group_depends
+		&& artifact_group_depends.error().code != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the header-info artifact_group_depends JSON: "

--- a/src/artifact/v3/header/type_info.cpp
+++ b/src/artifact/v3/header/type_info.cpp
@@ -91,7 +91,7 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	auto expected_artifact_provides =
 		type_info_json.Get("artifact_provides").and_then(json::ToKeyValueMap);
 	if (!expected_artifact_provides
-		&& expected_artifact_provides.error().code.value() != json::KeyError) {
+		&& expected_artifact_provides.error().code != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the type-info artifact_provides JSON: "
@@ -112,7 +112,7 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	auto expected_artifact_depends =
 		type_info_json.Get("artifact_depends").and_then(json::ToKeyValueMap);
 	if (!expected_artifact_depends
-		&& expected_artifact_depends.error().code.value() != json::KeyError) {
+		&& expected_artifact_depends.error().code != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the type-info artifact_depends JSON: "
@@ -132,7 +132,8 @@ ExpectedTypeInfo Parse(io::Reader &reader) {
 	auto expected_clears_artifact_provides =
 		type_info_json.Get("clears_artifact_provides").and_then(json::ToStringVector);
 	if (!expected_clears_artifact_provides
-		&& expected_clears_artifact_provides.error().code.value() != json::KeyError) {
+		&& expected_clears_artifact_provides.error().code
+			   != json::MakeError(json::KeyError, "").code) {
 		return expected::unexpected(parser_error::MakeError(
 			parser_error::Code::ParseError,
 			"Failed to parse the type-info clears_artifact_depends JSON: "

--- a/src/artifact/v3/payload/payload.cpp
+++ b/src/artifact/v3/payload/payload.cpp
@@ -35,7 +35,8 @@ ExpectedSize Reader::Read(vector<uint8_t>::iterator start, vector<uint8_t>::iter
 ExpectedPayloadReader Payload::Next() {
 	auto expected_tar_entry = tar_reader_->Next();
 	if (!expected_tar_entry) {
-		if (expected_tar_entry.error().code.value() == tar::ErrorCode::TarEOFError) {
+		if (expected_tar_entry.error().code
+			== tar::MakeError(tar::ErrorCode::TarEOFError, "").code) {
 			return expected::unexpected(parser_error::MakeError(
 				parser_error::Code::NoMorePayloadFilesError, expected_tar_entry.error().message));
 		}


### PR DESCRIPTION
Such comparisons are dangerous, because if you don't also compare the category, you can get false positives.
