### PR TITLE
fix: add mender-setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,6 @@ steps above:
   "ServerCertificate": "/etc/mender/server.crt"
 ```
 
-Keep in mind that `/etc/mender/mender.conf` will be overwritten if you rerun the
-`sudo make install` command.
-
 **Important:** `demo.crt` is not a secure certificate and should only be used for demo purposes,
 never in production.
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,11 @@ cd build
 Configure and start the build:
 
 ```
-cmake ..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
 make
 ```
+Make sure you configure installation to the `/usr` path prefix, as the executables required by systemd units and
+D-Bus policy file must be placed in the canonical paths.
 
 Install the client:
 ```

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ Install the client:
 sudo make install
 ```
 
+### Client setup
+
+The required configuration files for client operation can be created in several ways.
+
+- for an interactive setup process, use the [`mender-setup`](https://github.com/mendersoftware/mender-setup) tool.
+- in a Yocto-based set up, those are generated as part of the build process
+
 ### Installation notes
 
 Installing this way does not offer a complete system updater.  For this, you need additional


### PR DESCRIPTION
With the mender-setup tool being factored out, somebody who just follows the instructions in the README has no way to obtain a working configuration.
Hence, add a reference to the repository and mention that other configuration flows exist.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
