### PR TITLE
chore(context): Log provides/depends mismatches at error level

### DIFF
--- a/src/mender-update/context/context.cpp
+++ b/src/mender-update/context/context.cpp
@@ -404,7 +404,7 @@ expected::ExpectedBool ArtifactMatchesContext(
 	const auto &hdr_depends = hdr_info.depends;
 	AssertOrReturnUnexpected(hdr_depends.device_type.size() > 0);
 	if (!common::VectorContainsString(hdr_depends.device_type, device_type)) {
-		log::Debug("Artifact device type doesn't match");
+		log::Error("Artifact device type doesn't match");
 		return false;
 	}
 
@@ -412,7 +412,7 @@ expected::ExpectedBool ArtifactMatchesContext(
 		AssertOrReturnUnexpected(hdr_depends.artifact_name->size() > 0);
 		if (!common::VectorContainsString(
 				*hdr_depends.artifact_name, provides.at("artifact_name"))) {
-			log::Debug("Artifact name doesn't match");
+			log::Error("Artifact name doesn't match");
 			return false;
 		}
 	}
@@ -420,13 +420,13 @@ expected::ExpectedBool ArtifactMatchesContext(
 	if (hdr_depends.artifact_group) {
 		AssertOrReturnUnexpected(hdr_depends.artifact_group->size() > 0);
 		if (!common::MapContainsStringKey(provides, "artifact_group")) {
-			log::Debug(
+			log::Error(
 				"Missing artifact_group value in provides, required by artifact header info depends");
 			return false;
 		}
 		if (!common::VectorContainsString(
 				*hdr_depends.artifact_group, provides.at("artifact_group"))) {
-			log::Debug("Artifact group doesn't match");
+			log::Error("Artifact group doesn't match");
 			return false;
 		}
 	}
@@ -438,12 +438,12 @@ expected::ExpectedBool ArtifactMatchesContext(
 	}
 	for (auto it : *ti_depends) {
 		if (!common::MapContainsStringKey(provides, it.first)) {
-			log::Debug(
+			log::Error(
 				"Missing '" + it.first + "' in provides, required by artifact type info depends");
 			return false;
 		}
 		if (provides.at(it.first) != it.second) {
-			log::Debug(
+			log::Error(
 				"'" + it.first + "' artifact type info depends value '" + it.second
 				+ "' doesn't match provides value '" + provides.at(it.first) + "'");
 			return false;

--- a/tests/src/mender-update/cli/cli_test.cpp
+++ b/tests/src/mender-update/cli/cli_test.cpp
@@ -557,7 +557,10 @@ artifact_name=test
 		EXPECT_EQ(output.GetCout(), R"(Installing artifact...
 Installation failed. System not modified.
 )");
-		EXPECT_EQ(output.GetCerr(), "");
+		EXPECT_THAT(
+			output.GetCerr(),
+			testing::HasSubstr(
+				"'rootfs-image.checksum' artifact type info depends value 'notyourcorrectchecksum' doesn't match provides value 'f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'"));
 	}
 }
 


### PR DESCRIPTION
Just make sure that they show up in the logs, as the mismatch can be pretty confusing otherwise.

