### PR TITLE
fix: Allow blocks of zeroes after ArchiveEOF

### DIFF
--- a/src/artifact/tar/platform/libarchive/wrapper.hpp
+++ b/src/artifact/tar/platform/libarchive/wrapper.hpp
@@ -64,8 +64,6 @@ private:
 	 further read from */
 	ReaderContainer reader_container_;
 
-	vector<uint8_t> small_buf_;
-
 public:
 	Handle(io::Reader &reader);
 


### PR DESCRIPTION
The tar format says [1]:
> The end of an archive is marked by at least two consecutive zero-filled records.

Which means that if a file is a valid tar archive, a copy of the file with blocks of zeroes appended to its end is still a valid archive, with the same content.

Thus we cannot consider extra zeroes in a file for which libarchive tells us `ARCHIVE_EOF` as superflous data.

[1] https://en.wikipedia.org/wiki/Tar_(computing)#File_format

Ticket: MEN-7810
Changelog: none
