### PR TITLE
QA-794: Remove trigger to `mender-docs-site`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,29 +208,6 @@ trigger:mender-qa:
       - artifact: gitlab-ci-client-qemu-publish-job.yml
         job: generate-qa-trigger
 
-.trigger:mender-docs-site:
-  stage: trigger
-  inherit:
-    variables: false
-  rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
-      changes:
-      - Documentation/*
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-      when: never
-
-trigger:mender-docs-site:master:
-  extends: .trigger:mender-docs-site
-  trigger:
-    project: Northern.tech/Mender/mender-docs-site
-    branch: master
-
-trigger:mender-docs-site:production:
-  extends: .trigger:mender-docs-site
-  trigger:
-    project: Northern.tech/Mender/mender-docs-site
-    branch: production
-
 trigger:integration:
   stage: trigger
   inherit:


### PR DESCRIPTION
This trigger is meant to render the Device API page on changes for the D-Bus API documented at `Documentation/*.xml`.

This happens very seldom, and the Mender Docs site is anyway rendered often enough to publish these withing a day.