### PR TITLE
fix: so the Download_error state script gets executed for failures due to signature

### DIFF
--- a/app/state.go
+++ b/app/state.go
@@ -808,7 +808,8 @@ func (u *updateStoreState) Handle(ctx *StateContext, c Controller) (State, bool)
 	installer, err := c.ReadArtifactHeaders(u.imagein)
 	if err != nil {
 		log.Errorf("Fetching Artifact headers failed: %s", err)
-		return NewUpdateStatusReportState(&u.update, client.StatusFailure), false
+
+		return NewUpdateCleanupState(&u.update, client.StatusFailure), false
 	}
 
 	installers := c.GetInstallers()


### PR DESCRIPTION
changelog: title
ticket: MEN-6402

Changed the code so when encountering failures due to signature it goes into the update-error state, which will allow it to run Download_Error.