### PR TITLE
chore: Rewrote FilterProvides to not use regex

### DIFF
--- a/src/mender-update/context.hpp
+++ b/src/mender-update/context.hpp
@@ -156,6 +156,14 @@ private:
 expected::ExpectedBool ArtifactMatchesContext(
 	const ProvidesData &provides, const string &device_type, const artifact::HeaderView &hdr_view);
 
+error::Error FilterProvides(
+	const ProvidesData &new_provides,
+	const ClearsProvidesData &clears_provides,
+	ProvidesData &to_modify);
+
+
+bool CheckClearsMatch(const string &to_match, const string &clears_string);
+
 } // namespace context
 } // namespace update
 } // namespace mender


### PR DESCRIPTION
Replaced the regex in FilterProvides by matching a substring with the whole provides-string. This is done to remove ExceptionToErrorOrAbort. Added unit tests and a testing-function to context.

Ticket MEN-7323
