### PR TITLE
fix: Don't retry status update on 413

### DIFF
--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -137,7 +137,10 @@ error::Error HTTPClient::AsyncCall(
 					}
 					auto resp = ex_resp.value();
 					auto status = resp->GetStatusCode();
-					if (status != http::StatusUnauthorized) {
+					// 401, 413, and 429 handled by the header handler. Don't call the body handler.
+					if (status != http::StatusUnauthorized
+						&& status != http::StatusRequestBodyTooLarge
+						&& status != http::StatusTooManyRequests) {
 						body_handler(ex_resp);
 					}
 					// 401 handled by the header handler

--- a/src/common/http.hpp
+++ b/src/common/http.hpp
@@ -115,6 +115,8 @@ enum StatusCode {
 	StatusUnauthorized = 401,
 	StatusNotFound = 404,
 	StatusConflict = 409,
+	StatusRequestBodyTooLarge = 413,
+	StatusTooManyRequests = 429,
 
 	StatusInternalServerError = 500,
 	StatusNotImplemented = 501,

--- a/src/mender-update/daemon/states.cpp
+++ b/src/mender-update/daemon/states.cpp
@@ -570,6 +570,12 @@ void SendStatusUpdateState::DoStatusUpdate(Context &ctx, sm::EventPoster<StateEv
 				// failure, even if retry is enabled.
 				poster.PostEvent(StateEvent::DeploymentAborted);
 				return;
+			} else if (
+				err.code
+				== deployments::MakeError(deployments::RequestBodyTooLargeError, "").code) {
+				// There is no need to retry if the request body is too large
+				poster.PostEvent(StateEvent::Failure);
+				return;
 			}
 
 			switch (mode_) {

--- a/src/mender-update/deployments.hpp
+++ b/src/mender-update/deployments.hpp
@@ -59,6 +59,8 @@ enum DeploymentsErrorCode {
 	InvalidDataError,
 	BadResponseError,
 	DeploymentAbortedError,
+	TooManyRequestsError,
+	RequestBodyTooLargeError,
 };
 
 class DeploymentsErrorCategoryClass : public std::error_category {

--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -66,6 +66,10 @@ string DeploymentsErrorCategoryClass::message(int code) const {
 		return "Bad response error";
 	case DeploymentAbortedError:
 		return "Deployment was aborted on the server";
+	case TooManyRequestsError:
+		return "Too many requests";
+	case RequestBodyTooLargeError:
+		return "Request body too large";
 	}
 	assert(false);
 	return "Unknown";
@@ -646,8 +650,14 @@ error::Error DeploymentClient::PushLogs(
 
 			auto resp = exp_resp.value();
 			auto status = resp->GetStatusCode();
+
 			if (status == http::StatusNoContent) {
 				api_handler(error::NoError);
+			} else if (status == http::StatusRequestBodyTooLarge) {
+				// Don't retry if the request body is too large
+				api_handler(MakeError(
+					RequestBodyTooLargeError,
+					"Could not send logs to server: request body too large"));
 			} else {
 				auto ex_err_msg = api::ErrorMsgFromErrorResponse(*received_body);
 				string err_str;
@@ -662,7 +672,6 @@ error::Error DeploymentClient::PushLogs(
 			}
 		});
 }
-
 } // namespace deployments
 } // namespace update
 } // namespace mender

--- a/tests/src/mender-update/deployments_test.cpp
+++ b/tests/src/mender-update/deployments_test.cpp
@@ -1583,6 +1583,8 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 
 	const string response_data = R"({"error": "Access denied", "response-id": "some id here"})";
 
+	bool request_body_too_large = false;
+
 	vector<uint8_t> received_body;
 	server.AsyncServeUrl(
 		TEST_SERVER,
@@ -1600,8 +1602,11 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 			received_body.resize(ex_len.value());
 			req->SetBodyWriter(body_writer);
 		},
-		[&received_body, &expected_request_data, &response_data, deployment_id](
-			http::ExpectedIncomingRequestPtr exp_req) {
+		[&received_body,
+		 &expected_request_data,
+		 &response_data,
+		 deployment_id,
+		 &request_body_too_large](http::ExpectedIncomingRequestPtr exp_req) {
 			ASSERT_TRUE(exp_req) << exp_req.error().String();
 
 			auto req = exp_req.value();
@@ -1617,7 +1622,11 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 
 			resp->SetHeader("Content-Length", to_string(response_data.size()));
 			resp->SetBodyReader(make_shared<io::StringReader>(response_data));
-			resp->SetStatusCodeAndMessage(403, "Forbidden");
+			if (request_body_too_large) {
+				resp->SetStatusCodeAndMessage(413, "Request Body Too Large");
+			} else {
+				resp->SetStatusCodeAndMessage(403, "Forbidden");
+			}
 			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
 		});
 
@@ -1632,6 +1641,26 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 			EXPECT_THAT(resp.message, testing::HasSubstr("Got unexpected response"));
 			EXPECT_THAT(resp.message, testing::HasSubstr("403"));
 			EXPECT_THAT(resp.message, testing::HasSubstr("Access denied"));
+			loop.Stop();
+		});
+	EXPECT_EQ(err, error::NoError);
+
+	loop.Run();
+	EXPECT_TRUE(handler_called);
+
+	// Redo with 413 Request Body Too Large
+	handler_called = false;
+	request_body_too_large = true;
+
+	err = deps::DeploymentClient().PushLogs(
+		deployment_id,
+		test_log_file_path,
+		client,
+		[&handler_called, &loop](deps::StatusAPIResponse resp) {
+			handler_called = true;
+			EXPECT_NE(resp, error::NoError);
+			EXPECT_EQ(resp.code, deps::MakeError(deps::RequestBodyTooLargeError, "").code);
+			EXPECT_THAT(resp.message, testing::HasSubstr("Could not send logs to server"));
 			loop.Stop();
 		});
 	EXPECT_EQ(err, error::NoError);


### PR DESCRIPTION
Manual cherry-pick of https://github.com/mendersoftware/mender/pull/1911

There has been some refactoring in this part of the codebase, so I had to manually check 413 directly in the PushLogs body handler and check 413 directly in the result_handler in DoStatusUpdate. The rest should be the same.