### PR TITLE
fix: retry polling on all errors

### DIFF
--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -149,10 +149,8 @@ void SubmitInventoryState::DoSubmitInventory(Context &ctx, sm::EventPoster<State
 	auto handler = [this, &ctx, &poster](error::Error err) {
 		if (err != error::NoError) {
 			log::Error("Failed to submit inventory: " + err.String());
-			if (err.code != auth::MakeError(auth::UnauthorizedError, "").code) {
-				// Replace the inventory poll timer with a backoff
-				HandlePollingError(ctx, poster);
-			}
+			// Replace the inventory poll timer with a backoff
+			HandlePollingError(ctx, poster);
 			poster.PostEvent(StateEvent::Failure);
 			return;
 		}
@@ -261,10 +259,8 @@ void PollForDeploymentState::OnEnter(Context &ctx, sm::EventPoster<StateEvent> &
 		[this, &ctx, &poster](mender::update::deployments::CheckUpdatesAPIResponse response) {
 			if (!response) {
 				log::Error("Error while polling for deployment: " + response.error().String());
-				if (response.error().code != auth::MakeError(auth::UnauthorizedError, "").code) {
-					// Replace the update poll timer with a backoff
-					HandlePollingError(ctx, poster);
-				}
+				// Replace the update poll timer with a backoff
+				HandlePollingError(ctx, poster);
 				poster.PostEvent(StateEvent::Failure);
 				return;
 			} else if (!response.value()) {


### PR DESCRIPTION
When implementing the backoff for errors when polling for deployment or submitting inventory, we added an exception for unauthorized errors. After looking at how it was done in Mender Client 3, we discovered that such an exception was not present there, and that the backoff should be triggered for all types of errors.

Changelog: All errors when polling for deployment or submitting inventory are retried with an exponential backoff.

Ticket: MEN-7938