### PR TITLE
fix: Make partition checking more robust in every state.

### DIFF
--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -921,6 +921,10 @@ void StateLoopState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) 
 }
 
 void EndOfDeploymentState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) {
+	log::Info(
+		"Deployment with ID " + ctx.deployment.state_data->update_info.id
+		+ " finished with status: " + string(ctx.deployment.failed ? "Failure" : "Success"));
+
 	ctx.FinishDeploymentLogging();
 
 	ctx.deployment = {};

--- a/support/modules/rootfs-image
+++ b/support/modules/rootfs-image
@@ -107,7 +107,7 @@ EOF
     return 0
 }
 
-device_matches_root() {
+check_device_matches_root() {
     case "$1" in
         /dev/ubi*)
             # UBI is a bit peculiar. Trying to take the device number of the root device does not
@@ -120,6 +120,7 @@ device_matches_root() {
             if [ "$1" = "$ROOT_DEVICE" ]; then
                 return 0
             else
+                echo "Mounted root ($ROOT_DEVICE) does not match boot loader environment ($1)!" 1>&2
                 return 1
             fi
             ;;
@@ -128,35 +129,17 @@ device_matches_root() {
             if [ "$(stat -L -c %02t%02T "$1")" = "$(stat -L -c %04D /)" ]; then
                 return 0
             else
+                echo "Mounted root does not match boot loader environment ($1)!" 1>&2
                 return 1
             fi
             ;;
     esac
 }
 
-ensure_correct_root_mounted() {
-    if device_matches_root "$active"; then
-        return 0
-    fi
-
-    # If an upgrade is in progress then it can be on either partition, except in the Download
-    # and ArtifactInstall states (not rebooted yet).
-    if [ "$upgrade_available" = 1 ] && \
-            [ "$STATE" != "Download" ] && \
-            [ "$STATE" != "ArtifactInstall" ] && \
-            device_matches_root "$passive"; then
-        return 0
-    fi
-
-    echo "Mounted root does not match boot loader environment!" 1>&2
-    exit 1
-}
-
 check_requirements() {
     parse_conf_file
     check_environment_canary
     set_upgrade_vars
-    ensure_correct_root_mounted
 }
 
 case "$STATE" in
@@ -171,6 +154,13 @@ case "$STATE" in
 
     DownloadWithFileSizes)
         check_requirements
+
+        if [ "$upgrade_available" != 0 ]; then
+            echo "Unexpected \`upgrade_available=$upgrade_available\` in $STATE." 1>&2
+            exit 1
+        fi
+        check_device_matches_root "$active"
+
         line="$(cat stream-next)"
         file="$(echo $line | cut -d' ' -f1)"
         size="$(echo $line | cut -d' ' -f2)"
@@ -193,6 +183,13 @@ case "$STATE" in
 
     ArtifactInstall)
         check_requirements
+
+        if [ "$upgrade_available" != 0 ]; then
+            echo "Unexpected \`upgrade_available=$upgrade_available\` in $STATE." 1>&2
+            exit 1
+        fi
+        check_device_matches_root "$active"
+
         ${SETENV} -s - <<EOF
 mender_boot_part=$passive_num
 mender_boot_part_hex=$passive_num_hex
@@ -214,6 +211,7 @@ EOF
         if test "$upgrade_available" != 1; then
             exit 1
         fi
+        check_device_matches_root "$active"
         ;;
 
     ArtifactVerifyRollbackReboot)
@@ -221,24 +219,33 @@ EOF
         if test "$upgrade_available" = 1; then
             exit 1
         fi
+        check_device_matches_root "$active"
         ;;
 
     ArtifactCommit)
         check_requirements
-        if test "$upgrade_available" = 1; then
-            ${SETENV} upgrade_available 0
-        else
+
+        if [ "$upgrade_available" != 1 ]; then
+            echo "Unexpected \`upgrade_available=$upgrade_available\` in $STATE." 1>&2
+
             # If we get here, an upgrade in standalone mode failed to boot and the user is trying to commit from the old OS.
             # This communicates to the user that the upgrade failed.
             echo "Upgrade failed and was reverted: refusing to commit!" 1>&2
             exit 1
         fi
+        check_device_matches_root "$active"
+
+        ${SETENV} upgrade_available 0
         ;;
 
     ArtifactRollback)
         # If we cannot parse the config file, exit anyway and let the bootloader handle the rollback
         parse_conf_file || exit 0
         check_requirements
+
+        # We do not use `check_device_matches_root` here, since we can be on either partition at
+        # this point.
+
         if test "$upgrade_available" = 1; then
             ${SETENV} -s - <<EOF
 mender_boot_part=$passive_num


### PR DESCRIPTION
```
commit fde5b0469a7f2bd2c81638c1ded553d0bd233512
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Tue Nov 28 12:45:02 2023

    chore: Add a message when deployment has finished.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit ab31b5626362b91ee3bbc0eaf8f81caad5d56f61
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Tue Nov 28 09:40:04 2023

    fix: Make partition checking more robust in every state.
    
    In particular, this prevents the client from erronously committing a
    rootfs-image update if it's paused in the ArtifactReboot state, and
    then restarted through `systemctl restart` instead of through a
    reboot. Now it checks that the root partition is what we expect.
    
    This has been a bug in the Golang client too, so we want a changelog
    entry for this.
    
    Changelog: The client no longer erronously commits a rootfs-image
    artifact after being restarted using `systemctl restart` in the
    `ArtifactReboot` state.
    
    Ticket: MEN-6633
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```