### PR TITLE
feat: Add `SYSTEMD_UNIT_DIR` CMake variable.

### DIFF
--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SYSTEMD_UNIT_DIR /lib/systemd/system)
+set(SYSTEMD_UNIT_DIR /lib/systemd/system CACHE STRING "Directory where systemd unit files are installed")
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Use it to customize the location of the systemd unit files. Usually it is set to `/lib/systemd/system`.

Changelog: Commit
Ticket: None
