### PR TITLE
chore: Don't duplicate `DefaultPaths` in every source file.

### DIFF
--- a/src/client_shared/conf.hpp
+++ b/src/client_shared/conf.hpp
@@ -100,13 +100,14 @@ private:
 	ArgumentsMode mode_ {ArgumentsMode::RejectBareArguments};
 };
 
-const struct {
+struct DefaultPathsType {
 	string path_conf_dir = path::Join("/etc", "mender");
 	string conf_file = path::Join(path_conf_dir, "mender.conf");
 	string path_data_dir = path::Join("/usr/share", "mender");
 	string data_store = path::Join("/var/lib", "mender");
 	string fallback_conf_file = path::Join(data_store, "mender.conf");
-} DefaultPaths;
+};
+extern const DefaultPathsType DefaultPaths;
 
 // NOTE - When updating this class - either adding or removing variables. Be
 // sure to update the transitive dependencies also.

--- a/src/client_shared/conf/conf.cpp
+++ b/src/client_shared/conf/conf.cpp
@@ -37,6 +37,8 @@ namespace json = mender::common::json;
 
 const string kMenderVersion = MENDER_VERSION;
 
+const DefaultPathsType DefaultPaths;
+
 const ConfigErrorCategoryClass ConfigErrorCategory;
 
 const char *ConfigErrorCategoryClass::name() const noexcept {


### PR DESCRIPTION
This simple change saves more than 12K in the final binary.

For future reference, using `readelf -s` to look for duplicate symbols is a useful way to hunt for such space waste. I haven't looked deeply at it, but starting by looking in object files for duplicated `LOCAL` symbols without `WEAK` is a good beginning. I just found this one randomly though, and I cannot dive deeper into this rabbit hole now.
