### PR TITLE
fix: Submit inventory as soon as the device is accepted.

### DIFF
--- a/src/mender-update/daemon/context.hpp
+++ b/src/mender-update/daemon/context.hpp
@@ -169,6 +169,8 @@ public:
 	shared_ptr<deployments::DeploymentAPI> deployment_client;
 	shared_ptr<inventory::InventoryAPI> inventory_client;
 
+	bool has_submitted_inventory {false};
+
 	struct {
 		unique_ptr<StateData> state_data;
 		io::ReaderPtr artifact_reader;


### PR DESCRIPTION
Note that this fix only works "once". IOW if you reject a device and then re-admit it later, then it won't submit inventory again, but will follow the regular schedule.

Changelog: Title
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit ed4696e3d80908754ba7c8d430de8d2e7fb38a1f)
