### PR TITLE
chore: add mender-data-dir.service file

### DIFF
--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -2,6 +2,8 @@ set(SYSTEMD_UNIT_DIR /lib/systemd/system CACHE STRING "Directory where systemd u
 
 include(GNUInstallDirs)
 
+option(MENDER_DATA_DIR_SYSTEMD_UNIT "Install the mender-data-dir.service file" OFF)
+
 set(DBUS_POLICY_FILES
   dbus/io.mender.AuthenticationManager.conf
 )
@@ -35,6 +37,10 @@ set(SYSTEMD_UNITS
   mender-updated.service
   mender-authd.service
 )
+
+if(MENDER_DATA_DIR_SYSTEMD_UNIT)
+  list(APPEND SYSTEMD_UNITS mender-data-dir.service)
+endif()
 
 install(PROGRAMS ${INVENTORYSCRIPTS}
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mender/inventory

--- a/support/mender-authd.service
+++ b/support/mender-authd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Mender authentication service
 Wants=network-online.target
-After=systemd-resolved.service network-online.target mender-client-data-dir.service data.mount
+After=systemd-resolved.service network-online.target mender-data-dir.service data.mount
 Conflicts=mender.service
 
 [Service]

--- a/support/mender-data-dir.service
+++ b/support/mender-data-dir.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mender persistent data dir
+After=data.mount
+Before=mender-authd.service mender-updated.service
+ConditionPathExists=!/data/mender
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/bin/mkdir -p -m 0700 /data/mender
+
+[Install]
+WantedBy=mender-authd.service mender-updated.service

--- a/support/mender-updated.service
+++ b/support/mender-updated.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Mender OTA update service
 Wants=mender-authd.service network-online.target
-After=systemd-resolved.service network-online.target mender-client-data-dir.service data.mount
+After=systemd-resolved.service network-online.target mender-data-dir.service data.mount
 Conflicts=mender.service
 
 [Service]


### PR DESCRIPTION
Both the mender-authd.service and mender-udpated.service files have
mender-client-data-dir.service in the "After=" line. However, this
service file isn't provided by the mender package. Instead, the
mender-client-data-dir.service file currently resides in the
meta-mender repository. This means that the mender-authd.service and
mender-updated.service files are incorrect, but currently "just work"
because of the WantedBy in the mender-data-dir.service file.

Even though "After" does not mean "required" it can still be confusing
to users as to where this file comes from. Furthermore, a user may not
want the service file to exist at all, as their build setup may create
the /data directory (or /var/lib/mender) during the image creation.

  - Move the mender-data-dir.service file into the mender project.
  - Add a new option "MENDER_DATA_DIR_SYSTEMD_UNIT" set to OFF by
    default. When enabled, the mender-data-dir.service file is
    added to the MENDER_DATA_DIR_SYSTEMD_UNIT list.
  - Rename mender-client-data-dir.service to mender-data-dir.service
    in the mender-authd.service and mender-updated.service files.

Changelog: Add systemd mender-data-dir.service optionally installed
            with MENDER_DATA_DIR_SYSTEMD_UNIT CMake variable. This
            service historically has been in meta-mender repository and
            used elsewhere from there. By moving it to the source
            repository we'll have it better aligned with authd and
            updated services

Ticket: None
