### PR TITLE
4.0.x: feat: Add `SYSTEMD_UNIT_DIR` CMake variable.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,10 +57,6 @@ test:backward-compat:
   image: debian:10
   before_script:
     - apt update && apt install -yyq g++ git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev libboost-regex-dev libssl-dev libarchive-dev libdbus-1-dev curl dbus
-    # mender-artifact install
-    - curl https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
-      -o /usr/local/bin/mender-artifact
-    - chmod +x /usr/local/bin/mender-artifact
     # backport CMake
     - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports_deps.list
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ test:backward-compat:
       Pin: release a=buster-backports
       Pin-Priority: 999
       EOF
-    - apt update & apt install -yyq --allow-unauthenticated cmake
+    - apt update && apt install -yyq --allow-unauthenticated cmake
   script:
     - cmake -D MENDER_DOWNLOAD_BOOST=ON .
     - make --jobs=$(nproc --all) --keep-going

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ test:backward-compat:
   before_script:
     - apt update && apt install -yyq g++ git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev libboost-regex-dev libssl-dev libarchive-dev libdbus-1-dev curl dbus
     # backport CMake
-    - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports_deps.list
+    - echo "deb http://archive.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports_deps.list
     - |
       cat <<EOF> /etc/apt/preferences.d/prefer_backports.pref
       Package: cmake*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,9 +158,8 @@ publish:tests:
     # old component than two.
     - curl -f https://github.com/eddyxu/cpp-coveralls/commit/067c837c04e039e8c70aa53bceda1cded6751408.patch | patch -f /usr/local/lib/python3.11/site-packages/cpp_coveralls/__init__.py
 
-    - export CI_BRANCH=$CI_COMMIT_BRANCH
-    # "TRAVIS_JOB_ID" is hardcoded in cpp-coveralls, but it is semantically the
-    # same as "CI_JOB_ID" would be.
+    # Set "TRAVIS_*" variables based on GitLab ones
+    - export TRAVIS_BRANCH=$CI_COMMIT_BRANCH
     - export TRAVIS_JOB_ID=$CI_PIPELINE_ID
 
   script:

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SYSTEMD_UNIT_DIR /lib/systemd/system)
+set(SYSTEMD_UNIT_DIR /lib/systemd/system CACHE STRING "Directory where systemd unit files are installed")
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Use it to customize the location of the systemd unit files. Usually it is set to `/lib/systemd/system`.

Changelog: Commit
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 943b8198bff3328229f0f3055989807836c9f7d6)
