### PR TITLE
fix: doing so return 1 in Download_Enter state scripts aborts instead of retrying in an endless loop

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -731,6 +731,16 @@ func (uf *updateFetchState) Update() *datastore.UpdateInfo {
 	return &uf.update
 }
 
+func (uf *updateFetchState) HandleError(
+	ctx *StateContext,
+	c Controller,
+	err menderError,
+) (State, bool) {
+	log.Error(err.Error())
+
+	return NewUpdateErrorState(err, uf.Update()), false
+}
+
 func (uf *updateFetchState) PermitLooping() bool {
 	return false
 }

--- a/app/state_test.go
+++ b/app/state_test.go
@@ -1331,6 +1331,32 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 	},
 
 	{
+		caseName: "Error in Download state, with rollback",
+		stateChain: []State{
+			&updateFetchState{},
+			&updateStoreState{},
+			&updateCleanupState{},
+			&updateStatusReportState{},
+			&idleState{},
+		},
+		artifactStateChain: []string{
+			"Download_Enter_00",
+			"Download",
+			"Download_Error_00",
+			"Cleanup",
+		},
+		reportsLog: []string{
+			"downloading",
+			"failure",
+		},
+		TestModuleAttr: tests.TestModuleAttr{
+			ErrorStates:      []string{"Download"},
+			RollbackDisabled: false,
+		},
+		installOutcome: tests.SuccessfulRollback,
+	},
+
+	{
 		caseName: "Killed in Download state, no rollback",
 		stateChain: []State{
 			&updateFetchState{},
@@ -2583,14 +2609,16 @@ var stateTransitionsWithUpdateModulesTestCases []stateTransitionsWithUpdateModul
 		caseName: "Error in Download_Enter_00 state, no rollback",
 		stateChain: []State{
 			&updateFetchState{},
-			&errorState{},
+			&updateErrorState{},
+			&updateCleanupState{},
+			&updateStatusReportState{},
 			&idleState{},
 		},
 		artifactStateChain: []string{
 			"Download_Enter_00",
 			"Download_Error_00",
 		},
-		reportsLog: []string{""},
+		reportsLog: []string{"failure"},
 		TestModuleAttr: tests.TestModuleAttr{
 			ErrorStates:      []string{"Download_Enter_00"},
 			RollbackDisabled: true,


### PR DESCRIPTION
changelog: title
ticket: MEN-6319
