### PR TITLE
fix: Fix deployment on 32 bit systems when rootfs is larger than 4Gb

### DIFF
--- a/src/artifact/tar/platform/libarchive/tar.cpp
+++ b/src/artifact/tar/platform/libarchive/tar.cpp
@@ -73,13 +73,13 @@ ExpectedEntry Reader::Next() {
 			MakeError(TarReaderError, "Failed to get the name of the archive entry"));
 	}
 
-	const la_int64_t archive_entry_size_ {archive_entry_size(current_entry)};
+	const int64_t archive_entry_size_ {archive_entry_size(current_entry)};
 	if (archive_entry_size_ < 0) {
 		return expected::unexpected(
 			MakeError(TarReaderError, "Failed to get the size of the archive"));
 	}
 
-	return Entry(archive_name, static_cast<size_t>(archive_entry_size_), *this);
+	return Entry(archive_name, archive_entry_size_, *this);
 }
 
 } // namespace tar


### PR DESCRIPTION
When reading the archive entry size from the tar archive, the size was cast to size_t before storing it as an int64_t.

Ticket: MEN-8062
Changelog: Title
