### PR TITLE
fix: Amend D-Bus interface files path

### DIFF
--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -5,7 +5,7 @@ set(DBUS_INTERFACE_FILES
 )
 
 install(FILES ${DBUS_INTERFACE_FILES}
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/interface
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/interfaces
   COMPONENT dbus-interface-files
 )
 add_custom_target(install-dbus-interface-files


### PR DESCRIPTION
It should be `interfaces` according to:
* https://dbus.freedesktop.org/doc/dbus-api-design.html