### PR TITLE
build: Modify syntax for compatibility with CMake 3.18

### DIFF
--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -9,9 +9,9 @@ install(FILES ${DBUS_INTERFACE_FILES}
   COMPONENT dbus-interface-files
 )
 add_custom_target(install-dbus-interface-files
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=dbus-interface-files
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component dbus-interface-files
 )
 add_custom_target(uninstall-dbus-interface-files
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=dbus-interface-files -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component dbus-interface-files -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -11,7 +11,7 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANIFEST}")
   # here, just using a few more CPU cycles and adding some empty directories.
   if(CMAKE_INSTALL_COMPONENT)
     execute_process(
-      COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=${CMAKE_INSTALL_COMPONENT}
+      COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component ${CMAKE_INSTALL_COMPONENT}
       OUTPUT_VARIABLE install_output
       ERROR_VARIABLE install_output
     )

--- a/src/mender-auth/CMakeLists.txt
+++ b/src/mender-auth/CMakeLists.txt
@@ -7,10 +7,10 @@ install(TARGETS mender-auth
   COMPONENT mender-auth
 )
 add_custom_target(install-mender-auth
-  COMMAND ${CMAKE_COMMAND} --install . --component=mender-auth
+  COMMAND ${CMAKE_COMMAND} --install . --component mender-auth
 )
 add_custom_target(uninstall-mender-auth
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=mender-auth -P ${MENDER_BINARY_SRC_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component mender-auth -P ${MENDER_BINARY_SRC_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${MENDER_BINARY_SRC_DIR}
 )
 add_subdirectory(ipc)

--- a/src/mender-update/CMakeLists.txt
+++ b/src/mender-update/CMakeLists.txt
@@ -117,10 +117,10 @@ install(TARGETS mender-update
 )
 
 add_custom_target(install-mender-update
-  COMMAND ${CMAKE_COMMAND} --install . --component=mender-update
+  COMMAND ${CMAKE_COMMAND} --install . --component mender-update
 )
 add_custom_target(uninstall-mender-update
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=mender-update -P ${MENDER_BINARY_SRC_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component mender-update -P ${MENDER_BINARY_SRC_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${MENDER_BINARY_SRC_DIR}
 )
 

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -45,10 +45,10 @@ install(PROGRAMS ${INVENTORYSCRIPTS}
   COMPONENT inventory-scripts
 )
 add_custom_target(install-inventory-scripts
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=inventory-scripts
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component inventory-scripts
 )
 add_custom_target(uninstall-inventory-scripts
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=inventory-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component inventory-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -59,10 +59,10 @@ install(PROGRAMS ${INVENTORY_NETWORKSCRIPTS}
   EXCLUDE_FROM_ALL
 )
 add_custom_target(install-inventory-network-scripts
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=inventory-network-scripts
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component inventory-network-scripts
 )
 add_custom_target(uninstall-inventory-network-scripts
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=inventory-network-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component inventory-network-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -71,10 +71,10 @@ install(PROGRAMS ${IDENTITYSCRIPTS}
   COMPONENT identity-scripts
 )
 add_custom_target(install-identity-scripts
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=identity-scripts
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component identity-scripts
 )
 add_custom_target(uninstall-identity-scripts
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=identity-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component identity-scripts -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -83,10 +83,10 @@ install(FILES ${DBUS_POLICY_FILES}
   COMPONENT dbus-policy-files
 )
 add_custom_target(install-dbus-policy-files
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=dbus-policy-files
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component dbus-policy-files
 )
 add_custom_target(uninstall-dbus-policy-files
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=dbus-policy-files -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component dbus-policy-files -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -95,10 +95,10 @@ install(PROGRAMS ${MODULES}
   COMPONENT modules
 )
 add_custom_target(install-modules
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=modules
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component modules
 )
 add_custom_target(uninstall-modules
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=modules -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component modules -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -109,10 +109,10 @@ install(PROGRAMS ${MODULES_ARTIFACT_GENERATORS}
   EXCLUDE_FROM_ALL
 )
 add_custom_target(install-modules-gen
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=modules-gen
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component modules-gen
 )
 add_custom_target(uninstall-modules-gen
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=modules-gen -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component modules-gen -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -121,10 +121,10 @@ install(FILES ${SYSTEMD_UNITS}
   COMPONENT systemd
 )
 add_custom_target(install-systemd
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=systemd
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component systemd
 )
 add_custom_target(uninstall-systemd
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=systemd -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component systemd -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -134,10 +134,10 @@ install(FILES ${DOCS_EXAMPLES}
   COMPONENT examples
 )
 add_custom_target(install-examples
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=examples
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component examples
 )
 add_custom_target(uninstall-examples
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=examples -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component examples -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
@@ -146,9 +146,9 @@ install(PROGRAMS ${ROOTFS_IMAGE}
   COMPONENT rootfs-image-module
 )
 add_custom_target(install-rootfs-image-module
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component=rootfs-image-module
+  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component rootfs-image-module
 )
 add_custom_target(uninstall-rootfs-image-module
-  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_COMPONENT=rootfs-image-module -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+  COMMAND ${CMAKE_COMMAND} -D CMAKE_INSTALL_component rootfs-image-module -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
Older CMake versions do not support `--component=...` syntax, so use an space instead.