### PR TITLE
fix: Handle error during decompression

### DIFF
--- a/support/modules/directory
+++ b/support/modules/directory
@@ -26,16 +26,25 @@ case "$STATE" in
         test "$dest_dir" = "/" && \
             echo "Error: destination dir is '/', install not supported." && exit 1
         mkdir -p $dest_dir
-        if ! tar -cf ${prev_files_tar} -C ${dest_dir} .
+        
+        tar -cf ${prev_files_tar} -C ${dest_dir} .
+        createPrevSuccess=$?
+        if [ $createPrevSuccess -ne 0 ]
         then
-            ret=$?
+            echo "Fatal error: Unable to create backup"
             # Make sure there is no half-backup lying around.
             rm -f ${prev_files_tar}
-            exit $ret
+            exit $createPrevSuccess
         fi
         rm -rf ${dest_dir}
         mkdir -p ${dest_dir}
         tar -xf ${update_files_tar} -C ${dest_dir}
+        extractSuccess=$?
+        if [ $extractSuccess -ne 0 ]
+        then
+            echo "Fatal error: something went wrong during artifact installation"
+            exit $extractSuccess
+        fi
         ;;
 
     ArtifactRollback)


### PR DESCRIPTION
During the decompression and therefore installation of the directory artifact the return value is not checked.

If the decompression fails (e.g. due to size constraints) the artifact install process continues in the same way it would for an successful decompression. This can leave the system in a corrupted state with a partially installed update. 

This change fixes the issue by explicitly checking the return value of the decompression process and returning an error code in case of a failure.

Changelog: None
Ticket: None
