### PR TITLE
chore: changed parsing of some passthrough args in generators

### DIFF
--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -161,9 +161,34 @@ else
   exit 1
 fi
 
-
 # Create dest_dir file in plain text
 echo "$dest_dir" > $dest_dir_file
+
+# Check the the passthrough_args and potentially modify them
+# to avoid conflicts or to let them override the already args
+# provided to mender-artifact
+# Runs in a subshell to allow overriding some parameters passed
+# to mender-artifact
+passthrough_args_modified=" "
+echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+  if [ -n "$flag" ] && [ -n "$arg" ]; then
+    case $flag in
+      -T | --type)
+        echo "Error: Conflicting flag '$flag'. Already specified by the script."
+        exit 1
+        ;;
+      -o | --output-path)
+        output_path=$arg
+        ;;
+      -n | --name)
+        artifact_name=$arg
+        ;;
+      *)
+        passthrough_args_modified="$passthrough_args_modified $flag $arg"
+        ;;
+    esac
+  fi
+done
 
 mender-artifact write module-image \
   -T directory \
@@ -172,12 +197,13 @@ mender-artifact write module-image \
   -n $artifact_name \
   -f $update_files_tar \
   -f $dest_dir_file \
-  $passthrough_args
+  $passthrough_args_modified
 
-rm $update_files_tar
-rm $dest_dir_file
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read $output_path
-
+# End of subshell
+)
+rm $update_files_tar
+rm $dest_dir_file
 exit 0

--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -53,7 +53,7 @@ dest_dir_file="dest_dir"
 file_tree=""
 passthrough_args=""
 
-while (( "$#" )); do
+while [ -n "$1" ]; do
   case "$1" in
     --device-type | -t)
       if [ -z "$2" ]; then
@@ -147,7 +147,7 @@ esac
 # Create tarball, accepts directory.
 if [ -e "${file_tree}" ]; then
   if [ -d "${file_tree}" ]; then
-    if [ "$dest_dir" == "/" ]; then
+    if [ "$dest_dir" = "/" ]; then
       echo "Error: this Update Module does not support file tree deployment at /"
       exit 1
     fi

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -53,7 +53,7 @@ meta_data_file="meta-data.json"
 IMAGES=""
 passthrough_args=""
 
-while (( "$#" )); do
+while [ -n "$1" ]; do
   case "$1" in
     --device-type | -t)
       if [ -z "$2" ]; then

--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -134,17 +134,44 @@ HASHES=$(echo $HASHES | tr ' ' ',')
 
 eval "jq -n --argjson c '[$HASHES]' '{\"containers\": \$c, \"run_args\": \"${run_args}\"}'" > $meta_data_file
 
+# Check the the passthrough_args and potentially modify them
+# to avoid conflicts or to let them override the already args
+# provided to mender-artifact
+# # Runs in a subshell to allow overriding some parameters passed
+# to mender-artifact
+passthrough_args_modified=" "
+echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+  if [ -n "$flag" ] && [ -n "$arg" ]; then
+    case $flag in
+      -T | --type | -m | --meta-data)
+        echo "Error: Conflicting flag '$flag'. Already specified by the script."
+        exit 1
+        ;;
+      -o | --output-path)
+        output_path=$arg
+        ;;
+      -n | --name)
+        artifact_name=$arg
+        ;;
+      *)
+        passthrough_args_modified="$passthrough_args_modified $flag $arg"
+        ;;
+    esac
+  fi
+done
+
 mender-artifact write module-image \
   -T docker \
   $device_types \
   -o $output_path \
   -n $artifact_name \
   -m $meta_data_file \
-  $passthrough_args
+  $passthrough_args_modified
 
-rm $meta_data_file
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read $output_path
-
+# End of subshell
+)
+rm $meta_data_file
 exit 0

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -178,6 +178,32 @@ else
   stat -c %a "${file}" > $permissions_file
 fi
 
+# Check the the passthrough_args and potentially modify them
+# to avoid conflicts or to let them override the already args
+# provided to mender-artifact
+# Runs in a subshell to allow overriding some parameters passed
+# to mender-artifact
+passthrough_args_modified=" "
+echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+  if [ -n "$flag" ]; then
+    case $flag in
+      -T | --type)
+        echo "Error: Conflicting flag '$flag'. Already specified by the script."
+        exit 1
+        ;;
+      -o | --output-path)
+        output_path=$arg
+        ;;
+      -n | --name)
+        artifact_name=$arg
+        ;;
+      *)
+        passthrough_args_modified="$passthrough_args_modified $flag $arg"
+        ;;
+    esac
+  fi
+done
+
 mender-artifact write module-image \
   -T single-file \
   $device_types \
@@ -187,11 +213,12 @@ mender-artifact write module-image \
   -f "$filename_file" \
   -f "$permissions_file" \
   -f "$file" \
-  $passthrough_args
+  $passthrough_args_modified
 
-rm -rf $tmpdir
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read $output_path
-
+# End of subshell
+)
+rm -rf $tmpdir
 exit 0


### PR DESCRIPTION
Changelog: Returns an error when passing type, or when passing metadata to docker-artifact gen, and overrides output path
and name when passed as passthrough argument.

Ticket: MEN-7110
