### PR TITLE
fix: Use EscapeString when generating JSON for supplied artifact data

### DIFF
--- a/src/mender-update/context/context.cpp
+++ b/src/mender-update/context/context.cpp
@@ -351,8 +351,8 @@ error::Error MenderContext::CommitArtifactData(
 		string artifact_provides_str {"{"};
 		for (const auto &it : modified_provides) {
 			if (it.first != "artifact_name" && it.first != "artifact_group") {
-				artifact_provides_str +=
-					"\"" + it.first + "\":" + "\"" + json::EscapeString(it.second) + "\",";
+				artifact_provides_str += "\"" + json::EscapeString(it.first) + "\":" + "\""
+										 + json::EscapeString(it.second) + "\",";
 			}
 		}
 

--- a/src/mender-update/standalone/standalone.cpp
+++ b/src/mender-update/standalone/standalone.cpp
@@ -164,10 +164,10 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 	ss << "\"" << keys.version << "\":" << data.version;
 
 	ss << ",";
-	ss << "\"" << keys.artifact_name << "\":\"" << data.artifact_name << "\"";
+	ss << "\"" << keys.artifact_name << "\":\"" << json::EscapeString(data.artifact_name) << "\"";
 
 	ss << ",";
-	ss << "\"" << keys.artifact_group << "\":\"" << data.artifact_group << "\"";
+	ss << "\"" << keys.artifact_group << "\":\"" << json::EscapeString(data.artifact_group) << "\"";
 
 	ss << ",";
 	ss << "\"" << keys.payload_types << "\":[";
@@ -176,7 +176,7 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 		if (!first) {
 			ss << ",";
 		}
-		ss << "\"" << elem << "\"";
+		ss << "\"" << json::EscapeString(elem) << "\"";
 		first = false;
 	}
 	ss << "]";
@@ -189,7 +189,8 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 			if (!first) {
 				ss << ",";
 			}
-			ss << "\"" << elem.first << "\":\"" << elem.second << "\"";
+			ss << "\"" << json::EscapeString(elem.first) << "\":\""
+			   << json::EscapeString(elem.second) << "\"";
 			first = false;
 		}
 		ss << "}";
@@ -203,7 +204,7 @@ error::Error SaveStateData(database::Transaction &txn, const StateData &data) {
 			if (!first) {
 				ss << ",";
 			}
-			ss << "\"" << elem << "\"";
+			ss << "\"" << json::EscapeString(elem) << "\"";
 			first = false;
 		}
 		ss << "]";


### PR DESCRIPTION
Ticket: MEN-7974
Changelog: Title
