### PR TITLE
chore: int conv: Use utility functions and fix their issues.

### DIFF
--- a/src/common/common.hpp
+++ b/src/common/common.hpp
@@ -84,7 +84,17 @@ expected::expected<T, error::Error> StringTo(const string &str, int base = 10) {
 	if (!num) {
 		return expected::unexpected(num.error());
 	}
-	if (num.value() < numeric_limits<T>::min() or num.value() > numeric_limits<T>::max()) {
+	bool fits = true;
+	if (is_signed<T>()) {
+		if (num.value() < numeric_limits<T>::lowest() or num.value() > numeric_limits<T>::max()) {
+			fits = false;
+		}
+	} else {
+		if (static_cast<unsigned long long>(num.value()) > numeric_limits<T>::max()) {
+			fits = false;
+		}
+	}
+	if (not fits) {
 		return expected::unexpected(error::Error(
 			make_error_condition(errc::result_out_of_range),
 			"StringTo(): Number " + to_string(num.value())

--- a/src/common/json.hpp
+++ b/src/common/json.hpp
@@ -153,7 +153,18 @@ public:
 		if (!num) {
 			return expected::unexpected(num.error());
 		}
-		if (num.value() < numeric_limits<T>::min() or num.value() > numeric_limits<T>::max()) {
+		bool fits = true;
+		if (is_signed<T>()) {
+			if (num.value() < numeric_limits<T>::lowest()
+				or num.value() > numeric_limits<T>::max()) {
+				fits = false;
+			}
+		} else {
+			if (static_cast<unsigned long long>(num.value()) > numeric_limits<T>::max()) {
+				fits = false;
+			}
+		}
+		if (not fits) {
 			return expected::unexpected(error::Error(
 				make_error_condition(errc::result_out_of_range),
 				"Json::Get(): Number " + to_string(num.value())

--- a/src/common/yaml.hpp
+++ b/src/common/yaml.hpp
@@ -124,7 +124,18 @@ public:
 		if (!num) {
 			return expected::unexpected(num.error());
 		}
-		if (num.value() < numeric_limits<T>::min() or num.value() > numeric_limits<T>::max()) {
+		bool fits = true;
+		if (is_signed<T>()) {
+			if (num.value() < numeric_limits<T>::lowest()
+				or num.value() > numeric_limits<T>::max()) {
+				fits = false;
+			}
+		} else {
+			if (static_cast<unsigned long long>(num.value()) > numeric_limits<T>::max()) {
+				fits = false;
+			}
+		}
+		if (not fits) {
 			return expected::unexpected(error::Error(
 				make_error_condition(errc::result_out_of_range),
 				"Json::Get(): Number " + to_string(num.value())

--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -293,27 +293,14 @@ error::Error DeploymentClient::PushStatus(
 					+ content_length.error().String());
 				body_writer->SetUnlimited(true);
 			} else {
-				auto ex_len = common::StringToLongLong(content_length.value());
+				auto ex_len = common::StringTo<size_t>(content_length.value());
 				if (!ex_len) {
 					log::Error(
 						"Failed to convert the content length from the status API response headers to an integer: "
 						+ ex_len.error().String());
 					body_writer->SetUnlimited(true);
-				} else if (
-					ex_len.value() < 0
-					or static_cast<unsigned long long>(ex_len.value())
-						   > numeric_limits<size_t>::max()) {
-					// This is a ridiculuous limit, but we are mainly interested
-					// in catching corrupt data / mistakes here. Actually
-					// limiting memory usage in a useful way is something which
-					// should be thought through more carefully and maybe
-					// configurable.
-					api_handler(error::Error(
-						make_error_condition(errc::result_out_of_range),
-						"Content-Length out of range"));
-					return;
 				} else {
-					received_body->resize(static_cast<size_t>(ex_len.value()));
+					received_body->resize(ex_len.value());
 				}
 			}
 			resp->SetBodyWriter(body_writer);
@@ -471,27 +458,14 @@ error::Error DeploymentClient::PushLogs(
 					+ content_length.error().String());
 				body_writer->SetUnlimited(true);
 			} else {
-				auto ex_len = common::StringToLongLong(content_length.value());
+				auto ex_len = common::StringTo<size_t>(content_length.value());
 				if (!ex_len) {
 					log::Error(
 						"Failed to convert the content length from the status API response headers to an integer: "
 						+ ex_len.error().String());
 					body_writer->SetUnlimited(true);
-				} else if (
-					ex_len.value() < 0
-					or static_cast<unsigned long long>(ex_len.value())
-						   > numeric_limits<size_t>::max()) {
-					// This is a ridiculuous limit, but we are mainly interested
-					// in catching corrupt data / mistakes here. Actually
-					// limiting memory usage in a useful way is something which
-					// should be thought through more carefully and maybe
-					// configurable.
-					api_handler(error::Error(
-						make_error_condition(errc::result_out_of_range),
-						"Content-Length out of range"));
-					return;
 				} else {
-					received_body->resize(static_cast<size_t>(ex_len.value()));
+					received_body->resize(ex_len.value());
 				}
 			}
 			resp->SetBodyWriter(body_writer);


### PR DESCRIPTION
The `StringTo` function was supposed to be used in 15162ba17b77a3867a, but looks I forgot it. Take them into use and fix the issue that popped up when there is a signed/unsigned mismatch.
