### PR TITLE
QA-1223: Add longer timeouts for HTTP tests reaching external services

### DIFF
--- a/tests/src/common/http_test.cpp
+++ b/tests/src/common/http_test.cpp
@@ -1646,7 +1646,7 @@ TEST(HttpTest, SerialRequestsWithSameObjectAfterCancel) {
 }
 
 TEST(HttpTest, DestroyClientBeforeRequestComplete) {
-	TestEventLoop loop;
+	TestEventLoop loop(chrono::seconds(30));
 
 	bool client_hit_header = false;
 	bool client_hit_body = false;
@@ -2200,7 +2200,7 @@ TEST(HttpsTest, NoCertificateError) {
 }
 
 TEST(HttpsTest, CorrectDefaultCertificateStoreVerification) {
-	TestEventLoop loop;
+	TestEventLoop loop(chrono::seconds(30));
 
 	bool client_hit_header {false};
 	bool client_hit_body {false};
@@ -2527,7 +2527,7 @@ TEST(HttpsTest, MtlsSuccess) {
 }
 
 TEST(HttpsTest, CertsAndKeysLoadFailures) {
-	TestEventLoop loop;
+	TestEventLoop loop(chrono::seconds(30));
 
 	auto handler = [](http::ExpectedIncomingResponsePtr exp_resp) {
 		ASSERT_TRUE(false) << "Should never get here";


### PR DESCRIPTION
The test `CorrectDefaultCertificateStoreVerification` occasionally fails in CI with a timeout.

The rest of the tests communicate with localhost, which we should assume its reachable within the 5 seconds deafault timeout. But for the ones connecting externally give some extra time for more stability in CI.