### PR TITLE
ci: Fix coverage reporting for branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,9 +158,8 @@ publish:tests:
     # old component than two.
     - curl -f https://github.com/eddyxu/cpp-coveralls/commit/067c837c04e039e8c70aa53bceda1cded6751408.patch | patch -f /usr/local/lib/python3.11/site-packages/cpp_coveralls/__init__.py
 
-    - export CI_BRANCH=$CI_COMMIT_BRANCH
-    # "TRAVIS_JOB_ID" is hardcoded in cpp-coveralls, but it is semantically the
-    # same as "CI_JOB_ID" would be.
+    # Set "TRAVIS_*" variables based on GitLab ones
+    - export TRAVIS_BRANCH=$CI_COMMIT_BRANCH
     - export TRAVIS_JOB_ID=$CI_PIPELINE_ID
 
   script:


### PR DESCRIPTION
The code that accepts `CI_BRANCH` as a generic environment variable is actually not released upstream, and the latest pypi avilable version relies on `TRAVIS_*` type of variable.

See: https://github.com/eddyxu/cpp-coveralls/compare/v0.4.2...47f638727512126bc16b1365560854a86db70e7e#diff-b1eda260daddc41aa91c216b3b054933cc85304b6d5e3235c652f0b48c59fcf9R46

As we were missing the branch name, in the eyes of coveralls the "master" branch is frozen on golang code.