### PR TITLE
chore: Use repo instead of standalone deb packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
     description: "Version of docker to use in pipelines"
 
   # mender-artifact version for tests
-  MENDER_ARTIFACT_VERSION: 4.0.0
+  MENDER_ARTIFACT_VERSION: 4.1.0
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -44,7 +44,7 @@ test:unit:
   before_script:
     - apt update && apt install -yyq g++ cmake git make lcov pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev libdbus-1-dev curl dbus stunnel4 tinyproxy-bin netcat wget
     # mender-artifact install
-    - wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bdebian%2bbullseye_amd64.deb"
+    - wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bdebian%2bbullseye_amd64.deb"
       --output-document mender-artifact.deb
     - dpkg --install mender-artifact.deb
   script:
@@ -76,7 +76,7 @@ test:backward-compat:
   before_script:
     - apt update && apt install -yyq ccache clang cmake git make pkg-config liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev libdbus-1-dev curl dbus stunnel4 tinyproxy-bin netcat wget
     # mender-artifact install
-    - wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bubuntu%2bjammy_amd64.deb"
+    - wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bubuntu%2bjammy_amd64.deb"
       --output-document mender-artifact.deb
     - dpkg --install mender-artifact.deb
     - export CC=$(which clang)

--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -23,7 +23,7 @@ RUN MENDER_ARTIFACT_VERSION=$(sed -n 's/.*MENDER_ARTIFACT_VERSION: \(.*\)/\1/p' 
         echo "Could not parse  MENDER_ARTIFACT_VERSION from .gitlab-ci.yml" 1>&2; \
         exit 1; \
     fi; \
-    curl "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1+ubuntu+noble_amd64.deb" \
+    curl "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1+ubuntu+noble_amd64.deb" \
         --output /mender-artifact.deb && \
     dpkg --install /mender-artifact.deb && \
     rm /mender-artifact.deb


### PR DESCRIPTION
Mender supports tool installation using repositories now. This is the correct way of installing the packages instead of downloading fixed version as a *.deb files.

Ticket: QA-1090
Changelog: None

