### PR TITLE
build: Include missing sanitizer options

### DIFF
--- a/main.cmake
+++ b/main.cmake
@@ -20,6 +20,7 @@ endif()
 
 include(cmake/asan.cmake)
 include(cmake/threadsan.cmake)
+include(cmake/undefsan.cmake)
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
 option(COVERAGE "Turn coverage instrumentation on (Default: OFF)" OFF)


### PR DESCRIPTION
Otherwise `CMAKE_BUILD_TYPE=UndefSan`, as in CI tests, has no effect.