### PR TITLE
chore: updating CLI help screen

### DIFF
--- a/src/client_shared/conf.hpp
+++ b/src/client_shared/conf.hpp
@@ -23,6 +23,7 @@
 #include <client_shared/config_parser.hpp>
 #include <common/http.hpp>
 #include <common/path.hpp>
+#include <common/optional.hpp>
 
 namespace mender {
 namespace client_shared {
@@ -234,6 +235,11 @@ public:
 	}
 };
 
+struct CliArgument {
+	string name;
+	bool mandatory;
+};
+
 struct CliOption {
 	string long_option;
 	string short_option;
@@ -245,6 +251,7 @@ struct CliOption {
 struct CliCommand {
 	string name;
 	string description;
+	optional<CliArgument> argument;
 	vector<CliOption> options;
 };
 

--- a/src/client_shared/conf/conf_cli_help.cpp
+++ b/src/client_shared/conf/conf_cli_help.cpp
@@ -147,6 +147,19 @@ void PrintInTwoColumns(
 	}
 }
 
+string PrintArgument(optional<CliArgument> argument, ostream &stream) {
+	string cliarg;
+
+	if (argument.has_value()) {
+		if (argument.value().mandatory) {
+			cliarg = " " + argument.value().name;
+		} else {
+			cliarg = " [" + argument.value().name + "]";
+		}
+	}
+	return cliarg;
+}
+
 void PrintOptions(const vector<CliOption> &options, ostream &stream) {
 	PrintInTwoColumns(
 		options.begin(),
@@ -183,6 +196,10 @@ void PrintCommandHelp(const string &cli_name, const CliCommand &command, ostream
 		stream << " - " << command.description;
 	}
 	stream << endl << endl;
+
+	stream << "USAGE:" << endl;
+	stream << indent << cli_name << " [global options] " << command.name + " [command options]";
+	stream << PrintArgument(command.argument, stream) << endl << endl;
 
 	// Append --help option at the command level
 	vector<CliOption> options_with_help = command.options;

--- a/src/mender-update/cli/cli.cpp
+++ b/src/mender-update/cli/cli.cpp
@@ -49,6 +49,11 @@ const conf::CliCommand cmd_daemon {
 const conf::CliCommand cmd_install {
 	.name = "install",
 	.description = "Mender Artifact to install - local file or a URL",
+	.argument =
+		conf::CliArgument {
+			.name = "artifact",
+			.mandatory = true,
+		},
 	.options =
 		{
 			conf::CliOption {

--- a/tests/src/client_shared/conf_test.cpp
+++ b/tests/src/client_shared/conf_test.cpp
@@ -612,6 +612,38 @@ TEST(ConfTests, CliCliHelpCommandLookup) {
 						},
 				},
 				conf::CliCommand {
+					.name = "command-arg-1",
+					.description = "command with argument",
+					.argument =
+						conf::CliArgument {
+							.name = "arg-one",
+							.mandatory = true,
+						},
+					.options =
+						{
+							conf::CliOption {
+								.long_option = "option-one",
+								.description = "description of option-one",
+							},
+						},
+				},
+				conf::CliCommand {
+					.name = "command-arg-2",
+					.description = "command with argument 2",
+					.argument =
+						conf::CliArgument {
+							.name = "arg-one",
+							.mandatory = false,
+						},
+					.options =
+						{
+							conf::CliOption {
+								.long_option = "option-one",
+								.description = "description of option-one",
+							},
+						},
+				},
+				conf::CliCommand {
 					.name = "command-one",
 					.description = "masked command - it will never show",
 					.options =
@@ -636,9 +668,11 @@ TEST(ConfTests, CliCliHelpCommandLookup) {
 		help_non_existing.str(),
 		testing::HasSubstr(
 			R"(COMMANDS:
-   command-one  command 1 description
-   command-two  command 2 description
-   command-one  masked command - it will never show)"))
+   command-one    command 1 description
+   command-two    command 2 description
+   command-arg-1  command with argument
+   command-arg-2  command with argument 2
+   command-one    masked command - it will never show)"))
 		<< help_non_existing.str();
 
 	std::ostringstream help_command_1;
@@ -646,6 +680,9 @@ TEST(ConfTests, CliCliHelpCommandLookup) {
 	EXPECT_EQ(
 		R"(NAME:
    mender-something command-one - command 1 description
+
+USAGE:
+   mender-something [global options] command-one [command options]
 
 OPTIONS:
    --option-one  description only visible on command 1 help
@@ -661,12 +698,47 @@ OPTIONS:
 		R"(NAME:
    mender-something command-two - command 2 description
 
+USAGE:
+   mender-something [global options] command-two [command options]
+
 OPTIONS:
    --option-two  description only visible on command 2 help
    --help, -h    Show help and exit
 )",
 		help_command_2.str())
 		<< help_command_2.str();
+
+	std::ostringstream help_command_3;
+	conf::PrintCliCommandHelp(cli_lookup, "command-arg-1", help_command_3);
+	EXPECT_EQ(
+		R"(NAME:
+   mender-something command-arg-1 - command with argument
+
+USAGE:
+   mender-something [global options] command-arg-1 [command options] arg-one
+
+OPTIONS:
+   --option-one  description of option-one
+   --help, -h    Show help and exit
+)",
+		help_command_3.str())
+		<< help_command_3.str();
+
+	std::ostringstream help_command_4;
+	conf::PrintCliCommandHelp(cli_lookup, "command-arg-2", help_command_4);
+	EXPECT_EQ(
+		R"(NAME:
+   mender-something command-arg-2 - command with argument 2
+
+USAGE:
+   mender-something [global options] command-arg-2 [command options] [arg-one]
+
+OPTIONS:
+   --option-one  description of option-one
+   --help, -h    Show help and exit
+)",
+		help_command_4.str())
+		<< help_command_4.str();
 }
 
 class TestEnvClearer {


### PR DESCRIPTION
Updating CLI help screen to show arguments for commands, and updating the help screen to show more options and commands

Changelog: None

Ticket: MEN-6986