### PR TITLE
MEN-6858: Remove mender-client systemd service (alias) completely

### DIFF
--- a/support/mender-authd.service
+++ b/support/mender-authd.service
@@ -13,4 +13,3 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
-Alias=mender-client.service


### PR DESCRIPTION
After further discussion, we decided not have this alias and instead adjust every other dependency to the new systemd service name.

Ticket: MEN-6858
Changelog: systemd service `mender-client` does not exist anymore. Dependencies shall depend either `mender-authd` or `mender-updated`.

This reverts commit a807f996468da5911b1cf3e81ddbd8f31f4a1980.