### PR TITLE
chore: bump libboost_log to 1.83.0

### DIFF
--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -36,7 +36,7 @@ RUN mender-artifact write bootstrap-artifact \
 FROM ubuntu:24.04
 
 RUN mkdir -p /run/dbus
-RUN apt update && apt install -y libboost-log1.74.0 liblmdb0 libarchive13 dbus iproute2
+RUN apt update && apt install -y libboost-log1.83.0 liblmdb0 libarchive13 dbus iproute2
 
 COPY --from=build /mender-install/usr/bin/mender-update /usr/bin/mender-update
 COPY --from=build /mender-install/usr/bin/mender-auth /usr/bin/mender-auth


### PR DESCRIPTION
The following errors are present in mendersoftware/mender-client-docker:mender-master

```
mender-auth: error while loading shared libraries: libboost_log.so.1.83.0: cannot open shared object file: No such file or directory
mender-update: error while loading shared libraries: libboost_log.so.1.83.0: cannot open shared object file: No such file or directory
```