### PR TITLE
MEN-6836: Do not call the user's callback when returning an error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,14 @@
 execute_process(
-  COMMAND sh -c "git describe --tags --dirty --exact-match || git rev-parse --short HEAD"
+  COMMAND sh -c "git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE MENDER_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
+  ERROR_VARIABLE GIT_CMD_ERROR
 )
+if(NOT "${GIT_CMD_ERROR}" STREQUAL "")
+  message(FATAL_ERROR "Git command failed:\n" ${GIT_CMD_ERROR})
+endif()
+
 configure_file(mender-version.h.in mender-version.h)
 
 # Default for all components.

--- a/src/api/auth/auth.cpp
+++ b/src/api/auth/auth.cpp
@@ -392,7 +392,6 @@ error::Error Authenticator::WithToken(AuthenticatedAction action) {
 		if (err != error::NoError) {
 			// Should never fail. We rely on the signal heavily so let's fail
 			// hard if it does.
-			action(expected::unexpected(err));
 			return err;
 		}
 	}
@@ -440,7 +439,6 @@ error::Error Authenticator::WithToken(AuthenticatedAction action) {
 		// No token and failed to try to get one (should never happen).
 		ExpectedAuthData ex_auth_data = expected::unexpected(err);
 		PostPendingActions(ex_auth_data);
-		action(ex_auth_data);
 		return err;
 	}
 	// else record that token is already being fetched (by GetJwtToken()).

--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -10,7 +10,7 @@ COPY ./ .
 
 RUN mkdir /tmp/build
 RUN cmake -S /cpp/src/github.com/mendersoftware/mender -B /tmp/build
-RUN cmake --build /tmp/build
+RUN cmake --build /tmp/build --parallel $(nproc --all)
 RUN DESTDIR=/mender-install cmake --install /tmp/build --prefix /usr
 
 RUN mkdir -p /mender-install/etc/mender/


### PR DESCRIPTION
The design is that the entry level function `WithToken` should either
return error synchronously or eventually call the handler
asynchronously.

This fixes the issue where `mender-update` will abort with an unhandled
event. What was happening before is that an error while connecting to
the bus would post two events and later the state machine will handle
the second one from the `Idle` state.