### PR TITLE
MEN-6671: Close TCP socket when HTTP request/response is completed

### DIFF
--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -17,6 +17,7 @@
 #include <common/conf.hpp>
 #include <common/events_io.hpp>
 #include <common/log.hpp>
+#include <common/path.hpp>
 
 #include <mender-update/daemon/context.hpp>
 #include <mender-update/inventory.hpp>
@@ -29,6 +30,7 @@ namespace conf = mender::common::conf;
 namespace error = mender::common::error;
 namespace events = mender::common::events;
 namespace kv_db = mender::common::key_value_database;
+namespace path = mender::common::path;
 namespace log = mender::common::log;
 
 namespace main_context = mender::update::context;


### PR DESCRIPTION
By  calling `DoCancel()` before calling the user handler in all cases
except with a successful 101 Switching Protocols response.

As the user handler will use the `response_`, remove the reset of if
(and of the `request_`) from the `DoCancel()`. This has no side effects
as these classes have noop as destructors and the objects will anyway
later be set to the new request/response in subsequent calls.