### PR TITLE
build: Remove vendored CMake projects

### DIFF
--- a/main.cmake
+++ b/main.cmake
@@ -61,10 +61,8 @@ else()
   set(MENDER_USE_TINY_PROC_LIB 0)
 endif()
 
-add_subdirectory(vendor/expected)
 include_directories(${CMAKE_SOURCE_DIR}/vendor/expected/include)
 
-add_subdirectory(vendor/optional-lite)
 include_directories(${CMAKE_SOURCE_DIR}/vendor/optional-lite/include)
 
 include(cmake/build_mode.cmake)


### PR DESCRIPTION
C++ `expected` and `optional` replacement libraries are header only and we don't need to include their CMake projects.

The motivation of removing it is to not add a requirement on more recent versions of CMake that are used in vendored projects (namely: `expected` requires CMake 3.14).

This was fixed implicitly in master when all the vendored projects were moved to a separate directory. See in the following commit that we removed the `add_subdirectory` and moved only the `include` parts:
* https://github.com/mendersoftware/mender/commit/d9946929a63dc45e5acb6a73731ab8dd4b3b8391