### PR TITLE
chore: Add Key Value Parser for single-value maps.

### DIFF
--- a/src/common/key_value_parser.hpp
+++ b/src/common/key_value_parser.hpp
@@ -45,8 +45,14 @@ extern const KeyValueParserErrorCategoryClass KeyValueParserErrorCategory;
 
 error::Error MakeError(KeyValueParserErrorCode code, const string &msg);
 
+using KeyValueMap = unordered_map<string, string>;
+using ExpectedKeyValueMap = expected::expected<KeyValueMap, error::Error>;
 using KeyValuesMap = unordered_map<string, vector<string>>;
 using ExpectedKeyValuesMap = expected::expected<KeyValuesMap, error::Error>;
+
+ExpectedKeyValueMap ParseKeyValueMap(const vector<string> &items, char delimiter = '=');
+error::Error AddParseKeyValueMap(
+	KeyValueMap &base, const vector<string> &items, char delimiter = '=');
 
 ExpectedKeyValuesMap ParseKeyValues(const vector<string> &items, char delimiter = '=');
 error::Error AddParseKeyValues(

--- a/src/common/key_value_parser/key_value_parser.cpp
+++ b/src/common/key_value_parser/key_value_parser.cpp
@@ -49,6 +49,37 @@ error::Error MakeError(KeyValueParserErrorCode code, const string &msg) {
 	return error::Error(error_condition(code, KeyValueParserErrorCategory), msg);
 }
 
+ExpectedKeyValueMap ParseKeyValueMap(const vector<string> &items, char delimiter) {
+	KeyValueMap ret;
+	error::Error err = AddParseKeyValueMap(ret, items, delimiter);
+	if (error::NoError != err) {
+		return expected::unexpected(err);
+	} else {
+		return ret;
+	}
+}
+
+error::Error AddParseKeyValueMap(KeyValueMap &base, const vector<string> &items, char delimiter) {
+	for (auto str : items) {
+		auto delim_pos = str.find(delimiter);
+		if (delim_pos == string::npos) {
+			return MakeError(
+				KeyValueParserErrorCode::InvalidDataError, "Invalid data given: '" + str + "'");
+		}
+
+		string key = str.substr(0, delim_pos);
+		string value = str.substr(delim_pos + 1, str.size() - delim_pos - 1);
+		if (base.count(key) != 0) {
+			return MakeError(
+				KeyValueParserErrorCode::InvalidDataError, "Key listed more than once: " + key);
+		} else {
+			base[key] = {std::move(value)};
+		}
+	}
+
+	return error::NoError;
+}
+
 ExpectedKeyValuesMap ParseKeyValues(const vector<string> &items, char delimiter) {
 	KeyValuesMap ret;
 	error::Error err = AddParseKeyValues(ret, items, delimiter);

--- a/tests/src/common/key_value_parser_test.cpp
+++ b/tests/src/common/key_value_parser_test.cpp
@@ -28,6 +28,40 @@ using namespace std;
 TEST(KeyValueParserTests, ValidDistinctItems) {
 	vector<string> items = {"key1=value1", "key2=value2", "key3=value3", "key4="};
 
+	kvp::ExpectedKeyValueMap ret = kvp::ParseKeyValueMap(items);
+	ASSERT_TRUE(ret);
+
+	kvp::KeyValueMap ret_map = ret.value();
+	EXPECT_EQ(ret_map.size(), 4);
+	EXPECT_EQ(ret_map["key1"], "value1");
+	EXPECT_EQ(ret_map["key2"], "value2");
+	EXPECT_EQ(ret_map["key3"], "value3");
+	EXPECT_EQ(ret_map["key4"], "");
+
+	items = {"key1~value1", "key2~value2", "key3~value3", "key4~"};
+
+	ret = kvp::ParseKeyValueMap(items, '~');
+	ASSERT_TRUE(ret);
+
+	ret_map = ret.value();
+	EXPECT_EQ(ret_map.size(), 4);
+	EXPECT_EQ(ret_map["key1"], "value1");
+	EXPECT_EQ(ret_map["key2"], "value2");
+	EXPECT_EQ(ret_map["key3"], "value3");
+	EXPECT_EQ(ret_map["key4"], "");
+}
+
+TEST(KeyValueParserTests, InvalidMultiItems) {
+	vector<string> items = {"key1=value1", "key2=value2", "key3=value3", "key1=value11"};
+
+	kvp::ExpectedKeyValueMap ret = kvp::ParseKeyValueMap(items);
+	ASSERT_FALSE(ret);
+	EXPECT_EQ(ret.error().code, kvp::MakeError(kvp::InvalidDataError, "").code);
+}
+
+TEST(KeyValuesParserTests, ValidDistinctItems) {
+	vector<string> items = {"key1=value1", "key2=value2", "key3=value3", "key4="};
+
 	kvp::ExpectedKeyValuesMap ret = kvp::ParseKeyValues(items);
 	ASSERT_TRUE(ret);
 
@@ -61,7 +95,7 @@ TEST(KeyValueParserTests, ValidDistinctItems) {
 	EXPECT_EQ(ret_map["key4"], vector<string> {""});
 }
 
-TEST(KeyValueParserTests, ValidMultiItems) {
+TEST(KeyValuesParserTests, ValidMultiItems) {
 	vector<string> items = {
 		"key1=value1",
 		"key2=value2",
@@ -84,7 +118,7 @@ TEST(KeyValueParserTests, ValidMultiItems) {
 	EXPECT_EQ(ret_map["key3"], (vector<string> {"value3", "value31"}));
 }
 
-TEST(KeyValueParserTests, ValidMultiAddItems) {
+TEST(KeyValuesParserTests, ValidMultiAddItems) {
 	vector<string> items = {
 		"key1=value1",
 		"key2=value2",
@@ -114,7 +148,7 @@ TEST(KeyValueParserTests, ValidMultiAddItems) {
 	EXPECT_EQ(ret_map["key4"], (vector<string> {"value4"}));
 }
 
-TEST(KeyValueParserTests, InvalidItem) {
+TEST(KeyValuesParserTests, InvalidItem) {
 	vector<string> items = {"key1=value1", "key2=value2", "key3value3"};
 
 	kvp::ExpectedKeyValuesMap ret = kvp::ParseKeyValues(items);


### PR DESCRIPTION
The MultiValued maps are distinguished by the plural "Values" name.
