### PR TITLE
MEN-7900: Fix Mender client getting stuck after failure in sync state

### DIFF
--- a/src/mender-update/daemon/context.cpp
+++ b/src/mender-update/daemon/context.cpp
@@ -160,7 +160,9 @@ Context::Context(
 	download_client(make_shared<http_resumer::DownloadResumerClient>(
 		mender_context.GetConfig().GetHttpClientConfig(), event_loop)),
 	deployment_client(make_shared<deployments::DeploymentClient>()),
-	inventory_client(make_shared<inventory::InventoryClient>()) {
+	inventory_client(make_shared<inventory::InventoryClient>()),
+	deployment_timer(event_loop),
+	inventory_timer(event_loop) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/mender-update/daemon/context.hpp
+++ b/src/mender-update/daemon/context.hpp
@@ -174,6 +174,9 @@ public:
 	shared_ptr<deployments::DeploymentAPI> deployment_client;
 	shared_ptr<inventory::InventoryAPI> inventory_client;
 
+	events::Timer deployment_timer;
+	events::Timer inventory_timer;
+
 	struct {
 		unique_ptr<StateData> state_data;
 		io::ReaderPtr artifact_reader;

--- a/src/mender-update/daemon/state_machine.hpp
+++ b/src/mender-update/daemon/state_machine.hpp
@@ -68,6 +68,8 @@ private:
 	InitState init_state_;
 
 	IdleState idle_state_;
+	ScheduleNextPollState schedule_submit_inventory_state_;
+	ScheduleNextPollState schedule_poll_for_deployment_state_;
 	SubmitInventoryState submit_inventory_state_;
 	PollForDeploymentState poll_for_deployment_state_;
 	SendStatusUpdateState send_download_status_state_;

--- a/src/mender-update/daemon/states.hpp
+++ b/src/mender-update/daemon/states.hpp
@@ -56,34 +56,39 @@ public:
 	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
 };
 
+class ScheduleNextPollState : virtual public StateType {
+public:
+	ScheduleNextPollState(
+		events::Timer &timer, const string &poll_action, const StateEvent event, int interval);
+
+	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
+
+private:
+	events::Timer &timer_;
+	const string poll_action_;
+	const StateEvent event_;
+	int interval_;
+};
+
 class PollForDeploymentState : virtual public StateType {
 public:
-	PollForDeploymentState(
-		events::EventLoop &event_loop, int retry_interval_seconds, int retry_count);
+	PollForDeploymentState(int retry_interval_seconds, int retry_count);
 
 	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
 
 private:
 	void HandlePollingError(Context &ctx, sm::EventPoster<StateEvent> &poster);
-	struct {
-		http::ExponentialBackoff backoff;
-		events::Timer wait_timer;
-	} retry_;
+	http::ExponentialBackoff backoff_;
 };
 
 class SubmitInventoryState : virtual public StateType {
 public:
-	SubmitInventoryState(
-		events::EventLoop &event_loop, int retry_interval_seconds, int retry_count);
+	SubmitInventoryState(int retry_interval_seconds, int retry_count);
 	void OnEnter(Context &ctx, sm::EventPoster<StateEvent> &poster) override;
 
 private:
 	void HandlePollingError(Context &ctx, sm::EventPoster<StateEvent> &poster);
-	void DoSubmitInventory(Context &ctx, sm::EventPoster<StateEvent> &poster);
-	struct {
-		http::ExponentialBackoff backoff;
-		events::Timer wait_timer;
-	} retry_;
+	http::ExponentialBackoff backoff_;
 };
 
 class SaveState : virtual public StateType {


### PR DESCRIPTION
From the code point, the issue was that the re-scheduling of new polls for updates or inventory were done from the states _after_ the sync state, so unless the state machine reached that point the new polls would not be scheduled.

Fix by creating two new states, that just do the re-scheduling, between idle and sync. Note that the timer(s) have now been moved to the context object so that it can be accessed from multiple states (namely, update polling and submit inventory states which would need to manipulate the timer for exponential back-off retries.

Changelog: Fix issue where any error in Sync state (triggered for example with an error in Sync_Enter or Sync_Leave state scripts) leaves the client stuck in idle state forever and no new polls for update nor submit of inventory would be attempted again.

TODO:
- [x] Modify [the integration tests](https://github.com/mendersoftware/integration/blob/f67ea8820c5944a696fc8502d8fcd7d90cf41d26/tests/tests/test_state_scripts.py#L167) so that this bug would have been caught (check that i fails with master and passes with this PR)
- [x] Consider duplicating the classes (discussion below)
- [x] Consider refactor the backoff (discussion below)