### PR TITLE
build: Enable some more warnings by default.

### DIFF
--- a/src/artifact/sha/sha.hpp
+++ b/src/artifact/sha/sha.hpp
@@ -70,7 +70,7 @@ public:
 	string String() const {
 		std::stringstream ss {};
 		for (unsigned int i = 0; i < 32; ++i) {
-			ss << std::hex << std::setw(2) << std::setfill('0') << (int) sha_.at(i);
+			ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(sha_.at(i));
 		}
 		return ss.str();
 	}

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -42,15 +42,24 @@ add_library(common_cpp INTERFACE)
 target_compile_options(common_cpp INTERFACE
   # Make all warnings that are on into errors.
   -Werror -Wall
+
   # Make sure we use `override` everywhere.
   -Wsuggest-override
+
   # Warn about lossy number conversions, which often arise in int64_t vs size_t scenarios.
   -Wconversion
+
   # Don't warn about sign conversion, which have an extreme amount of false positives. This is
   # mainly because sizes are unsigned, while iterator arithmetic is signed, and they are very often
   # combined, which is perfectly fine. It's possible this may hide certain real errors, but the
   # sheer amount of false positives just isn't worth it.
   -Wno-sign-conversion
+
+  # Miscellaneus.
+  -Wpacked
+  -Wpointer-arith
+  -Wredundant-decls
+  -Wold-style-cast
 )
 target_include_directories(common_cpp SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/expected/include)
 target_include_directories(common_cpp SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/optional-lite/include)

--- a/src/common/crypto/platform/openssl/crypto.cpp
+++ b/src/common/crypto/platform/openssl/crypto.cpp
@@ -174,10 +174,7 @@ ExpectedPrivateKey LoadFromHSMEngine(const Args &args) {
 
 	auto private_key = unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)>(
 		ENGINE_load_private_key(
-			engine.get(),
-			args.private_key_path.c_str(),
-			(UI_METHOD *) nullptr,
-			nullptr /*callback_data */),
+			engine.get(), args.private_key_path.c_str(), nullptr, nullptr /*callback_data */),
 		pkey_free_func);
 	if (private_key == nullptr) {
 		return expected::unexpected(MakeError(

--- a/src/common/events/events_io.cpp
+++ b/src/common/events/events_io.cpp
@@ -176,7 +176,7 @@ error::Error TeeReader::ReadyToAsyncRead(
 	if (leaf_readers_[leaf_reader].buffer_bytes_missing > 0) {
 		// Special case, reading missing bytes
 		TeeReaderLeafContext &ctx = leaf_readers_[leaf_reader];
-		auto to_read = std::min(ctx.buffer_bytes_missing, (size_t) (end - start));
+		auto to_read = std::min(ctx.buffer_bytes_missing, static_cast<size_t>(end - start));
 		auto handler_wrapper = [this, handler, &ctx](mio::ExpectedSize result) {
 			if (result) {
 				ctx.buffer_bytes_missing -= result.value();

--- a/src/common/http/http.cpp
+++ b/src/common/http/http.cpp
@@ -180,7 +180,7 @@ string URLEncode(const string &value) {
 		} else {
 			// Any other characters are percent-encoded
 			escaped << uppercase;
-			escaped << '%' << setw(2) << int((unsigned char) c);
+			escaped << '%' << setw(2) << static_cast<int>(static_cast<unsigned char>(c));
 			escaped << nouppercase;
 		}
 	}

--- a/src/common/platform/dbus/asio_libdbus/dbus.cpp
+++ b/src/common/platform/dbus/asio_libdbus/dbus.cpp
@@ -42,6 +42,15 @@ namespace log = mender::common::log;
 
 using namespace std;
 
+// DBus uses many macros with C style casts which get expanded in this file. Therefore the usual
+// method which excludes system headers from warnings doesn't work. So just disable warnings for C
+// style casts in this file.
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#else
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 // The code below integrates ASIO and libdbus. Or, more precisely, it uses
 // asio::io_context as the main/event loop for libdbus.
 //

--- a/tests/src/common/http_resumer/http_resumer_test.cpp
+++ b/tests/src/common/http_resumer/http_resumer_test.cpp
@@ -435,7 +435,7 @@ TEST_P(DownloadResumerTest, Cases) {
 
 	http::ResponseHandler user_body_handler = [&test_case,
 											   &loop](http::ExpectedIncomingResponsePtr exp_resp) {
-		EXPECT_EQ((bool) exp_resp, test_case.success);
+		EXPECT_EQ(exp_resp.has_value(), test_case.success);
 		loop.Stop();
 	};
 


### PR DESCRIPTION
This builds on #1676.

Originally we wanted to include this list:
* `-Wbad-function-cast`
* `-Wcast-qual`
* `-Wconversion`
* `-Wpacked`
* `-Wpadded`
* `-Wpointer-arith`
* `-Wredundant-decls`
* `-Wswitch-default`

but since it is from C, several changes were made:

* `-Wbad-function-cast` - This does not work with C++.
* `-Wcast-qual` - We should use the C++ specific `-Wold-style-cast` instead, which catches more cases than this one.
* `-Wpadded` - This only affects space usage, and would take some effort to fix. Since the C++ client is no longer being pursued for the embedded side, I chose to omit this one now, although it could be revisited later.
* `-Wswitch-default` - This one is a bit tricky, IMHO it does more harm than good to add this. A typical example of where this is a problem is [here](https://github.com/mendersoftware/mender/blob/4.0.4/src/common/error.cpp#L35-L50). We deliberately avoid using a `default` case here, in order for the compiler to warn us if we add labels to the enum without adding them here. We cannot move the final return into a `default` case, because that silences the warning. We also cannot compile it with `-Wswitch-default` on, because there is no way to tell the compiler "we deliberately omit the default case here". So I removed this from the set.