### PR TITLE
MEN-8818: Make Update modules generators POSIX compatible

### DIFF
--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -170,7 +170,7 @@ echo "$dest_dir" > $dest_dir_file
 # Runs in a subshell to allow overriding some parameters passed
 # to mender-artifact
 passthrough_args_modified=" "
-echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+echo $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
   if [ -n "$flag" ] && [ -n "$arg" ]; then
     case $flag in
       -T | --type)

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -184,7 +184,7 @@ fi
 # Runs in a subshell to allow overriding some parameters passed
 # to mender-artifact
 passthrough_args_modified=" "
-echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+echo $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
   if [ -n "$flag" ]; then
     case $flag in
       -T | --type)


### PR DESCRIPTION
By removing the unnecessary `-n` flag. According to POSIX specification "Implementations shall not support any options". Ref:
* https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html