### PR TITLE
fix: Fix crash when Sync_Leave returns error during a deployment.

### DIFF
--- a/src/mender-update/daemon/state_machine.hpp
+++ b/src/mender-update/daemon/state_machine.hpp
@@ -48,6 +48,9 @@ public:
 
 	// Mainly for tests.
 	void StopAfterDeployment();
+#ifndef NDEBUG
+	void StopAfterDeployments(int number);
+#endif
 
 private:
 	Context &ctx_;
@@ -189,6 +192,16 @@ private:
 				rootfs_script_path,
 				script_executor::OnError::Fail),
 			sync_error_(
+				loop,
+				script_executor::State::Sync,
+				script_executor::Action::Error,
+				script_timeout,
+				retry_interval,
+				retry_timeout,
+				artifact_script_path,
+				rootfs_script_path,
+				script_executor::OnError::Ignore),
+			sync_error_download_(
 				loop,
 				script_executor::State::Sync,
 				script_executor::Action::Error,
@@ -458,6 +471,7 @@ private:
 		StateScriptState sync_leave_;
 		StateScriptState sync_leave_download_;
 		StateScriptState sync_error_;
+		StateScriptState sync_error_download_;
 
 		SaveStateScriptState download_enter_;
 		StateScriptState download_leave_;

--- a/src/mender-update/daemon/state_machine/state_machine.cpp
+++ b/src/mender-update/daemon/state_machine/state_machine.cpp
@@ -245,7 +245,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	main_states_.AddTransition(update_failure_state_,                   se::Success,                     ss.failure_leave_update_save_provides_,  tf::Immediate);
 	main_states_.AddTransition(update_failure_state_,                   se::Failure,                     ss.failure_leave_update_save_provides_,  tf::Immediate);
-  main_states_.AddTransition(update_failure_state_,                   se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
+	main_states_.AddTransition(update_failure_state_,                   se::StateLoopDetected,           state_loop_state_,                       tf::Immediate);
 
 	main_states_.AddTransition(ss.failure_leave_update_save_provides_,  se::Success,                     update_save_provides_state_,             tf::Immediate);
 	main_states_.AddTransition(ss.failure_leave_update_save_provides_,  se::Failure,                     update_save_provides_state_,             tf::Immediate);

--- a/src/mender-update/daemon/state_machine/state_machine.cpp
+++ b/src/mender-update/daemon/state_machine/state_machine.cpp
@@ -108,7 +108,10 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	main_states_.AddTransition(ss.sync_leave_,                          se::Failure,                     ss.sync_error_,                          tf::Immediate);
 
 	main_states_.AddTransition(ss.sync_leave_download_,                 se::Success,                     send_download_status_state_,             tf::Immediate);
-	main_states_.AddTransition(ss.sync_leave_download_,                 se::Failure,                     ss.sync_error_,                          tf::Immediate);
+	main_states_.AddTransition(ss.sync_leave_download_,                 se::Failure,                     ss.sync_error_download_,                 tf::Immediate);
+
+	main_states_.AddTransition(ss.sync_error_download_,                 se::Success,                     end_of_deployment_state_,                tf::Immediate);
+	main_states_.AddTransition(ss.sync_error_download_,                 se::Failure,                     end_of_deployment_state_,                tf::Immediate);
 
 	// Cannot fail due to FailureMode::Ignore.
 	main_states_.AddTransition(send_download_status_state_,             se::Success,                     ss.download_enter_,                      tf::Immediate);
@@ -453,6 +456,19 @@ void StateMachine::StopAfterDeployment() {
 		exit_state_,
 		sm::TransitionFlag::Immediate);
 }
+
+#ifndef NDEBUG
+void StateMachine::StopAfterDeployments(int number) {
+	exit_state_.ExitAfter(number);
+	main_states_.AddTransition(
+		end_of_deployment_state_, StateEvent::Success, exit_state_, sm::TransitionFlag::Immediate);
+	main_states_.AddTransition(
+		exit_state_,
+		StateEvent::Success,
+		state_scripts_.idle_enter_,
+		sm::TransitionFlag::Immediate);
+}
+#endif
 
 } // namespace daemon
 } // namespace update

--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -953,7 +953,15 @@ ExitState::ExitState(events::EventLoop &event_loop) :
 }
 
 void ExitState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) {
+#ifndef NDEBUG
+	if (--iterations_left_ <= 0) {
+		event_loop_.Stop();
+	} else {
+		poster.PostEvent(StateEvent::Success);
+	}
+#else
 	event_loop_.Stop();
+#endif
 }
 
 namespace deployment_tracking {

--- a/src/mender-update/daemon/states.hpp
+++ b/src/mender-update/daemon/states.hpp
@@ -264,8 +264,18 @@ public:
 
 	error::Error exit_error;
 
+#ifndef NDEBUG
+	void ExitAfter(int number) {
+		iterations_left_ = number;
+	}
+#endif
+
 private:
 	events::EventLoop &event_loop_;
+
+#ifndef NDEBUG
+	int iterations_left_ {1};
+#endif
 };
 
 

--- a/support/mender-updated.service
+++ b/support/mender-updated.service
@@ -11,6 +11,7 @@ Group=root
 ExecStart=/usr/bin/mender-update daemon
 Restart=always
 WatchdogSec=86400
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The problem is that once we have entered the `sync_leave_download`
internal state, a deployment has started, and a deployment always has
to be ended, to properly clean up. This is fine when
`sync_leave_download` is successful and proceeds into subsequent
download states, which always end with the
`end_of_deployment_state`. But if `sync_leave_download` fails, then it
goes directly to `sync_error`, which does not know about the
deployment, and does not go to `end_of_deployment_state`.

Fix this by creating a dedicated `sync_error_download` state.

This bug happened only occasionally in the test
`test_state_scripts[Corrupted_script_version_in_etc-test_set11]` in
the integration repository, typically under load. The reason it
happened only occasionally is that the test is programmed to fail in
`Sync_Leave` only once, and inventory submission is always run
first. So by the time it got to the deployment it was always returning
success. But under load it could happen that the inventory submission
failed, which would run `Sync_Error` instead and skip `Sync_Leave`,
leaving it around for the upcoming deployment, where the bug would
then occur.

Testing this in unit tests requires supporting more than one
deployment run, which requires an extra member in the exit state. In
the spirit of trying to limit space requirements for embedded system,
I've made this member, which is only used for tests, debug-only.

Changelog: Fix crash when `Sync_Leave` returns error during a
deployment. The error message would be:
```
State machine event DeploymentStarted was not handled by any transition
```
and would happen on the next deployment following the `Sync_Leave`
error. With a long polling interval, this could cause the bug to be
latent for quite a while.

Ticket: MEN-7379

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>