### PR TITLE
fix: Fail when device tier is invalid instead of warning

### DIFF
--- a/src/client_shared/conf/conf.cpp
+++ b/src/client_shared/conf/conf.cpp
@@ -311,8 +311,8 @@ error::Error MenderConfig::LoadConfigFile_(const string &path, bool required) {
 			return error::NoError;
 		} else {
 			// other errors (parsing errors,...) for default paths should produce warnings
-			log::Warning("Failed to load config from '" + path + "': " + ret.error().message);
-			return error::NoError;
+			log::Error("Failed to load config from '" + path + "': " + ret.error().message);
+			return ret.error();
 		}
 	}
 	// else

--- a/src/client_shared/conf/conf.cpp
+++ b/src/client_shared/conf/conf.cpp
@@ -34,6 +34,7 @@ namespace error = mender::common::error;
 namespace expected = mender::common::expected;
 namespace log = mender::common::log;
 namespace json = mender::common::json;
+namespace config_parser = mender::client_shared::config_parser;
 
 const string kMenderVersion = MENDER_VERSION;
 
@@ -310,6 +311,13 @@ error::Error MenderConfig::LoadConfigFile_(const string &path, bool required) {
 			log::Debug("Failed to load config from '" + path + "': " + ret.error().message);
 			return error::NoError;
 		} else {
+			// Incorrect DeviceTier shall lead to the daemon failure
+			auto device_tier_error = config_parser::MakeError(
+				config_parser::ConfigParserErrorCode::DeviceTierError, "Invalid DeviceTier");
+			if (ret.error().code == device_tier_error.code) {
+				log::Error("Failed to get DeviceTier from '" + path + "': " + ret.error().message);
+				return ret.error();
+			}
 			// other errors (parsing errors,...) for default paths should produce warnings
 			log::Warning("Failed to load config from '" + path + "': " + ret.error().message);
 			return error::NoError;

--- a/src/client_shared/config_parser.hpp
+++ b/src/client_shared/config_parser.hpp
@@ -58,6 +58,7 @@ struct ClientSecurity {
 enum ConfigParserErrorCode {
 	NoError = 0,
 	ValidationError,
+	DeviceTierError,
 };
 
 class ConfigParserErrorCategoryClass : public std::error_category {

--- a/src/client_shared/config_parser/config_parser.cpp
+++ b/src/client_shared/config_parser/config_parser.cpp
@@ -113,7 +113,7 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 			const string &tier = e_cfg_string.value();
 			if (!device_tier::IsValid(tier)) {
 				auto err = MakeError(
-					ConfigParserErrorCode::ValidationError, "Invalid DeviceTier: " + tier);
+					ConfigParserErrorCode::DeviceTierError, "Invalid DeviceTier: " + tier);
 				return expected::unexpected(err);
 			}
 			this->device_tier = tier;

--- a/tests/src/client_shared/config_parser_test.cpp
+++ b/tests/src/client_shared/config_parser_test.cpp
@@ -725,6 +725,6 @@ TEST_F(ConfigParserTests, DeviceTierInvalidConfiguration) {
 	config_parser::MenderConfigFromFile mc;
 	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
 	ASSERT_FALSE(ret);
-	EXPECT_EQ(ret.error().code, config_parser::MakeError(config_parser::ValidationError, "").code);
+	EXPECT_EQ(ret.error().code, config_parser::MakeError(config_parser::DeviceTierError, "").code);
 	EXPECT_THAT(ret.error().String(), testing::HasSubstr("Invalid DeviceTier: foobar"));
 }


### PR DESCRIPTION
Changelog: Fail when device tier has invalid value
Ticket: ME-636