### PR TITLE
fix: Fix undefined behaviour after a move operation

### DIFF
--- a/src/artifact/v3/payload/payload.cpp
+++ b/src/artifact/v3/payload/payload.cpp
@@ -48,7 +48,8 @@ ExpectedPayloadReader Payload::Next() {
 			parser_error::Code::ParseError, expected_tar_entry.error().message));
 	}
 	auto tar_entry {expected_tar_entry.value()};
-	return Reader {std::move(tar_entry), manifest_.Get("data/0000/" + tar_entry.Name())};
+	string tar_name = tar_entry.Name();
+	return Reader {std::move(tar_entry), manifest_.Get("data/0000/" + tar_name)};
 }
 
 } // namespace payload


### PR DESCRIPTION
This fixes the case where we access an object after it has been moved.

Ticket: MEN-7980
Changelog: None

