### PR TITLE
chore: Make sure the event loop is kicked even without a starting event.

### DIFF
--- a/src/common/state_machine.hpp
+++ b/src/common/state_machine.hpp
@@ -143,6 +143,8 @@ public:
 		// We don't actually own the object, we are just keeping a pointer to it. Use null
 		// deleter.
 		event_loop_.reset(&event_loop, [](events::EventLoop *loop) {});
+
+		PostToEventLoop();
 	}
 
 	void DetachFromEventLoop() {


### PR DESCRIPTION
Otherwise the first state will not be entered unless there is an event to trigger it.
