### PR TITLE
docs: correct rendering on the synchronized updates deprecation

### DIFF
--- a/Documentation/io.mender.Update1.xml
+++ b/Documentation/io.mender.Update1.xml
@@ -6,7 +6,7 @@
     io.mender.Update1:
     @short_description: Mender Update Management API v1
 
-    !! This feature will be removed in Mender client 4.0. For server-side support duration, please refer to our [blog post](https://mender.io/blog/mender-3-6-auto-generation-of-delta-updates#:~:text=Deprecation%3A%20Synchronized%20updates).
+    !! This feature will be removed in Mender client 4.0. For server-side support duration, please refer to our blog post - https://mender.io/blog/mender-3-6-auto-generation-of-delta-updates - section Deprecation: Synchronized updates
 
     This interface lets applications interact with the update flow. It is exposed at
 


### PR DESCRIPTION
Ticket: MEN-6648
Title: None


[First version](https://github.com/mendersoftware/mender/pull/1493) rendered incorrectly (didn't respect the link syntax).
This one uses a more basic format for the message.

![Screenshot from 2023-11-17 11-41-21](https://github.com/mendersoftware/mender/assets/1640260/d69f30bd-8613-4562-8056-5fdfcd1988a8)
