### PR TITLE
MEN-7159: Progress reader updates the output only when progressing

### DIFF
--- a/src/mender-update/progress_reader/progress_reader.cpp
+++ b/src/mender-update/progress_reader/progress_reader.cpp
@@ -28,8 +28,9 @@ expected::ExpectedSize Reader::Read(
 	if (exp_read) {
 		bytes_read_ += exp_read.value();
 		int percentage = (bytes_read_ / static_cast<float>(tot_size_)) * 100;
-		if (percentage > last_percentage) {
+		if (percentage > last_percentage_) {
 			cerr << "\r" << percentage << "%";
+			last_percentage_ = percentage;
 		}
 	}
 	return exp_read;

--- a/src/mender-update/progress_reader/progress_reader.hpp
+++ b/src/mender-update/progress_reader/progress_reader.hpp
@@ -40,7 +40,7 @@ private:
 	shared_ptr<io::Reader> reader_;
 	size_t tot_size_;
 	size_t bytes_read_ {0};
-	int last_percentage {-1};
+	int last_percentage_ {-1};
 };
 
 } // namespace progress

--- a/tests/src/mender-update/progress_reader/progress_reader_test.cpp
+++ b/tests/src/mender-update/progress_reader/progress_reader_test.cpp
@@ -63,5 +63,5 @@ TEST(ProgressReaderTests, RegularRead) {
 
 	std::string output = testing::internal::GetCapturedStderr();
 
-	EXPECT_EQ(output, "\r0%\r5%\r5%\r25%\r90%\r100%");
+	EXPECT_EQ(output, "\r0%\r5%\r25%\r90%\r100%");
 }


### PR DESCRIPTION
Due to a bug in the logic, the progress was being updated after every block, even if the percentage number was not changing. This made the reading/writing of Artifacts slow and noisy.