### PR TITLE
fix: Invalid Range request when content_length is 0 (unknown)

### DIFF
--- a/src/common/http/http_resumer.cpp
+++ b/src/common/http/http_resumer.cpp
@@ -413,10 +413,12 @@ io::ExpectedAsyncReaderPtr DownloadResumerClient::MakeBodyAsyncReader(
 
 http::OutgoingRequestPtr DownloadResumerClient::RemainingRangeRequest() const {
 	auto range_req = make_shared<http::OutgoingRequest>(*user_request_);
-	range_req->SetHeader(
-		"Range",
-		"bytes=" + to_string(resumer_state_->offset) + "-"
-			+ to_string(resumer_state_->content_length - 1));
+	if (resumer_state_->content_length > 0) {
+		range_req->SetHeader(
+			"Range",
+			"bytes=" + to_string(resumer_state_->offset) + "-"
+				+ to_string(resumer_state_->content_length - 1));
+	}
 	return range_req;
 };
 


### PR DESCRIPTION
If an HTTP download is resumed without the client ever having learned the `content_length`, it will request the update with the following invalid header:
```
Range: bytes=0--1
```
Changelog: None
Ticket: #8880