### PR TITLE
MEN-7818: Fix regression updating from Client v4 to Client v5 or newer

### DIFF
--- a/src/mender-update/standalone/standalone.cpp
+++ b/src/mender-update/standalone/standalone.cpp
@@ -170,7 +170,7 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 	ss << "\"" << keys.artifact_group << "\":\"" << data.artifact_group << "\"";
 
 	ss << ",";
-	ss << "\"" << keys.payload_types << "\": [";
+	ss << "\"" << keys.payload_types << "\":[";
 	bool first = true;
 	for (auto elem : data.payload_types) {
 		if (!first) {
@@ -183,7 +183,7 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 
 	if (data.artifact_provides) {
 		ss << ",";
-		ss << "\"" << keys.artifact_provides << "\": {";
+		ss << "\"" << keys.artifact_provides << "\":{";
 		bool first = true;
 		for (auto elem : data.artifact_provides.value()) {
 			if (!first) {
@@ -197,7 +197,7 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 
 	if (data.artifact_clears_provides) {
 		ss << ",";
-		ss << "\"" << keys.artifact_clears_provides << "\": [";
+		ss << "\"" << keys.artifact_clears_provides << "\":[";
 		bool first = true;
 		for (auto elem : data.artifact_clears_provides.value()) {
 			if (!first) {

--- a/src/mender-update/standalone/standalone.cpp
+++ b/src/mender-update/standalone/standalone.cpp
@@ -103,7 +103,7 @@ ExpectedOptionalStateData LoadStateData(database::KeyValueDatabase &db) {
 
 	if (dst.version == 1) {
 		// In version 1, if there is any data at all, it is equivalent to this:
-		dst.in_state = StateData::kInStateArtifactCommit_Enter;
+		dst.in_state = StateData::kBeforeStateArtifactCommit_Enter;
 		dst.failed = false;
 		dst.rolled_back = false;
 


### PR DESCRIPTION
It is not related to the major bump of the Client, but it was reported in Mender Hub with this suspicion so let's keep the Git commit aligned.

While working on internal improvements to support more advance use cases in standalone mode, we introduced a new version of the standalone store. See commit 2c1d92212.

In that commit it can be seen the code dealing with the migration (iow an update triggered from standalone store v1 being committed with standalone store v2): when missing the state, set the state that will trigger the state machine into continuing into commit state.

However a later commit aiming to increase robustness of the process added new states into the standalone state machine, and the migration from store v1 was not taking into account, provoking a regression where the client is not able to "continue" an update. See commit 056d9c26f.

(There are more commits in between these to, but the gist of the problem is captured in these two).

The fix is rather simple, read it by yourself :)

Setting changelog to `None` because the bug has not been released.