### PR TITLE
QA-712: Use upper case for Mender Client everywhere

### DIFF
--- a/Documentation/io.mender.Authentication1.xml
+++ b/Documentation/io.mender.Authentication1.xml
@@ -6,10 +6,10 @@
     io.mender.Authentication1:
     @short_description: Mender Authentication API v1
 
-    !!! This feature is available since Mender client 3.0.
+    !!! This feature is available since Mender Client 3.0.
 
     This interface lets applications authenticate with the Mender server. The
-    Mender client will handle the authentication and provide the user with a
+    Mender Client will handle the authentication and provide the user with a
     JSON Web Token (JWT) and the server URL, which the user can use to do API
     calls to the Mender server on his own. It is exposed at
 
@@ -35,7 +35,7 @@
       FetchJwtToken:
       @success: false on errors
 
-      Instructs the Mender client to fetch the JWT token from the server. When
+      Instructs the Mender Client to fetch the JWT token from the server. When
       the token is ready, a JwtTokenStateChange signal will be emitted.
     -->
     <method name="FetchJwtToken">
@@ -47,7 +47,7 @@
       @token: Current JWT token
       @server_url: Server URL
 
-      Emitted whenever a valid JWT is available in the Mender client. The event
+      Emitted whenever a valid JWT is available in the Mender Client. The event
       includes the new token and the server URL.
     -->
     <signal name="JwtTokenStateChange">

--- a/Documentation/io.mender.Update1.xml
+++ b/Documentation/io.mender.Update1.xml
@@ -6,7 +6,7 @@
     io.mender.Update1:
     @short_description: Mender Update Management API v1
 
-    !! This feature was deprecated in Mender client 4.0.
+    !! This feature was deprecated in Mender Client 4.0.
 
     This interface lets applications interact with the update flow. It is exposed at
 
@@ -43,7 +43,7 @@
           where the `id` is equal to the deployment ID, the update_control_map
           is cleared after the deployment finished. This happens if the
           update_control_map is provisioned with the deployment.
-        * `states` instructs the Mender client what to do when entering
+        * `states` instructs the Mender Client what to do when entering
           the state given as object key. Valid `state` values include: `ArtifactInstall_Enter`,
           `ArtifactReboot_Enter` and `ArtifactCommit_Enter`.
           * `action` is the action


### PR DESCRIPTION
Following up of what was decided for the Mender docs content. See:
* https://github.com/mendersoftware/mender-docs/pull/2473