### PR TITLE
feat: send tier in authentication request

### DIFF
--- a/src/client_shared/CMakeLists.txt
+++ b/src/client_shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(client_shared_config_parser STATIC config_parser/config_parser.cpp)
-target_link_libraries(client_shared_config_parser PUBLIC common_json common_log)
+target_link_libraries(client_shared_config_parser PUBLIC common_json common_log common_device_tier)
 
 add_library(client_shared_identity_parser STATIC identity_parser/identity_parser.cpp)
 target_link_libraries(client_shared_identity_parser PUBLIC common_key_value_parser common_processes common_json)

--- a/src/client_shared/config_parser.hpp
+++ b/src/client_shared/config_parser.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <common/error.hpp>
 #include <common/expected.hpp>
+#include <common/device_tier.hpp>
 
 #ifndef MENDER_COMMON_CONFIG_PARSER_HPP
 #define MENDER_COMMON_CONFIG_PARSER_HPP
@@ -29,6 +30,7 @@ using namespace std;
 using mender::common::expected::ExpectedBool;
 
 namespace error = mender::common::error;
+namespace device_tier = mender::common::device_tier;
 
 /** HttpsClient holds the configuration for the client side mTLS
 	configuration */
@@ -164,7 +166,7 @@ public:
 	string tenant_token;
 
 	/** Device tier classification */
-	string device_tier;
+	string device_tier = device_tier::kStandard;
 
 	/** List of available servers, to which client can fall over */
 	vector<string> servers;

--- a/src/client_shared/config_parser/config_parser.cpp
+++ b/src/client_shared/config_parser/config_parser.cpp
@@ -31,6 +31,7 @@ using namespace std;
 namespace expected = mender::common::expected;
 namespace json = mender::common::json;
 namespace log = mender::common::log;
+namespace device_tier = mender::common::device_tier;
 
 const ConfigParserErrorCategoryClass ConfigParserErrorCategory;
 
@@ -109,7 +110,13 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		const json::Json value_json = e_cfg_value.value();
 		const json::ExpectedString e_cfg_string = value_json.GetString();
 		if (e_cfg_string) {
-			this->device_tier = e_cfg_string.value();
+			const string &tier = e_cfg_string.value();
+			if (!device_tier::IsValid(tier)) {
+				auto err = MakeError(
+					ConfigParserErrorCode::ValidationError, "Invalid DeviceTier: " + tier);
+				return expected::unexpected(err);
+			}
+			this->device_tier = tier;
 			applied = true;
 		}
 	}

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -70,6 +70,9 @@ target_include_directories(common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_include_directories(common PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(common PUBLIC common_cpp)
 
+add_library(common_device_tier STATIC device_tier.cpp)
+target_link_libraries(common_device_tier PUBLIC common)
+
 add_library(common_setup STATIC setup/platform/posix/setup.cpp)
 target_link_libraries(common_setup PUBLIC common)
 

--- a/src/common/device_tier.cpp
+++ b/src/common/device_tier.cpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/device_tier.hpp>
+
+namespace mender {
+namespace common {
+namespace device_tier {
+
+const std::string kStandard = "standard";
+const std::string kSystem = "system";
+const std::string kMicro = "micro";
+
+bool IsValid(const std::string &tier) {
+	return tier == kStandard || tier == kSystem || tier == kMicro;
+}
+
+} // namespace device_tier
+} // namespace common
+} // namespace mender

--- a/src/common/device_tier.hpp
+++ b/src/common/device_tier.hpp
@@ -1,0 +1,34 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_DEVICE_TIER_HPP
+#define MENDER_COMMON_DEVICE_TIER_HPP
+
+#include <string>
+
+namespace mender {
+namespace common {
+namespace device_tier {
+
+extern const std::string kStandard;
+extern const std::string kSystem;
+extern const std::string kMicro;
+
+bool IsValid(const std::string &tier);
+
+} // namespace device_tier
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_DEVICE_TIER_HPP

--- a/src/mender-auth/api/CMakeLists.txt
+++ b/src/mender-auth/api/CMakeLists.txt
@@ -3,6 +3,7 @@ target_link_libraries(mender_auth_api_auth PUBLIC
   api_auth
   common_http
   client_shared_identity_parser
+  common_device_tier
 )
 
 if(MENDER_EMBED_MENDER_AUTH)

--- a/src/mender-auth/api/auth.hpp
+++ b/src/mender-auth/api/auth.hpp
@@ -23,6 +23,7 @@
 #include <common/events.hpp>
 #include <common/error.hpp>
 #include <common/http.hpp>
+#include <common/device_tier.hpp>
 
 #include <api/auth.hpp>
 
@@ -39,6 +40,7 @@ namespace crypto = mender::common::crypto;
 namespace events = mender::common::events;
 namespace error = mender::common::error;
 namespace http = mender::common::http;
+namespace device_tier = mender::common::device_tier;
 
 namespace conf = mender::client_shared::conf;
 
@@ -68,7 +70,8 @@ error::Error FetchJWTToken(
 	const crypto::Args &args,
 	const string &device_identity_script_path,
 	APIResponseHandler api_handler,
-	const string &tenant_token = "");
+	const string &tenant_token = "",
+	const string &device_tier = device_tier::kStandard);
 
 #ifdef MENDER_EMBED_MENDER_AUTH
 class AuthenticatorHttp : public mender::api::auth::Authenticator {

--- a/src/mender-auth/api/auth/auth.cpp
+++ b/src/mender-auth/api/auth/auth.cpp
@@ -91,7 +91,8 @@ error::Error FetchJWTToken(
 	const crypto::Args &crypto_args,
 	const string &device_identity_script_path,
 	APIResponseHandler api_handler,
-	const string &tenant_token) {
+	const string &tenant_token,
+	const string &device_tier) {
 	key_value_parser::ExpectedKeyValuesMap expected_identity_data =
 		identity_parser::GetIdentityData(device_identity_script_path);
 	if (!expected_identity_data) {
@@ -109,6 +110,8 @@ error::Error FetchJWTToken(
 	if (tenant_token.size() > 0) {
 		request_body_map.insert({"tenant_token", tenant_token});
 	}
+
+	request_body_map.insert({"tier", device_tier});
 
 	auto expected_public_key = crypto::ExtractPublicKey(crypto_args);
 	if (!expected_public_key) {

--- a/src/mender-auth/cli/actions.cpp
+++ b/src/mender-auth/cli/actions.cpp
@@ -111,7 +111,8 @@ error::Error DoAuthenticate(
 			timer.Cancel();
 			loop.Stop();
 		},
-		config.tenant_token);
+		config.tenant_token,
+		config.device_tier);
 	if (err != error::NoError) {
 		return err;
 	}

--- a/src/mender-auth/ipc/server.cpp
+++ b/src/mender-auth/ipc/server.cpp
@@ -59,7 +59,8 @@ error::Error AuthenticatingForwarder::Listen(
 				args,
 				identity_script_path == "" ? default_identity_script_path_ : identity_script_path,
 				[this](auth_client::APIResponse resp) { FetchJwtTokenHandler(resp); },
-				tenant_token_);
+				tenant_token_,
+				device_tier_);
 			if (err != error::NoError) {
 				log::Error("Failed to trigger token fetching: " + err.String());
 				return false;

--- a/src/mender-auth/ipc/server.hpp
+++ b/src/mender-auth/ipc/server.hpp
@@ -54,6 +54,7 @@ public:
 	AuthenticatingForwarder(events::EventLoop &loop, const conf::MenderConfig &config) :
 		servers_ {config.servers},
 		tenant_token_ {config.tenant_token},
+		device_tier_ {config.device_tier},
 		client_ {config.GetHttpClientConfig(), loop},
 		forwarder_ {http::ServerConfig {}, config.GetHttpClientConfig(), loop},
 		default_identity_script_path_ {config.paths.GetIdentityScript()},
@@ -91,6 +92,7 @@ private:
 
 	const vector<string> &servers_;
 	const string tenant_token_;
+	const string device_tier_;
 	http::Client client_;
 	http_forwarder::Server forwarder_;
 	string default_identity_script_path_;

--- a/src/mender-update/CMakeLists.txt
+++ b/src/mender-update/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(mender_context PUBLIC
   common_log
   common_path
   common_yaml
+  common_device_tier
 )
 
 add_library(mender_deployments STATIC deployments/deployments.cpp)

--- a/src/mender-update/context/context.cpp
+++ b/src/mender-update/context/context.cpp
@@ -21,6 +21,7 @@
 
 #include <artifact/artifact.hpp>
 #include <common/common.hpp>
+#include <common/device_tier.hpp>
 #include <common/error.hpp>
 #include <common/expected.hpp>
 #include <common/io.hpp>
@@ -47,6 +48,7 @@ namespace json = mender::common::json;
 namespace kv_db = mender::common::key_value_database;
 namespace log = mender::common::log;
 namespace path = mender::common::path;
+namespace device_tier = mender::common::device_tier;
 
 #ifdef MENDER_USE_YAML_CPP
 namespace yaml = mender::common::yaml;
@@ -283,7 +285,7 @@ expected::ExpectedString MenderContext::GetDeviceType() {
 //   1) When we poll for a deployment and the device_tier is set to `system`
 //   2) When matching the artifact context when installing a mender-orchestrator manifest
 expected::ExpectedString MenderContext::GetCompatibleType(const string &payload_type) {
-	if (config_.device_tier == "system") {
+	if (config_.device_tier == device_tier::kSystem) {
 #ifdef MENDER_USE_YAML_CPP
 		if (payload_type == "") {
 			// Deployment polling -> use system_type

--- a/tests/src/common/CMakeLists.txt
+++ b/tests/src/common/CMakeLists.txt
@@ -25,6 +25,11 @@ target_link_libraries(json_test PUBLIC common_json main_test gmock)
 gtest_discover_tests(json_test NO_PRETTY_VALUES)
 add_dependencies(tests json_test)
 
+add_executable(device_tier_test EXCLUDE_FROM_ALL device_tier_test.cpp)
+target_link_libraries(device_tier_test PUBLIC common_device_tier main_test gmock)
+gtest_discover_tests(device_tier_test NO_PRETTY_VALUES)
+add_dependencies(tests device_tier_test)
+
 add_executable(yaml_test EXCLUDE_FROM_ALL yaml_test.cpp)
 target_link_libraries(yaml_test PUBLIC common_yaml main_test gmock)
 gtest_discover_tests(yaml_test ${MENDER_TEST_FLAGS} NO_PRETTY_VALUES)

--- a/tests/src/common/device_tier_test.cpp
+++ b/tests/src/common/device_tier_test.cpp
@@ -1,0 +1,51 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/device_tier.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace std;
+namespace device_tier = mender::common::device_tier;
+
+TEST(DeviceTierTests, ValidTiers) {
+	EXPECT_TRUE(device_tier::IsValid(device_tier::kStandard));
+	EXPECT_TRUE(device_tier::IsValid(device_tier::kSystem));
+	EXPECT_TRUE(device_tier::IsValid(device_tier::kMicro));
+}
+
+TEST(DeviceTierTests, InvalidTiers) {
+	EXPECT_FALSE(device_tier::IsValid("foobar"));
+	EXPECT_FALSE(device_tier::IsValid(""));
+	EXPECT_FALSE(device_tier::IsValid("Standard"));
+	EXPECT_FALSE(device_tier::IsValid("System"));
+	EXPECT_FALSE(device_tier::IsValid("Micro"));
+	EXPECT_FALSE(device_tier::IsValid("STANDARD"));
+	EXPECT_FALSE(device_tier::IsValid("SYSTEM"));
+	EXPECT_FALSE(device_tier::IsValid("MICRO"));
+}
+
+TEST(DeviceTierTests, TierValues) {
+	EXPECT_EQ(device_tier::kStandard, "standard");
+	EXPECT_EQ(device_tier::kSystem, "system");
+	EXPECT_EQ(device_tier::kMicro, "micro");
+}
+
+TEST(DeviceTierTests, EdgeCases) {
+	EXPECT_FALSE(device_tier::IsValid(" standard"));
+	EXPECT_FALSE(device_tier::IsValid("standard "));
+	EXPECT_FALSE(device_tier::IsValid(" standard "));
+	EXPECT_FALSE(device_tier::IsValid("standard\n"));
+	EXPECT_FALSE(device_tier::IsValid("standard\t"));
+}

--- a/tests/src/mender-update/context_test.cpp
+++ b/tests/src/mender-update/context_test.cpp
@@ -20,6 +20,7 @@
 
 #include <artifact/artifact.hpp>
 #include <common/common.hpp>
+#include <common/device_tier.hpp>
 #include <client_shared/conf.hpp>
 #include <common/key_value_database_lmdb.hpp>
 #include <common/json.hpp>
@@ -30,6 +31,7 @@
 
 namespace common = mender::common;
 namespace conf = mender::client_shared::conf;
+namespace device_tier = mender::common::device_tier;
 namespace error = mender::common::error;
 namespace json = mender::common::json;
 namespace kv_db = mender::common::key_value_database;
@@ -895,7 +897,7 @@ TEST_F(ContextTests, GetCompatibleTypeDevice) {
 TEST_F(ContextTests, GetCompatibleTypeSystem) {
 	conf::MenderConfig cfg;
 	cfg.paths.SetDataStore(test_state_dir.Path());
-	cfg.device_tier = "system";
+	cfg.device_tier = device_tier::kSystem;
 
 	context::MenderContext ctx(cfg);
 	auto err = ctx.Initialize();
@@ -941,7 +943,7 @@ TEST_F(ContextTests, GetCompatibleTypeSystem) {
 TEST_F(ContextTests, GetCompatibleTypeSystemMissingTopology) {
 	conf::MenderConfig cfg;
 	cfg.paths.SetDataStore(test_state_dir.Path());
-	cfg.device_tier = "system";
+	cfg.device_tier = device_tier::kSystem;
 
 	context::MenderContext ctx(cfg);
 	auto err = ctx.Initialize();
@@ -961,7 +963,7 @@ TEST_F(ContextTests, GetCompatibleTypeSystemMissingTopology) {
 TEST_F(ContextTests, GetCompatibleTypeSystemNoYaml) {
 	conf::MenderConfig cfg;
 	cfg.paths.SetDataStore(test_state_dir.Path());
-	cfg.device_tier = "system";
+	cfg.device_tier = device_tier::kSystem;
 
 	context::MenderContext ctx(cfg);
 	auto err = ctx.Initialize();


### PR DESCRIPTION
Ticket: MEN-8636
Changelog: Add device tier support to authentication requests. The client now sends a 'tier' parameter in authentication requests, supporting "standard" (default), "micro", and "system" tiers. The tier is configurable via the DeviceTier configuration option, with "standard" as the default.