### PR TITLE
feat: Add User-Agent header to HTTP requests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,4 +20,3 @@ add_subdirectory(client_shared)
 add_subdirectory(mender-update)
 add_subdirectory(mender-auth)
 add_subdirectory(artifact)
-

--- a/src/common/http/platform/beast/http.cpp
+++ b/src/common/http/platform/beast/http.cpp
@@ -24,6 +24,8 @@
 #include <common/common.hpp>
 #include <common/crypto.hpp>
 
+#include <mender-version.h>
+
 namespace mender {
 namespace common {
 namespace http {
@@ -424,6 +426,9 @@ error::Error Client::AsyncCall(
 	req->SetHeader("HOST", header_url);
 
 	log::Trace("Setting HOST address: " + header_url);
+
+	// Add User-Agent header for all requests
+	req->SetHeader("User-Agent", "Mender/" MENDER_VERSION);
 
 	header_handler_ = header_handler;
 	body_handler_ = body_handler;

--- a/tests/src/common/http_test.cpp
+++ b/tests/src/common/http_test.cpp
@@ -26,6 +26,8 @@
 #include <common/testing.hpp>
 #include <common/processes.hpp>
 
+#include <mender-version.h>
+
 using namespace std;
 
 namespace error = mender::common::error;
@@ -415,6 +417,9 @@ void TestHeaders() {
 
 			ASSERT_TRUE(req->GetHeader("X-MyrequestHeader"));
 			EXPECT_EQ(req->GetHeader("X-MyrequestHeader").value(), "header_value");
+
+			ASSERT_TRUE(req->GetHeader("User-Agent"));
+			EXPECT_EQ(req->GetHeader("User-Agent").value(), "Mender/" MENDER_VERSION);
 		},
 		[&server_hit_body](http::ExpectedIncomingRequestPtr exp_req) {
 			server_hit_body = true;
@@ -425,6 +430,9 @@ void TestHeaders() {
 
 			ASSERT_TRUE(req->GetHeader("X-MyrequestHeader"));
 			EXPECT_EQ(req->GetHeader("X-MyrequestHeader").value(), "header_value");
+
+			ASSERT_TRUE(req->GetHeader("User-Agent"));
+			EXPECT_EQ(req->GetHeader("User-Agent").value(), "Mender/" MENDER_VERSION);
 
 			auto exp_resp = req->MakeResponse();
 			ASSERT_TRUE(exp_resp) << exp_resp.error().String();


### PR DESCRIPTION
The Mender client version will now be sent to the server through the User-Agent header.

Tiicket: MEN-1979
Changelog: Title
