### PR TITLE
fix: inventory-geo appears to hang while wget retries many times

### DIFF
--- a/support/mender-inventory-geo
+++ b/support/mender-inventory-geo
@@ -40,7 +40,7 @@ ATTR_NAME_LAT="geo-lat"
 ATTR_NAME_LON="geo-lon"
 
 if [ ! -f "${TEMPFILE}" ]; then
-    ipinfo=$(wget --timeout=${TIMEOUT} -q -O /dev/stdout \
+    ipinfo=$(wget --timeout=${TIMEOUT} -q -O /dev/stdout --tries=2 \
                   --header 'Accept: application/json' \
                   https://ipinfo.io)
     if [ $? != 0 ] || [ -z "${ipinfo}" ]; then


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [√] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: wget effectively hangs when using ipinfo.io in restricted environments

Changelog: Add retry limit to inventory geo script to prevent hanging
Ticket: None
```

- [√] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

In mender-inventory-geo the wget command has a timeout but wget will retry forever. In restricted environments this effectively causes the script to hang, never sending inventory data.
I have added tries=2 to allow wget to fail so the script can handle it

Thank you!
