### PR TITLE
fix: Ensure enough body writer capacity if no Content-Length sent by deployments API

### DIFF
--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -293,6 +293,7 @@ error::Error DeploymentClient::PushStatus(
 				log::Debug(
 					"Failed to get content length from the status API response headers: "
 					+ content_length.error().String());
+				body_writer->SetUnlimited(true);
 			} else {
 				auto ex_len = common::StringToLongLong(content_length.value());
 				if (!ex_len) {
@@ -457,6 +458,7 @@ error::Error DeploymentClient::PushLogs(
 				log::Debug(
 					"Failed to get content length from the status API response headers: "
 					+ content_length.error().String());
+				body_writer->SetUnlimited(true);
 			} else {
 				auto ex_len = common::StringToLongLong(content_length.value());
 				if (!ex_len) {


### PR DESCRIPTION
Discovered in review of a copy-pasted version of this code into mendersoftware/mender-update-orchestrator#30.

Ticket: none
Changelog: none
