### PR TITLE
fix: Don't retry status update on 413

### DIFF
--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -137,8 +137,9 @@ error::Error HTTPClient::AsyncCall(
 					}
 					auto resp = ex_resp.value();
 					auto status = resp->GetStatusCode();
-					// 401 and 429 handled by the header handler. Don't call the body handler.
+					// 401, 413, and 429 handled by the header handler. Don't call the body handler.
 					if (status != http::StatusUnauthorized
+						&& status != http::StatusRequestBodyTooLarge
 						&& status != http::StatusTooManyRequests) {
 						body_handler(ex_resp);
 					}

--- a/src/common/http.hpp
+++ b/src/common/http.hpp
@@ -120,6 +120,7 @@ enum StatusCode {
 	StatusUnauthorized = 401,
 	StatusNotFound = 404,
 	StatusConflict = 409,
+	StatusRequestBodyTooLarge = 413,
 	StatusTooManyRequests = 429,
 
 	StatusInternalServerError = 500,

--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -700,6 +700,12 @@ void SendStatusUpdateState::DoStatusUpdateHandler(
 			// failure, even if retry is enabled.
 			poster.PostEvent(StateEvent::DeploymentAborted);
 			return;
+		} else if (
+			error.error.code
+			== deployments::MakeError(deployments::RequestBodyTooLargeError, "").code) {
+			// There is no need to retry if the request body is too large
+			poster.PostEvent(StateEvent::Failure);
+			return;
 		}
 
 		switch (mode_) {

--- a/src/mender-update/deployments.hpp
+++ b/src/mender-update/deployments.hpp
@@ -63,6 +63,7 @@ enum DeploymentsErrorCode {
 	BadResponseError,
 	DeploymentAbortedError,
 	TooManyRequestsError,
+	RequestBodyTooLargeError,
 };
 
 class DeploymentsErrorCategoryClass : public std::error_category {

--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -68,6 +68,8 @@ string DeploymentsErrorCategoryClass::message(int code) const {
 		return "Deployment was aborted on the server";
 	case TooManyRequestsError:
 		return "Too many requests";
+	case RequestBodyTooLargeError:
+		return "Request body too large";
 	}
 	assert(false);
 	return "Unknown";
@@ -661,6 +663,8 @@ error::Error DeploymentClient::PushLogs(
 
 			// StatusTooManyRequests must have been handled in PushLogsHeaderHandler already
 			assert(status != http::StatusTooManyRequests);
+			// StatusRequestBodyTooLarge must have been handled in PushLogsHeaderHandler already
+			assert(status != http::StatusRequestBodyTooLarge);
 
 			if (status == http::StatusNoContent) {
 				api_handler(LogsAPIResponse {status, nullopt, error::NoError});
@@ -699,6 +703,12 @@ void DeploymentClient::PushLogsHeaderHandler(
 	if (status == http::StatusTooManyRequests) {
 		LogsAPIResponse response = {
 			status, resp->GetHeaders(), MakeError(TooManyRequestsError, "Too many requests")};
+		api_handler(response);
+	} else if (status == http::StatusRequestBodyTooLarge) {
+		LogsAPIResponse response = {
+			status,
+			resp->GetHeaders(),
+			MakeError(RequestBodyTooLargeError, "Could not send logs to server")};
 		api_handler(response);
 	}
 	auto content_length = resp->GetHeader("Content-Length");

--- a/tests/src/mender-update/deployments_test.cpp
+++ b/tests/src/mender-update/deployments_test.cpp
@@ -857,6 +857,7 @@ TEST_F(DeploymentsTests, PushStatusFailureTest) {
 	const string response_data = R"({"error": "Access denied", "response-id": "some id here"})";
 
 	bool aborted_failure = false;
+	bool request_body_too_large = false;
 
 	vector<uint8_t> received_body;
 	server.AsyncServeUrl(
@@ -875,8 +876,12 @@ TEST_F(DeploymentsTests, PushStatusFailureTest) {
 			received_body.resize(ex_len.value());
 			req->SetBodyWriter(body_writer);
 		},
-		[&received_body, &expected_request_data, &response_data, deployment_id, &aborted_failure](
-			http::ExpectedIncomingRequestPtr exp_req) {
+		[&received_body,
+		 &expected_request_data,
+		 &response_data,
+		 deployment_id,
+		 &aborted_failure,
+		 &request_body_too_large](http::ExpectedIncomingRequestPtr exp_req) {
 			ASSERT_TRUE(exp_req) << exp_req.error().String();
 
 			auto req = exp_req.value();
@@ -892,7 +897,9 @@ TEST_F(DeploymentsTests, PushStatusFailureTest) {
 
 			resp->SetHeader("Content-Length", to_string(response_data.size()));
 			resp->SetBodyReader(make_shared<io::StringReader>(response_data));
-			if (aborted_failure) {
+			if (request_body_too_large) {
+				resp->SetStatusCodeAndMessage(413, "Request Body Too Large");
+			} else if (aborted_failure) {
 				resp->SetStatusCodeAndMessage(409, "Conflict");
 			} else {
 				resp->SetStatusCodeAndMessage(403, "Forbidden");
@@ -1537,6 +1544,8 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 
 	const string response_data = R"({"error": "Access denied", "response-id": "some id here"})";
 
+	bool request_body_too_large = false;
+
 	vector<uint8_t> received_body;
 	server.AsyncServeUrl(
 		TEST_SERVER,
@@ -1554,8 +1563,11 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 			received_body.resize(ex_len.value());
 			req->SetBodyWriter(body_writer);
 		},
-		[&received_body, &expected_request_data, &response_data, deployment_id](
-			http::ExpectedIncomingRequestPtr exp_req) {
+		[&received_body,
+		 &expected_request_data,
+		 &response_data,
+		 deployment_id,
+		 &request_body_too_large](http::ExpectedIncomingRequestPtr exp_req) {
 			ASSERT_TRUE(exp_req) << exp_req.error().String();
 
 			auto req = exp_req.value();
@@ -1571,7 +1583,11 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 
 			resp->SetHeader("Content-Length", to_string(response_data.size()));
 			resp->SetBodyReader(make_shared<io::StringReader>(response_data));
-			resp->SetStatusCodeAndMessage(403, "Forbidden");
+			if (request_body_too_large) {
+				resp->SetStatusCodeAndMessage(413, "Request Body Too Large");
+			} else {
+				resp->SetStatusCodeAndMessage(403, "Forbidden");
+			}
 			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
 		});
 
@@ -1586,6 +1602,26 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 			EXPECT_THAT(resp.error.message, testing::HasSubstr("Got unexpected response"));
 			EXPECT_THAT(resp.error.message, testing::HasSubstr("403"));
 			EXPECT_THAT(resp.error.message, testing::HasSubstr("Access denied"));
+			loop.Stop();
+		});
+	EXPECT_EQ(err, error::NoError);
+
+	loop.Run();
+	EXPECT_TRUE(handler_called);
+
+	// Redo with 413 Request Body Too Large
+	handler_called = false;
+	request_body_too_large = true;
+
+	err = deps::DeploymentClient().PushLogs(
+		deployment_id,
+		test_log_file_path,
+		client,
+		[&handler_called, &loop](deps::StatusAPIResponse resp) {
+			handler_called = true;
+			EXPECT_NE(resp.error, error::NoError);
+			EXPECT_EQ(resp.error.code, deps::MakeError(deps::RequestBodyTooLargeError, "").code);
+			EXPECT_THAT(resp.error.message, testing::HasSubstr("Could not send logs to server"));
 			loop.Stop();
 		});
 	EXPECT_EQ(err, error::NoError);


### PR DESCRIPTION
Changelog: Added an explicit check for 413 Request Body Too Large errors when sending deployment logs in order to not go into an unnecessary retry loop when the deployment logs are too big.
Ticket: ME-616
