### PR TITLE
Fix: Private key file permissions

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -193,6 +193,7 @@ target_compile_options(common_crypto PRIVATE
 target_link_libraries(common_crypto PUBLIC
   common_log
   common_io
+  common_path
   sha
   OpenSSL::SSL
   OpenSSL::Crypto

--- a/src/common/path.hpp
+++ b/src/common/path.hpp
@@ -43,7 +43,12 @@ enum class Perms {
 	Others_exec,
 };
 
-error::Error Permissions(const string &file_path, vector<Perms> perms);
+enum class WarnMode { WarnOnChange, NoWarnOnChange };
+
+error::Error Permissions(
+	const string &file_path,
+	vector<Perms> perms,
+	WarnMode warn_on_change = WarnMode::NoWarnOnChange);
 
 string JoinOne(const string &prefix, const string &path);
 
@@ -66,6 +71,8 @@ bool IsAbsolute(const string &path);
 bool FileExists(const string &path);
 
 error::Error FileDelete(const string &path);
+
+expected::ExpectedInt FileCreate(const string &path, vector<Perms> perms);
 
 error::Error DeleteRecursively(const string &path);
 

--- a/src/common/path/platform/c++17/path.cpp
+++ b/src/common/path/platform/c++17/path.cpp
@@ -112,14 +112,32 @@ expected::ExpectedBool IsExecutable(const string &file_path, const bool warn) {
 	}
 }
 
-error::Error Permissions(const string &file_path, const vector<Perms> perms) {
+error::Error Permissions(
+	const string &file_path, const vector<Perms> perms, WarnMode warn_on_change) {
 	if (perms.size() == 0) {
 		return error::NoError;
 	}
-	fs::perms p {};
-	std::for_each(perms.cbegin(), perms.cend(), [&p](const Perms perm) { p |= perm_map.at(perm); });
+	fs::perms old_perms {};
 	try {
-		fs::permissions(file_path, p);
+		old_perms = fs::status(file_path).permissions();
+	} catch (const fs::filesystem_error &e) {
+		return error::Error(
+			e.code().default_error_condition(),
+			"Could not check permissions on '" + file_path + "'");
+	}
+
+	fs::perms new_perms {};
+	std::for_each(perms.cbegin(), perms.cend(), [&new_perms](const Perms perm) {
+		new_perms |= perm_map.at(perm);
+	});
+	if (old_perms == new_perms) {
+		return error::NoError;
+	}
+	if (warn_on_change == WarnMode::WarnOnChange) {
+		log::Warning("Changing permissions on the '" + file_path + "' file");
+	}
+	try {
+		fs::permissions(file_path, new_perms);
 	} catch (const fs::filesystem_error &e) {
 		return error::Error(
 			e.code().default_error_condition(), "Could not set permissions on '" + file_path + "'");

--- a/src/mender-auth/cli/keystore.cpp
+++ b/src/mender-auth/cli/keystore.cpp
@@ -69,7 +69,7 @@ error::Error MenderKeyStore::Load() {
 			"Error loading private key from " + key_name_ + ": " + exp_key.error().message);
 	}
 	log::Info("Successfully loaded private key from " + key_name_);
-	key_ = move(exp_key.value());
+	key_ = std::move(exp_key.value());
 
 	return error::NoError;
 }

--- a/tests/src/common/CMakeLists.txt
+++ b/tests/src/common/CMakeLists.txt
@@ -111,6 +111,7 @@ gtest_discover_tests(key_value_parser_test NO_PRETTY_VALUES)
 add_dependencies(tests key_value_parser_test)
 
 add_executable(crypto_test EXCLUDE_FROM_ALL crypto_test.cpp)
+target_compile_options(crypto_test PRIVATE ${PLATFORM_SPECIFIC_COMPILE_OPTIONS})
 target_link_libraries(crypto_test PUBLIC
   common_crypto
   common_testing

--- a/tests/src/common/crypto_test.cpp
+++ b/tests/src/common/crypto_test.cpp
@@ -15,6 +15,7 @@
 #include <common/crypto.hpp>
 #include <artifact/sha/sha.hpp>
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,7 @@ namespace mtesting = mender::common::testing;
 using testing::HasSubstr;
 
 namespace error = mender::common::error;
+namespace fs = std::filesystem;
 namespace path = mender::common::path;
 
 namespace mender {
@@ -247,6 +249,8 @@ TEST(CryptoTest, TestPrivateKeySaveToPEM) {
 	string tmpfile = path::Join(tmpdir.Path(), "private.key");
 	auto err = private_key.SaveToPEM(tmpfile);
 	EXPECT_EQ(error::NoError, err);
+	fs::perms perms = fs::status(tmpfile).permissions();
+	EXPECT_EQ(perms, fs::perms::owner_read | fs::perms::owner_write);
 
 	EXPECT_TRUE(mtesting::FilesEqual(private_key_file, tmpfile));
 }

--- a/tests/src/common/crypto_test.cpp
+++ b/tests/src/common/crypto_test.cpp
@@ -16,6 +16,7 @@
 #include <artifact/sha/sha.hpp>
 
 #include <filesystem>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -253,6 +254,24 @@ TEST(CryptoTest, TestPrivateKeySaveToPEM) {
 	EXPECT_EQ(perms, fs::perms::owner_read | fs::perms::owner_write);
 
 	EXPECT_TRUE(mtesting::FilesEqual(private_key_file, tmpfile));
+
+	// Pre-existing file should get its permissions fixed.
+	ofstream key2 {"private.key2"};
+	key2.close();
+	err = path::Permissions(
+		"private.key2",
+		{path::Perms::Owner_read,
+		 path::Perms::Owner_write,
+		 path::Perms::Group_read,
+		 path::Perms::Group_write,
+		 path::Perms::Others_read,
+		 path::Perms::Others_write});
+	EXPECT_EQ(error::NoError, err);
+
+	err = private_key.SaveToPEM(tmpfile);
+	EXPECT_EQ(error::NoError, err);
+	perms = fs::status(tmpfile).permissions();
+	EXPECT_EQ(perms, fs::perms::owner_read | fs::perms::owner_write);
 }
 
 } // namespace crypto

--- a/tests/src/mender-auth/cli/keystore_test.cpp
+++ b/tests/src/mender-auth/cli/keystore_test.cpp
@@ -95,6 +95,6 @@ TEST(CliTest, KeyStoreSaveNonExistingPath) {
 	err = store.Save();
 	EXPECT_TRUE(err != error::NoError);
 
-	EXPECT_THAT(err.message, testing::StartsWith("Failed to open the private key file"));
+	EXPECT_THAT(err.message, testing::StartsWith("Failed to create file"));
 	EXPECT_THAT(err.message, testing::HasSubstr("No such file or directory"));
 }


### PR DESCRIPTION
I intentionally kept the changes from the last commit separate so that they can be easily dropped (or reverted in the future may that be necessary).