### PR TITLE
serialize numeric inventory values without quotes 

### DIFF
--- a/src/mender-update/inventory.cpp
+++ b/src/mender-update/inventory.cpp
@@ -14,6 +14,9 @@
 
 #include <mender-update/inventory.hpp>
 
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
 #include <functional>
 #include <sstream>
 #include <string>
@@ -71,6 +74,39 @@ error::Error MakeError(InventoryErrorCode code, const string &msg) {
 
 const string uri = "/api/devices/v1/inventory/device/attributes";
 
+enum class ValueType {
+	Integer,
+	Float,
+	String
+};
+
+ValueType GetValueType(const string& value) {
+	if (value.empty()) {
+		return ValueType::String;
+	}
+
+	// First check if it's an integer
+	auto int_result = common::StringToLongLong(value);
+	if (int_result) {
+		return ValueType::Integer;
+	}
+
+	// Then check if it's a floating point number
+	char* endptr;
+	errno = 0;
+	double parsed_value = strtod(value.c_str(), &endptr);
+	
+	// Validate that the entire string was consumed and no conversion errors occurred
+	if (errno == 0 && endptr == value.c_str() + value.length() && endptr != value.c_str()) {
+		// Additional validation: reject NaN and infinite values as they don't serialize well in JSON
+		if (std::isfinite(parsed_value)) {
+			return ValueType::Float;
+		}
+	}
+
+	return ValueType::String;
+}
+
 error::Error PushInventoryData(
 	const string &inventory_generators_dir,
 	events::EventLoop &loop,
@@ -98,12 +134,29 @@ error::Error PushInventoryData(
 		top_ss << json::EscapeString(key);
 		top_ss << R"(","value":)";
 		if (inv_data[key].size() == 1) {
-			top_ss << "\"" + json::EscapeString(inv_data[key][0]) + "\"";
+			const string& value = inv_data[key][0];
+			ValueType value_type = GetValueType(value);
+			
+			if (value_type == ValueType::Integer || value_type == ValueType::Float) {
+				// Serialize numeric values without quotes
+				top_ss << value;
+			} else {
+				// Serialize string values with quotes and escaping
+				top_ss << "\"" << json::EscapeString(value) << "\"";
+			}
 		} else {
 			stringstream items_ss;
 			items_ss << "[";
 			for (const auto &str : inv_data[key]) {
-				items_ss << "\"" + json::EscapeString(str) + "\",";
+				ValueType value_type = GetValueType(str);
+				
+				if (value_type == ValueType::Integer || value_type == ValueType::Float) {
+					// Serialize numeric values without quotes
+					items_ss << str << ",";
+				} else {
+					// Serialize string values with quotes and escaping
+					items_ss << "\"" << json::EscapeString(str) << "\",";
+				}
 			}
 			auto items_str = items_ss.str();
 			// replace the trailing comma with the closing square bracket


### PR DESCRIPTION
The C++ client was wrapping all inventory values in quotes during JSON serialization, causing numeric filtering operations ($gt, $lt, etc.) to fail in the Mender UI. This occurred because MongoDB treats quoted values as strings, preventing numeric comparisons.

This change adds type detection to distinguish between numeric and string values during inventory serialization:
- Integer values (42, -123, 0) are serialized without quotes
- Float values (3.14, 1.23e-4) are serialized without quotes
- String values ("hello", "true") are serialized with quotes and escaping
- Mixed arrays are handled with per-element type detection

The fix maintains backward compatibility with existing string-based inventory data while enabling proper numeric filtering in the UI.

Ticket: MEN-8717
Changelog: Fixed numeric inventory values serialization to enable server-side filtering operations


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
