### PR TITLE
fix: add optional dynamic linking to boost::log

### DIFF
--- a/src/common/cmake/boost.cmake
+++ b/src/common/cmake/boost.cmake
@@ -3,6 +3,10 @@
 find_package(Boost 1.74 COMPONENTS log)
 
 option(MENDER_DOWNLOAD_BOOST "Download Boost if it is not found (Default: OFF)" OFF)
+option(MENDER_USE_DYNAMIC_BOOST_LOG "Link dynamically to boost::log  (Default: OFF)" OFF)
+if(MENDER_USE_DYNAMIC_BOOST_LOG)
+  ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
+endif()
 
 if(NOT MENDER_DOWNLOAD_BOOST AND NOT ${Boost_FOUND})
   message(FATAL_ERROR


### PR DESCRIPTION
When building boost as a dynamic library, hundreds of `undefined reference to `boost::log` errors occur during linking. As the default behavior currently is to link against boost::log statically, it is best to add a new option that explicitly enables dynamic linking to boost::log. This new option is called MENDER_USE_DYNAMIC_BOOST_LOG.

Changelog: None
Ticket: None
