### PR TITLE
feat: Add a termination signal handler the mender-auth

### DIFF
--- a/src/mender-auth/cli/actions.cpp
+++ b/src/mender-auth/cli/actions.cpp
@@ -143,6 +143,17 @@ error::Error DaemonAction::Execute(context::MenderContext &main_context) {
 
 	events::EventLoop loop {};
 
+	events::SignalHandler signal_handler {loop};
+
+	err = signal_handler.RegisterHandler(
+		{SIGTERM, SIGINT, SIGQUIT}, [&loop](events::SignalNumber signum) {
+			log::Info("Termination signal received, shutting down gracefully");
+			loop.Stop();
+		});
+	if (err != error::NoError) {
+		return err;
+	}
+
 	ipc::Server ipc_server {loop, config};
 
 	err = ipc_server.Listen(


### PR DESCRIPTION
This adds a signal handler for SIG{TERM,INT,QUIT} to mender-auth, so that the
daemon exits gracefully in these circumstances by stopping the event loop.

Ticket: MEN-6733
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>