### PR TITLE
fix: Swap order of daemon state machines.

### DIFF
--- a/src/mender-update/daemon/state_machine/state_machine.cpp
+++ b/src/mender-update/daemon/state_machine/state_machine.cpp
@@ -60,8 +60,8 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 		ctx_.mender_context.GetConfig().paths.GetArtScriptsPath(),
 		ctx_.mender_context.GetConfig().paths.GetRootfsScriptsPath()),
 	runner_(ctx) {
-	runner_.AddStateMachine(main_states_);
 	runner_.AddStateMachine(deployment_tracking_.states_);
+	runner_.AddStateMachine(main_states_);
 
 	runner_.AttachToEventLoop(event_loop_);
 

--- a/tests/src/mender-update/daemon/state_test.cpp
+++ b/tests/src/mender-update/daemon/state_test.cpp
@@ -2388,7 +2388,7 @@ vector<StateTransitionsTestCase> GenerateStateTransitionsTestCases() {
 					"installing",
 					"failure",
 				},
-			.install_outcome = InstallOutcome::SuccessfulRollback,
+			.install_outcome = InstallOutcome::UnsuccessfulInstall,
 			.error_states = {"ArtifactInstall", "ArtifactFailure_Leave_00"},
 		},
 


### PR DESCRIPTION
This came about because the main state machine inspects the `ctx.deployment.rollback_failed` variable, which is set in the `deployment_tracking` state machine. We always want the setting to happen first, and in one corner case this did not happen if there were no intervening states between the inspection and the previous state.

Illustrating with an example. In most cases it would work because:

```
main_state.OLD_STATE
deployment_tracking.OLD_STATE
  |
  v
main_state.INTERMEDIARY_STATE
deployment_tracking.NEW_STATE.<set rollback_failed flag>
  |
  v
main_state.NEW_STATE.<inspect rollback_failed flag>
```

But in the simplest of transitions, it would break, like this:

```
main_state.OLD_STATE
deployment_tracking.OLD_STATE
  |
  v
main_state.NEW_STATE.<inspect rollback_failed flag>
deployment_tracking.NEW_STATE.<set rollback_failed flag>
```

where one can see the flag is set too late. `ArtifactFailure_Leave` is one place where it happens. By reversing the order of the state machines, this does not happen anymore, and this should always be the correct action, since the `deployment_tracking` never checks any external variables.

Changelog: Artifact name is now properly marked as "INCONSISTENT" if there is an error in the `ArtifactFailure_Leave` script during an installation.

Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 20f85f05d57b3fa41200cafa79656a0da16f577d)
