### PR TITLE
fix: Clear the inventory data hash on re-authentication

### DIFF
--- a/src/api/auth/auth.cpp
+++ b/src/api/auth/auth.cpp
@@ -80,7 +80,6 @@ error::Error Authenticator::WithToken(AuthenticatedAction action) {
 	}
 	// else record that token is already being fetched (by GetJwtToken()).
 	token_fetch_in_progress_ = true;
-
 	return error::NoError;
 }
 
@@ -151,7 +150,9 @@ void Authenticator::HandleReceivedToken(
 			return;
 		}
 	}
-
+	if (no_token == NoTokenAction::Finish && action_ != nullptr) {
+		action_();
+	}
 	PostPendingActions(ex_auth_data);
 }
 

--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -87,7 +87,6 @@ error::Error HTTPClient::AsyncCall(
 				});
 				return;
 			}
-			reauthenticated_ = true;
 		};
 
 	return authenticator_.WithToken(

--- a/src/api/client.hpp
+++ b/src/api/client.hpp
@@ -79,19 +79,10 @@ public:
 		authenticator_.ExpireToken();
 	}
 
-	bool HasReauthenticated() {
-		return reauthenticated_;
-	}
-
-	void SetReauthenticated(bool reauthenticated) {
-		reauthenticated_ = reauthenticated;
-	}
-
 private:
 	events::EventLoop &event_loop_;
 	http::Client http_client_;
 	auth::Authenticator &authenticator_;
-	bool reauthenticated_ {false};
 };
 
 } // namespace api

--- a/src/mender-update/daemon/context.hpp
+++ b/src/mender-update/daemon/context.hpp
@@ -166,7 +166,6 @@ public:
 	mender::auth::api::auth::AuthenticatorHttp authenticator;
 #endif
 
-public:
 	// For polling, and for making status updates.
 	api::HTTPClient http_client;
 	// For the artifact download.
@@ -174,8 +173,6 @@ public:
 
 	shared_ptr<deployments::DeploymentAPI> deployment_client;
 	shared_ptr<inventory::InventoryAPI> inventory_client;
-
-	bool has_submitted_inventory {false};
 
 	struct {
 		unique_ptr<StateData> state_data;

--- a/src/mender-update/daemon/state_machine/state_machine.cpp
+++ b/src/mender-update/daemon/state_machine/state_machine.cpp
@@ -68,8 +68,14 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 	runner_(ctx) {
 	runner_.AddStateMachine(deployment_tracking_.states_);
 	runner_.AddStateMachine(main_states_);
-
 	runner_.AttachToEventLoop(event_loop_);
+	ctx.authenticator.RegisterTokenReceivedCallback([&ctx]() {
+		if (ctx.inventory_client->has_submitted_inventory) {
+			log::Debug("Client has re-authenticated - clear inventory data cache");
+			ctx.inventory_client->ClearDataCache();
+			ctx.inventory_client->has_submitted_inventory = false;
+		}
+	});
 
 	using se = StateEvent;
 	using tf = sm::TransitionFlag;

--- a/src/mender-update/inventory.hpp
+++ b/src/mender-update/inventory.hpp
@@ -72,6 +72,8 @@ public:
 		APIResponseHandler api_handler) = 0;
 
 	virtual void ClearDataCache() = 0;
+
+	bool has_submitted_inventory {false};
 };
 
 class InventoryClient : public InventoryAPI {


### PR DESCRIPTION
This fixes the case where e.g. a third party tool re-authenticates by using the D-Bus API while mender-update is waiting for the next poll interval to expire. The inventory will now be resubmitted when the poll triggers.

Ticket: MEN-7873
Changelog: Title
