### PR TITLE
chore: Make sure bootstrap artifact is installed before returning info.

### DIFF
--- a/src/mender-update/cli/actions.cpp
+++ b/src/mender-update/cli/actions.cpp
@@ -76,7 +76,10 @@ static error::Error DoMaybeInstallBootstrapArtifact(context::MenderContext &main
 	}
 	log::Info("Installing the bootstrap Artifact");
 	auto result = standalone::Install(
-		main_context, bootstrap_artifact_path, artifact::config::Signature::Skip);
+		main_context,
+		bootstrap_artifact_path,
+		artifact::config::Signature::Skip,
+		standalone::InstallOptions::NoStdout);
 
 	if (result.err != error::NoError) {
 		error::Error err =
@@ -103,6 +106,11 @@ error::Error MaybeInstallBootstrapArtifact(context::MenderContext &main_context)
 }
 
 error::Error ShowArtifactAction::Execute(context::MenderContext &main_context) {
+	error::Error err = MaybeInstallBootstrapArtifact(main_context);
+	if (err != error::NoError) {
+		return err;
+	}
+
 	auto exp_provides = main_context.LoadProvides();
 	if (!exp_provides) {
 		return exp_provides.error();
@@ -110,7 +118,7 @@ error::Error ShowArtifactAction::Execute(context::MenderContext &main_context) {
 
 	auto &provides = exp_provides.value();
 	if (provides.count("artifact_name") == 0 || provides["artifact_name"] == "") {
-		cout << "Unknown" << endl;
+		cout << "unknown" << endl;
 	} else {
 		cout << provides["artifact_name"] << endl;
 	}
@@ -118,6 +126,11 @@ error::Error ShowArtifactAction::Execute(context::MenderContext &main_context) {
 }
 
 error::Error ShowProvidesAction::Execute(context::MenderContext &main_context) {
+	error::Error err = MaybeInstallBootstrapArtifact(main_context);
+	if (err != error::NoError) {
+		return err;
+	}
+
 	auto exp_provides = main_context.LoadProvides();
 	if (!exp_provides) {
 		return exp_provides.error();

--- a/src/mender-update/cli/cli_test.cpp
+++ b/src/mender-update/cli/cli_test.cpp
@@ -92,7 +92,7 @@ TEST(CliTest, ShowArtifact) {
 		mtesting::RedirectStreamOutputs redirect_output;
 		vector<string> args {"--data", tmpdir.Path(), "show-artifact"};
 		EXPECT_EQ(cli::Main(args), 0);
-		EXPECT_EQ(redirect_output.GetCout(), "Unknown\n");
+		EXPECT_EQ(redirect_output.GetCout(), "unknown\n");
 	}
 
 	auto &db = context.GetMenderStoreDB();
@@ -147,7 +147,8 @@ TEST(CliTest, ShowProvides) {
 		mtesting::RedirectStreamOutputs redirect_output;
 		vector<string> args {"--data", tmpdir.Path(), "show-provides"};
 		EXPECT_EQ(cli::Main(args), 0);
-		EXPECT_EQ(redirect_output.GetCout(), "");
+		EXPECT_EQ(redirect_output.GetCout(), R"(artifact_name=unknown
+)");
 	}
 
 	auto verify = [&](const string &content) {
@@ -164,7 +165,8 @@ TEST(CliTest, ShowProvides) {
 
 	{
 		SCOPED_TRACE("Line number");
-		verify("");
+		verify(R"(artifact_name=unknown
+)");
 	}
 
 	{
@@ -203,7 +205,7 @@ TEST(CliTest, ShowProvides) {
 		data = "my-group";
 		err = db.Write(context.artifact_group_key, vector<uint8_t>(data.begin(), data.end()));
 		ASSERT_EQ(err, error::NoError) << err.String();
-		verify("artifact_group=my-group\n");
+		verify("artifact_group=my-group\nartifact_name=unknown\n");
 	}
 
 	{
@@ -213,7 +215,7 @@ TEST(CliTest, ShowProvides) {
 		data = "my-group";
 		err = db.Write(context.artifact_group_key, vector<uint8_t>(data.begin(), data.end()));
 		ASSERT_EQ(err, error::NoError) << err.String();
-		verify("rootfs-image.checksum=abc\nartifact_group=my-group\n");
+		verify("rootfs-image.checksum=abc\nartifact_group=my-group\nartifact_name=unknown\n");
 	}
 
 	{
@@ -223,7 +225,7 @@ TEST(CliTest, ShowProvides) {
 		data = "not-this-one";
 		err = db.Write(context.artifact_group_key, vector<uint8_t>(data.begin(), data.end()));
 		ASSERT_EQ(err, error::NoError) << err.String();
-		verify("rootfs-image.checksum=abc\nartifact_group=this-one\n");
+		verify("rootfs-image.checksum=abc\nartifact_group=this-one\nartifact_name=unknown\n");
 	}
 }
 

--- a/src/mender-update/standalone.hpp
+++ b/src/mender-update/standalone.hpp
@@ -96,6 +96,11 @@ struct ResultAndError {
 	error::Error err;
 };
 
+enum class InstallOptions {
+	None,
+	NoStdout,
+};
+
 // Return true if there is standalone data (indicating that an update is in progress), false if not.
 // Note: StateData is expected to be empty. IOW it will not clear fields that happen to be
 // empty in the database.
@@ -109,7 +114,8 @@ error::Error RemoveStateData(database::KeyValueDatabase &db);
 ResultAndError Install(
 	context::MenderContext &main_context,
 	const string &src,
-	artifact::config::Signature verify_signature = artifact::config::Signature::Verify);
+	artifact::config::Signature verify_signature = artifact::config::Signature::Verify,
+	InstallOptions options = InstallOptions::None);
 ResultAndError Commit(context::MenderContext &main_context);
 ResultAndError Rollback(context::MenderContext &main_context);
 
@@ -127,7 +133,10 @@ ResultAndError DoRollback(
 	StateData &data,
 	update_module::UpdateModule &update_module);
 
-ResultAndError DoEmptyPayloadArtifact(context::MenderContext &main_context, StateData &data);
+ResultAndError DoEmptyPayloadArtifact(
+	context::MenderContext &main_context,
+	StateData &data,
+	InstallOptions options = InstallOptions::None);
 
 ResultAndError InstallationFailureHandler(
 	context::MenderContext &main_context,


### PR DESCRIPTION
In a fresh provisioning situation, we need to do so or the info will be empty.

We introduce a new options struct to be able to reuse the existing installation code without printing information, since the bootstrap artifact is a implementation detail and the user might be confused otherwise. Error logs are still printed, so no real info should be lost.
