### PR TITLE
fix: Make crypto load and use the openssl.cnf file

### DIFF
--- a/src/common/crypto/platform/openssl/crypto.cpp
+++ b/src/common/crypto/platform/openssl/crypto.cpp
@@ -32,6 +32,7 @@
 #endif // MENDER_CRYPTO_OPENSSL_LEGACY
 
 #include <openssl/evp.h>
+#include <openssl/conf.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
 
@@ -281,6 +282,11 @@ ExpectedPrivateKey LoadFrom(const Args &args) {
 #endif // ndef MENDER_CRYPTO_OPENSSL_LEGACY
 
 ExpectedPrivateKey PrivateKey::Load(const Args &args) {
+	// Load OpenSSL config
+	if ((CONF_modules_load_file(nullptr, nullptr, 0) != OPENSSL_SUCCESS)) {
+		log::Warning("Failed to load OpenSSL configuration file: " + GetOpenSSLErrorMessage());
+	}
+
 	log::Trace("Loading private key");
 	if (args.ssl_engine != "") {
 		return LoadFromHSMEngine(args);


### PR DESCRIPTION
Libcrypto does not load the openssl.cnf file automatically. This removes the need for manually having to export e.g. `PKCS11_MODULE_PATH` as an env var when loading a pkcs11 interface (if it's already specified in openssl.cnf).
