### PR TITLE
fix: Correct the signature length check for ECDSA keys supplied via PKCS#11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Northern.tech AS
+Copyright 2025 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 Northern.tech AS
+Copyright 2024 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/vendor/github.com/mendersoftware/mender-artifact/artifact/signer.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/artifact/signer.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
 	"math/big"
@@ -77,6 +78,8 @@ func (r *RSA) Verify(message, sig []byte, key interface{}) error {
 // ECDSA Crypto interface implementation
 const ecdsa256curveBits = 256
 const ecdsa256keySize = 32
+const ecdsa256Asn1SizeBytes = 70
+const ecdsa256Asn1Padding = 2
 
 type ECDSA256 struct{}
 
@@ -159,14 +162,52 @@ func MarshalECDSASignature(r, s *big.Int) ([]byte, error) {
 
 func UnmarshalECDSASignature(sig []byte) (r, s *big.Int, e error) {
 	// check if the size of the key matches provided one
-	if len(sig) != 2*ecdsa256keySize {
-		return nil, nil, errors.Errorf("signer: invalid ecdsa key size: %d", len(sig))
+	if len(sig) == 2*ecdsa256keySize {
+		// get the signature; see corresponding `Sign` function for more details
+		// about serialization
+		r = big.NewInt(0).SetBytes(sig[:ecdsa256keySize])
+		s = big.NewInt(0).SetBytes(sig[ecdsa256keySize:])
+		return r, s, nil
 	}
 
-	// get the signature; see corresponding `Sign` function for more details
-	// about serialization
-	r = big.NewInt(0).SetBytes(sig[:ecdsa256keySize])
-	s = big.NewInt(0).SetBytes(sig[ecdsa256keySize:])
+	// in case of a key supplied via PKCS#11 URI, we have no control over what the signature is
+	// since it is designed to be actually verified via the same mechanism (PKCS#11 URI).
+	// We know here that it is ECDSA key, and judging form the size we can assume
+	// that it is ASN.1 encoded. If so, then it should be between 70 and 72 bytes.
+	// In other words:
+	// if the signature has not been created with MarshalECDSASignature, then we assume
+	// it is to be decoded via ASN.1, with the protection on the signature length.
+	if len(sig) >= ecdsa256Asn1SizeBytes &&
+		len(sig) <= ecdsa256Asn1SizeBytes+ecdsa256Asn1Padding {
+		return UnmarshalECDSASignatureASN1(sig)
+	}
+
+	return nil, nil, errors.Errorf("signer: invalid ecdsa signature size: %d", len(sig))
+}
+
+func UnmarshalECDSASignatureASN1(sig []byte) (r *big.Int, s *big.Int, err error) {
+	var value asn1.RawValue
+	_, err = asn1.Unmarshal(sig, &value)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "cannot unmarshal asn1 data")
+	}
+	bytesValue := value.Bytes
+	if len(bytesValue) > 0 {
+		var v asn1.RawValue
+		bytesValue, err = asn1.Unmarshal(bytesValue, &v)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "cannot unmarshal asn1 r value")
+		}
+		r = big.NewInt(0).SetBytes(v.Bytes)
+	}
+	if len(bytesValue) > 0 {
+		var v asn1.RawValue
+		_, err = asn1.Unmarshal(bytesValue, &v)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "cannot unmarshal asn1 s value")
+		}
+		s = big.NewInt(0).SetBytes(v.Bytes)
+	}
 	return r, s, nil
 }
 


### PR DESCRIPTION
### Description

The PR enables the checking PKCS#11 signatures with mender-client, when using an ecdsa - keyfile, like introduced in mender-artifact with commit: 6ef1fdfd057f438ea777a0f7430d15a3c23b52c4

    An ASN.1 DER encoded signature is specified by RFC 3279 as:
    Ecdsa-Sig-Value ::= SEQUENCE  {
        r     INTEGER,
        s     INTEGER
    }

    ASN.1 gives an overhead of 6 bytes (SEQUENCE and INTEGER tags + length) and
    for P-256 "r" and "s" are 32 bytes each. This gives a minimum length of 70
    bytes. "r" and "s" should be positive numbers so if the numbers are negative
    (msb is 1), the numbers need to be padded, i.e. they will use 33 bytes
    instead of 32. This means the encoded signature can be 71 or 72 bytes
    depending on padding.

ported from: mender-artifact: 6ef1fdfd057f438ea777a0f7430d15a3c23b52c4


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
