### PR TITLE
fix: rootfs-image: Avoid logging errors if config file is missing.

### DIFF
--- a/support/modules/rootfs-image
+++ b/support/modules/rootfs-image
@@ -49,6 +49,10 @@ parse_conf_file() {
             ${MENDER_DATASTORE_DIR:-/var/lib/mender}/mender.conf \
             ${MENDER_CONF_DIR:-/etc/mender}/mender.conf \
     ; do
+        if [ ! -f "$CONF_FILE" ]; then
+            continue
+        fi
+
         if [ "$JQ_AVAILABLE" = 1 ]; then
             # Use the alternative operator "//" to set tmp to "" instead of "null"
             tmp="$(jq -r '.RootfsPartA // empty' < "$CONF_FILE" || true)"


### PR DESCRIPTION
The "fallback" configuration file at /var/lib/mender/mender.conf is optional. We should therefore not log an error if it is not present.

Changelog: None
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

The fallback configuration file /var/lib/mender/mender.conf is optional. When it's missing we end up with those error logs from the rootfs-image update module:
```
Update Module output (stderr): can't open /var/lib/mender/mender.conf: no such file"
Update Module output (stderr): /usr/share/mender/modules/v3/rootfs-image: line 56: {...}
Update Module output (stderr): can't open /var/lib/mender/mender.conf: no such file" |  
Update Module output (stderr): /usr/share/mender/modules/v3/rootfs-image: line 54: {...}
```
With this PR we first check if the config file exists before parsing it.