### PR TITLE
fix: add timeout to prevent hanging downloads on connection loss

### DIFF
--- a/src/common/http.hpp
+++ b/src/common/http.hpp
@@ -524,6 +524,9 @@ private:
 
 	vector<uint8_t> body_buffer_;
 
+	// Timer for read timeouts to prevent hanging on connection loss
+	events::Timer read_timeout_timer_;
+
 	asio::ip::tcp::resolver::results_type resolver_results_;
 
 	// The reason that these are inside a struct is a bit complicated. We need to deal with what

--- a/src/common/http/platform/beast/http.cpp
+++ b/src/common/http/platform/beast/http.cpp
@@ -293,7 +293,8 @@ Client::Client(
 	no_proxy_ {client.no_proxy},
 	cancelled_ {make_shared<bool>(true)},
 	resolver_(GetAsioIoContext(event_loop)),
-	body_buffer_(HTTP_BEAST_BUFFER_SIZE) {
+	body_buffer_(HTTP_BEAST_BUFFER_SIZE),
+	read_timeout_timer_(event_loop) {
 }
 
 Client::~Client() {
@@ -1170,8 +1171,24 @@ void Client::AsyncReadNextBodyPart(
 	auto &cancelled = cancelled_;
 	auto &response_data = response_data_;
 
+	// Add a timeout timer to ensure we don't get stuck if we lose connection
+	read_timeout_timer_.AsyncWait(chrono::minutes(5), [this, cancelled](error::Error err) {
+		if (!*cancelled) {
+			if (err != error::NoError) {
+				if (err.code != make_error_condition(errc::operation_canceled)) {
+					log::Error("Read timeout timer caused error: " + err.String());
+					CallErrorHandler(err, request_, body_handler_);
+				}
+			} else {
+				CallErrorHandler(
+					MakeError(DownloadResumerError, "Read timed out"), request_, body_handler_);
+			}
+		}
+	});
+
 	auto async_handler = [this, cancelled, response_data](const error_code &ec, size_t num_read) {
 		if (!*cancelled) {
+			read_timeout_timer_.Cancel();
 			ReadBodyHandler(ec, num_read);
 		}
 	};
@@ -1282,6 +1299,7 @@ void Client::Cancel() {
 
 void Client::DoCancel() {
 	resolver_.cancel();
+	read_timeout_timer_.Cancel();
 	if (stream_) {
 		stream_->lowest_layer().cancel();
 		stream_->lowest_layer().close();


### PR DESCRIPTION
If network connection is lost while downloading an artifact, the client
can hang when calling `beast::http::async_read_some` in `AsyncReadNextBodyPart`.
Implement an AsyncWait timer that triggers an error handler after 5 minutes.

Ticket: MEN-8717
Changelog: Fix an issue where mender-update hangs when network connection is
lost during artifact download. Implement a 5-minute timeout in `AsyncReadNextBodyPart`
to allow the HTTP resumer to resume the download.