### PR TITLE
chore: Fix missing deployment logs in certain cases.

### DIFF
--- a/src/mender-update/deployments/platform/boost_log/deployments.cpp
+++ b/src/mender-update/deployments/platform/boost_log/deployments.cpp
@@ -81,10 +81,14 @@ error::Error DeploymentLog::PrepareLogDirectory() {
 
 error::Error DeploymentLog::DoPrepareLogDirectory() {
 	fs::path dir_path(data_store_dir_);
-	bool created = fs::create_directories(dir_path);
-	if (created) {
-		// should basically never happen, but if we happened to create the
-		// directory, it's empty and thus well-prepared
+
+	// `create_directories` may fail on some platforms with an error if the destination exists
+	// as a symlink, even if the target is a valid directory. So let's check for existence
+	// first.
+	if (not fs::exists(dir_path)) {
+		// should rarely happen, but if we happened to create the directory, it's empty and
+		// thus well-prepared
+		fs::create_directories(dir_path);
 		return error::NoError;
 	}
 


### PR DESCRIPTION
I haven't been able to reproduce this in our CI, only locally, so it's possible that the behavior has changed between libc versions. Checking for existence should be safe in either case though.

Our integration tests check for the submission of deployment logs for failed deployments already.

Ticket: MEN-6867
