### PR TITLE
WIP

### DIFF
--- a/src/mender-update/daemon/state_events.hpp
+++ b/src/mender-update/daemon/state_events.hpp
@@ -26,6 +26,7 @@ enum class StateEvent {
 	Failure,
 	NothingToDo,
 	Retry,
+	DeploymentAborted,
 	InventoryPollingTriggered,
 	DeploymentPollingTriggered,
 	StateLoopDetected,
@@ -48,6 +49,8 @@ inline std::string StateEventToString(const StateEvent &event) {
 		return "NothingToDo";
 	case StateEvent::Retry:
 		return "Retry";
+	case StateEvent::DeploymentAborted:
+		return "DeploymentAborted";
 	case StateEvent::InventoryPollingTriggered:
 		return "InventoryPollingTriggered";
 	case StateEvent::DeploymentPollingTriggered:

--- a/src/mender-update/daemon/state_machine/state_machine.cpp
+++ b/src/mender-update/daemon/state_machine/state_machine.cpp
@@ -139,6 +139,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	// Cannot fail due to FailureMode::Ignore.
 	main_states_.AddTransition(send_download_status_state_,             se::Success,                     ss.download_enter_,                      tf::Immediate);
+	main_states_.AddTransition(send_download_status_state_,             se::DeploymentAborted,           ss.download_leave_,                      tf::Immediate);
 
 	main_states_.AddTransition(ss.download_enter_,                      se::Success,                     update_download_state_,                  tf::Immediate);
 	main_states_.AddTransition(ss.download_enter_,                      se::Failure,                     ss.download_error_,                      tf::Immediate);
@@ -165,6 +166,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	// Cannot fail due to FailureMode::Ignore.
 	main_states_.AddTransition(send_install_status_state_,              se::Success,                     ss.install_enter_,                       tf::Immediate);
+	main_states_.AddTransition(send_install_status_state_,              se::DeploymentAborted,           clear_artifact_data_state_,              tf::Immediate);
 
 	main_states_.AddTransition(update_install_state_,                   se::Success,                     ss.install_leave_,                       tf::Immediate);
 	main_states_.AddTransition(update_install_state_,                   se::Failure,                     ss.install_error_rollback_,              tf::Immediate);
@@ -187,6 +189,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	// Cannot fail due to FailureMode::Ignore.
 	main_states_.AddTransition(send_reboot_status_state_,               se::Success,                     ss.reboot_enter_,                        tf::Immediate);
+	main_states_.AddTransition(send_reboot_status_state_,               se::DeploymentAborted,           clear_artifact_data_state_,              tf::Immediate);
 
 	main_states_.AddTransition(ss.reboot_enter_,                        se::Success,                     update_reboot_state_,                    tf::Immediate);
 	main_states_.AddTransition(ss.reboot_enter_,                        se::Failure,                     ss.reboot_error_,                        tf::Immediate);
@@ -210,6 +213,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	main_states_.AddTransition(send_commit_status_state_,               se::Success,                     ss.commit_enter_,                        tf::Immediate);
 	main_states_.AddTransition(send_commit_status_state_,               se::Failure,                     update_check_rollback_state_,            tf::Immediate);
+	main_states_.AddTransition(send_commit_status_state_,               se::DeploymentAborted,           update_check_rollback_state_,            tf::Immediate);
 
 	main_states_.AddTransition(ss.commit_enter_,                        se::Success,                     update_commit_state_,                    tf::Immediate);
 	main_states_.AddTransition(ss.commit_enter_,                        se::Failure,                     ss.commit_error_,                        tf::Immediate);
@@ -296,6 +300,7 @@ StateMachine::StateMachine(Context &ctx, events::EventLoop &event_loop) :
 
 	main_states_.AddTransition(send_final_status_state_,                se::Success,                     clear_artifact_data_state_,              tf::Immediate);
 	main_states_.AddTransition(send_final_status_state_,                se::Failure,                     clear_artifact_data_state_,              tf::Immediate);
+	main_states_.AddTransition(send_final_status_state_,                se::DeploymentAborted,           clear_artifact_data_state_,              tf::Immediate);
 
 	main_states_.AddTransition(clear_artifact_data_state_,              se::Success,                     end_of_deployment_state_,                tf::Immediate);
 	main_states_.AddTransition(clear_artifact_data_state_,              se::Failure,                     end_of_deployment_state_,                tf::Immediate);


### PR DESCRIPTION
Ticket: ME-527
Changelog: Add a new state event, `DeploymentAborted`, which is posted and checked whenever we send status updates to the server. Each state that sends status now explicitly checks if the deployment is aborted and handles it accordingly. Previously it was only handled in the commit state, which meant that if you aborted a deployment during e.g. download, the device could still reboot.