### PR TITLE
Revert "build: Set MinSizeRel as the default build type"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,6 @@ cmake_minimum_required(VERSION 3.15)
 
 project(mender)
 
-# Set the default build type to MinSizeRel. We care more about size than speed.
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING
-    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
-    FORCE)
-endif()
-
 add_subdirectory(support)
 add_subdirectory(Documentation)
 


### PR DESCRIPTION
It's redundant, since it already exists in 84c13e9fe.

This reverts commit 0b923f656ea8621678b43f849ac71daba32737f3.
