### PR TITLE
chore: Add an alternative implementation of KeyValueDatabase

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,18 @@ test:unit:
   script:
     - cmake -D COVERAGE=ON .
     - make --jobs=$(nproc --all) --keep-going coverage
+    # Clean things up for another round of coverage data gathering
+    - mv coverage.lcov coverage_base.lcov
+    - make clean
+    - find . \( -name '*.gcda' -o -name '*.gcno' \) -exec rm '{}' \;
+    # Now run key-value DB tests without LMDB (thus testing BlobDB)
+    - cmake -D COVERAGE=ON -D MENDER_USE_LMDB=OFF .
+    - make key_value_database_test
+    - tests/src/common/key_value_database_test
+    - make coverage_no_tests
+    - mv coverage.lcov coverage_no_lmdb.lcov
+    # And combine the coverage data
+    - lcov -a 'coverage_*.lcov' -o coverage.lcov --ignore-errors inconsistent
   artifacts:
     expire_in: 2w
     reports:

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -129,6 +129,11 @@ if(MENDER_USE_LMDB)
     common
     common_log
   )
+else()
+  target_link_libraries(common_key_value_database PUBLIC common_cpp)
+  target_include_directories(common_key_value_database PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+  # TODO: make the blob implementation select-able (when we have multiple)
+  target_sources(common_key_value_database PRIVATE key_value_database/platform/blobdb/blobdb.cpp key_value_database/platform/blobdb/file_blob.cpp)
 endif()
 
 add_library(common_events STATIC

--- a/src/common/key_value_database.cpp
+++ b/src/common/key_value_database.cpp
@@ -48,6 +48,33 @@ Error MakeError(ErrorCode code, const string &msg) {
 	return Error(error_condition(code, KeyValueDatabaseErrorCategory), msg);
 }
 
+expected::ExpectedBytes KeyValueDatabase::Read(const string &key) {
+	vector<uint8_t> ret;
+	auto err = ReadTransaction([&key, &ret](Transaction &txn) -> error::Error {
+		auto result = txn.Read(key);
+		if (result) {
+			ret = std::move(result.value());
+			return error::NoError;
+		} else {
+			return result.error();
+		}
+	});
+	if (mender::common::error::NoError != err) {
+		return expected::unexpected(err);
+	} else {
+		return ret;
+	}
+}
+
+error::Error KeyValueDatabase::Write(const string &key, const vector<uint8_t> &value) {
+	return WriteTransaction(
+		[&key, &value](Transaction &txn) -> error::Error { return txn.Write(key, value); });
+}
+
+error::Error KeyValueDatabase::Remove(const string &key) {
+	return WriteTransaction([&key](Transaction &txn) -> error::Error { return txn.Remove(key); });
+}
+
 Error ReadString(Transaction &txn, const string &key, string &value_str, bool missing_ok) {
 	auto ex_bytes = txn.Read(key);
 	if (!ex_bytes) {

--- a/src/common/key_value_database.hpp
+++ b/src/common/key_value_database.hpp
@@ -50,6 +50,9 @@ enum ErrorCode {
 
 	// LMDB can apparently return this, but it should not happen.
 	AlreadyExistsError,
+
+	// When a read transaction is attempted to be used for writing.
+	TransactionError,
 };
 using Error = mender::common::error::Error;
 

--- a/src/common/key_value_database.hpp
+++ b/src/common/key_value_database.hpp
@@ -70,6 +70,10 @@ class KeyValueDatabase : virtual public Transaction {
 public:
 	virtual Error WriteTransaction(function<Error(Transaction &)> txnFunc) = 0;
 	virtual Error ReadTransaction(function<Error(Transaction &)> txnFunc) = 0;
+
+	expected::ExpectedBytes Read(const string &key) override;
+	error::Error Write(const string &key, const vector<uint8_t> &value) override;
+	error::Error Remove(const string &key) override;
 };
 
 Error MakeError(ErrorCode code, const string &msg);

--- a/src/common/key_value_database/platform/blobdb/blobdb.cpp
+++ b/src/common/key_value_database/platform/blobdb/blobdb.cpp
@@ -1,0 +1,161 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/key_value_database_blobdb.hpp>
+#include <common/key_value_database/platform/blobdb/file_blob.hpp>
+
+#include <limits>
+#include <unordered_map>
+
+#include <common/common.hpp>
+#include <common/error.hpp>
+#include <common/expected.hpp>
+#include <common/io.hpp>
+#include <common/log.hpp>
+#include <common/path.hpp>
+
+namespace mender {
+namespace common {
+namespace key_value_database {
+
+namespace common = mender::common;
+namespace io = mender::common::io;
+namespace log = mender::common::log;
+namespace path = mender::common::path;
+
+
+expected::ExpectedBytes BlobdbTransaction::Read(const string &key) {
+	if (!db_) {
+		auto ex_db = DeserializeDB();
+		if (!ex_db) {
+			return expected::unexpected(ex_db.error().WithContext("Cannot read DB contents"));
+		}
+		db_ = make_unique<DB>(std::move(ex_db.value()));
+	}
+	if (!common::MapContainsStringKey(*db_, key)) {
+		return expected::unexpected(MakeError(KeyError, "Key " + key + " not found in database"));
+	}
+
+	return db_->at(key);
+}
+
+error::Error BlobdbTransaction::Write(const string &key, const vector<uint8_t> &value) {
+	if (!write_) {
+		return MakeError(TransactionError, "Cannot write in a read transaction");
+	}
+	if (!db_) {
+		auto ex_db = DeserializeDB();
+		if (!ex_db) {
+			return ex_db.error().WithContext("Cannot read DB contents");
+		}
+		db_ = make_unique<DB>(std::move(ex_db.value()));
+	}
+
+	(*db_)[key] = value;
+	return error::NoError;
+}
+
+error::Error BlobdbTransaction::Remove(const string &key) {
+	if (!write_) {
+		return MakeError(TransactionError, "Cannot remove in a read transaction");
+	}
+
+	if (!db_) {
+		auto ex_db = DeserializeDB();
+		if (!ex_db) {
+			return ex_db.error().WithContext("Cannot read DB contents");
+		}
+		db_ = make_unique<DB>(std::move(ex_db.value()));
+	}
+	db_->erase(key);
+	return error::NoError;
+}
+
+error::Error BlobdbTransaction::Commit() {
+	if (!db_) {
+		// nothing to commit
+		return error::NoError;
+	}
+	// write the in-memory DB to persistent storage
+	auto err = SerializeDB(*db_);
+	db_.reset();
+	return err;
+}
+
+error::Error BlobdbTransaction::Abort() {
+	// just throw away the in-memory DB
+	db_.reset();
+	return error::NoError;
+}
+
+BlobdbTransaction::~BlobdbTransaction() {
+	auto err = Abort();
+	if (err != error::NoError) {
+		log::Error(
+			"Uncommitted key-value DB transaction destroyed and abort failed: " + err.message);
+	}
+}
+
+error::Error KeyValueDatabaseBlobdb::Open(const string &db_path_or_name) {
+	db_path_or_name_ = db_path_or_name;
+
+	return error::NoError;
+}
+
+error::Error KeyValueDatabaseBlobdb::Close() {
+	return error::NoError;
+}
+
+error::Error KeyValueDatabaseBlobdb::RunTransaction(
+	bool write, function<error::Error(Transaction &)> txnFunc) {
+	FileBlobdbTransaction txn {db_path_or_name_, write};
+	auto err = txn.LockDB();
+	if (err != error::NoError) {
+		return err;
+	}
+	err = txnFunc(txn);
+	if (err == error::NoError) {
+		err = txn.Commit();
+	} else {
+		// There is no way txn.Abort() could return an error now, but let's be
+		// safe in case of future changes.
+		auto ab_err = txn.Abort();
+		if (ab_err != error::NoError) {
+			err = err.FollowedBy(ab_err);
+		}
+	}
+	auto unlock_err = txn.UnlockDB();
+	if (unlock_err != error::NoError) {
+		if (err != error::NoError) {
+			return err.FollowedBy(unlock_err);
+		} else {
+			return unlock_err;
+		}
+	}
+	return err;
+}
+
+error::Error KeyValueDatabaseBlobdb::WriteTransaction(
+	function<error::Error(Transaction &)> txnFunc) {
+	return RunTransaction(true, txnFunc);
+}
+
+error::Error KeyValueDatabaseBlobdb::ReadTransaction(
+	function<error::Error(Transaction &)> txnFunc) {
+	return RunTransaction(false, txnFunc);
+}
+
+} // namespace key_value_database
+} // namespace common
+} // namespace mender

--- a/src/common/key_value_database/platform/blobdb/file_blob.cpp
+++ b/src/common/key_value_database/platform/blobdb/file_blob.cpp
@@ -1,0 +1,195 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <common/key_value_database_blobdb.hpp>
+#include <common/key_value_database/platform/blobdb/file_blob.hpp>
+
+// We need these two C headers for open() and close(), respectively, because we
+// need to do flock() and there's no C++ API for that.
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/file.h> // flock()
+
+#include <cerrno>
+#include <cstdio>
+
+#include <common/path.hpp>
+
+namespace mender {
+namespace common {
+namespace key_value_database {
+
+namespace path = common::path;
+
+error::Error FileBlobdbTransaction::SerializeDB(const DB &db) {
+	// There can be no collision because no two transactions can be serializing
+	// the DB at the same time so no random/special name needed here.
+	string new_file_path = path_or_name_ + ".new";
+	auto ex_ofs = io::OpenOfstream(new_file_path);
+	if (!ex_ofs) {
+		return ex_ofs.error().WithContext("Cannot save DB contents");
+	}
+	auto &ofs = ex_ofs.value();
+
+	auto err = error::NoError;
+	for (const auto &kv : db) {
+		if (kv.first.size() > std::numeric_limits<uint32_t>::max()) {
+			err = error::Error(
+				generic_category().default_error_condition(EOVERFLOW),
+				"Key data too long, cannot be serialized");
+			break;
+		}
+		if (kv.second.size() > std::numeric_limits<uint32_t>::max()) {
+			err = error::Error(
+				generic_category().default_error_condition(EOVERFLOW),
+				"Value data too long, cannot be serialized");
+			break;
+		}
+		uint32_t data_size = static_cast<uint32_t>(kv.first.size());
+		ofs.write(reinterpret_cast<const char *>(&data_size), sizeof(data_size));
+		if (!ofs) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to write key size");
+			break;
+		}
+		ofs.write(kv.first.data(), kv.first.size());
+		if (!ofs) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to write key data");
+			break;
+		}
+		data_size = static_cast<uint32_t>(kv.second.size());
+		ofs.write(reinterpret_cast<const char *>(&data_size), sizeof(data_size));
+		if (!ofs) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to write value size");
+			break;
+		}
+		ofs.write(reinterpret_cast<const char *>(kv.second.data()), kv.second.size());
+		if (!ofs) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to write value data");
+			break;
+		}
+	}
+	ofs.close();
+
+	if (err == error::NoError) {
+		if (std::rename(new_file_path.c_str(), path_or_name_.c_str()) != 0) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to replace DB contents");
+		}
+	}
+	if (err != error::NoError) {
+		std::remove(new_file_path.c_str());
+	}
+	return err;
+}
+
+ExpectedDB FileBlobdbTransaction::DeserializeDB() {
+	if (!path::FileExists(path_or_name_)) {
+		return DB();
+	}
+	auto ex_ifs = io::OpenIfstream(path_or_name_);
+	if (!ex_ifs) {
+		return expected::unexpected(ex_ifs.error().WithContext("Cannot load DB contents"));
+	}
+	auto &ifs = ex_ifs.value();
+
+	auto err = error::NoError;
+	DB loaded;
+	while (ifs) {
+		uint32_t data_size = 0;
+		ifs.read(reinterpret_cast<char *>(&data_size), sizeof(data_size));
+		if (data_size == 0) {
+			if (!ifs.eof()) {
+				err = error::Error(
+					generic_category().default_error_condition(errno), "Failed to read key size");
+			}
+			break;
+		}
+		auto key = string(data_size, '\0');
+		ifs.read(key.data(), data_size);
+		if ((!ifs && !ifs.eof()) || (ifs.gcount() != data_size)) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to read key data");
+			break;
+		}
+		data_size = 0;
+		ifs.read(reinterpret_cast<char *>(&data_size), sizeof(data_size));
+		if (data_size == 0) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to read value size");
+			break;
+		}
+		auto value = vector<uint8_t>(data_size);
+		ifs.read(reinterpret_cast<char *>(value.data()), data_size);
+		if ((!ifs && !ifs.eof()) || (ifs.gcount() != data_size)) {
+			err = error::Error(
+				generic_category().default_error_condition(errno), "Failed to read value data");
+			break;
+		}
+		loaded[key] = value;
+	}
+	if (err == error::NoError && !ifs.eof()) {
+		err = error::Error(
+			generic_category().default_error_condition(errno), "Error while reading DB data");
+	}
+
+	if (err != error::NoError) {
+		return expected::unexpected(err);
+	}
+	return loaded;
+}
+
+error::Error FileBlobdbTransaction::LockDB() {
+	fd_ = open(path_or_name_.c_str(), O_RDONLY | O_CREAT, S_IRUSR | S_IWUSR);
+	if (fd_ == -1) {
+		return error::Error(
+			generic_category().default_error_condition(errno),
+			"Failed to open DB at '" + path_or_name_ + "'");
+	}
+
+	int ret;
+	if (write_) {
+		ret = flock(fd_, LOCK_EX);
+	} else {
+		ret = flock(fd_, LOCK_SH);
+	}
+	if (ret != 0) {
+		auto flock_errno = errno;
+		close(fd_);
+		fd_ = -1;
+		return error::Error(
+			generic_category().default_error_condition(flock_errno),
+			"Failed to lock DB '" + path_or_name_ + "'");
+	}
+
+	return error::NoError;
+}
+
+error::Error FileBlobdbTransaction::UnlockDB() {
+	errno = 0;
+	close(fd_);
+	if (errno != 0) {
+		return error::Error(
+			generic_category().default_error_condition(errno),
+			"Failed to release lock on DB '" + path_or_name_ + "'");
+	}
+	return error::NoError;
+}
+
+} // namespace key_value_database
+} // namespace common
+} // namespace mender

--- a/src/common/key_value_database/platform/blobdb/file_blob.hpp
+++ b/src/common/key_value_database/platform/blobdb/file_blob.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_FILE_BLOBDB_HPP
+#define MENDER_COMMON_FILE_BLOBDB_HPP
+
+#include <common/key_value_database_blobdb.hpp>
+
+namespace mender {
+namespace common {
+namespace key_value_database {
+
+class FileBlobdbTransaction : public BlobdbTransaction {
+public:
+	FileBlobdbTransaction(const string &path_or_name, bool write) :
+		BlobdbTransaction(path_or_name, write) {};
+
+	error::Error SerializeDB(const DB &db) override;
+	ExpectedDB DeserializeDB() override;
+	error::Error LockDB() override;
+	error::Error UnlockDB() override;
+
+private:
+	int fd_ = -1;
+};
+
+} // namespace key_value_database
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_FILE_BLOBDB_HPP

--- a/src/common/key_value_database/platform/lmdb/lmdb.cpp
+++ b/src/common/key_value_database/platform/lmdb/lmdb.cpp
@@ -150,33 +150,6 @@ void KeyValueDatabaseLmdb::Close() {
 	env_.reset();
 }
 
-expected::ExpectedBytes KeyValueDatabaseLmdb::Read(const string &key) {
-	vector<uint8_t> ret;
-	auto err = ReadTransaction([&key, &ret](Transaction &txn) -> error::Error {
-		auto result = txn.Read(key);
-		if (result) {
-			ret = std::move(result.value());
-			return error::NoError;
-		} else {
-			return result.error();
-		}
-	});
-	if (mender::common::error::NoError != err) {
-		return expected::unexpected(err);
-	} else {
-		return ret;
-	}
-}
-
-error::Error KeyValueDatabaseLmdb::Write(const string &key, const vector<uint8_t> &value) {
-	return WriteTransaction(
-		[&key, &value](Transaction &txn) -> error::Error { return txn.Write(key, value); });
-}
-
-error::Error KeyValueDatabaseLmdb::Remove(const string &key) {
-	return WriteTransaction([&key](Transaction &txn) -> error::Error { return txn.Remove(key); });
-}
-
 error::Error KeyValueDatabaseLmdb::WriteTransaction(function<error::Error(Transaction &)> txnFunc) {
 	AssertOrReturnError(env_);
 

--- a/src/common/key_value_database_blobdb.hpp
+++ b/src/common/key_value_database_blobdb.hpp
@@ -1,0 +1,79 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef MENDER_COMMON_BLOBDB_HPP
+#define MENDER_COMMON_BLOBDB_HPP
+
+#include <common/error.hpp>
+#include <common/expected.hpp>
+#include <common/key_value_database.hpp>
+
+namespace mender {
+namespace common {
+namespace key_value_database {
+
+namespace error = mender::common::error;
+namespace expected = mender::common::expected;
+
+using DB = unordered_map<string, vector<uint8_t>>;
+using ExpectedDB = expected::expected<DB, error::Error>;
+
+class BlobdbTransaction : public Transaction {
+public:
+	BlobdbTransaction(const string &path_or_name, bool write) :
+		path_or_name_ {path_or_name},
+		write_ {write} {};
+
+	virtual ~BlobdbTransaction();
+
+	expected::ExpectedBytes Read(const string &key) override;
+	error::Error Write(const string &key, const vector<uint8_t> &value) override;
+	error::Error Remove(const string &key) override;
+
+	error::Error Commit();
+	error::Error Abort();
+
+	virtual error::Error SerializeDB(const DB &db) = 0;
+	virtual ExpectedDB DeserializeDB() = 0;
+	virtual error::Error LockDB() = 0;
+	virtual error::Error UnlockDB() = 0;
+
+protected:
+	const string path_or_name_;
+	bool write_;
+
+private:
+	unique_ptr<DB> db_;
+};
+
+// Note: Using KeyValueDatabaseBlobdb from multiple threads is not
+// safe, but using separate instances to access the same database is safe.
+class KeyValueDatabaseBlobdb : public KeyValueDatabase {
+public:
+	error::Error Open(const string &path_or_name);
+	error::Error Close();
+
+	error::Error WriteTransaction(function<error::Error(Transaction &)> txnFunc) override;
+	error::Error ReadTransaction(function<error::Error(Transaction &)> txnFunc) override;
+
+private:
+	error::Error RunTransaction(bool write, function<error::Error(Transaction &)> txnFunc);
+	string db_path_or_name_;
+};
+
+} // namespace key_value_database
+} // namespace common
+} // namespace mender
+
+#endif // MENDER_COMMON_BLOBDB_HPP

--- a/src/common/key_value_database_lmdb.hpp
+++ b/src/common/key_value_database_lmdb.hpp
@@ -52,9 +52,6 @@ public:
 	error::Error Open(const string &path);
 	void Close();
 
-	expected::ExpectedBytes Read(const string &key) override;
-	error::Error Write(const string &key, const vector<uint8_t> &value) override;
-	error::Error Remove(const string &key) override;
 	error::Error WriteTransaction(function<error::Error(Transaction &)> txnFunc) override;
 	error::Error ReadTransaction(function<error::Error(Transaction &)> txnFunc) override;
 

--- a/src/mender-update/context.hpp
+++ b/src/mender-update/context.hpp
@@ -28,7 +28,7 @@
 #ifdef MENDER_USE_LMDB
 #include <common/key_value_database_lmdb.hpp>
 #else
-#error MenderContext requires LMDB
+#include <common/key_value_database_blobdb.hpp>
 #endif // MENDER_USE_LMDB
 
 namespace mender {
@@ -158,6 +158,8 @@ public:
 private:
 #ifdef MENDER_USE_LMDB
 	kv_db::KeyValueDatabaseLmdb mender_store_;
+#else
+	kv_db::KeyValueDatabaseBlobdb mender_store_;
 #endif // MENDER_USE_LMDB
 	conf::MenderConfig &config_;
 };

--- a/src/mender-update/context/context.cpp
+++ b/src/mender-update/context/context.cpp
@@ -107,7 +107,6 @@ error::Error MakeError(MenderContextErrorCode code, const string &msg) {
 }
 
 error::Error MenderContext::Initialize() {
-#ifdef MENDER_USE_LMDB
 	auto err = mender_store_.Open(path::Join(config_.paths.GetDataStore(), "mender-store"));
 	if (error::NoError != err) {
 		return err;
@@ -125,9 +124,6 @@ error::Error MenderContext::Initialize() {
 	}
 
 	return error::NoError;
-#else
-	return error::NoError;
-#endif
 }
 
 kv_db::KeyValueDatabase &MenderContext::GetMenderStoreDB() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_custom_target(coverage_no_tests
                --exclude '*_test.*'
                --exclude '*/googlemock/*'
                --exclude '*/vendor/*'
+               --ignore-errors unused
 )
 
 # CMake is not clever enough to build the tests before running them so we use

--- a/tests/src/common/key_value_database_test.cpp
+++ b/tests/src/common/key_value_database_test.cpp
@@ -19,6 +19,8 @@
 
 #ifdef MENDER_USE_LMDB
 #include <common/key_value_database_lmdb.hpp>
+#else
+#include <common/key_value_database_blobdb.hpp>
 #endif
 
 #include <cstdio>
@@ -58,6 +60,14 @@ static vector<KeyValueDatabaseSetup> GenerateDatabaseSetups() {
 	auto err = lmdb_db->Open(elem.tmpdir->Path() + "mender-store");
 	assert(err == error::NoError);
 	elem.db = lmdb_db;
+	ret.push_back(elem);
+#else
+	elem.name = "BlobDB";
+	elem.tmpdir = std::make_shared<mender::common::testing::TemporaryDirectory>();
+	auto blob_db = std::make_shared<kvdb::KeyValueDatabaseBlobdb>();
+	auto err = blob_db->Open(elem.tmpdir->Path() + "/mender-store");
+	assert(err == error::NoError);
+	elem.db = blob_db;
 	ret.push_back(elem);
 #endif
 


### PR DESCRIPTION
Probably the most trivial one just using a single blob stored in
persistent storage (a file, for now, on POSIX systems) and using
basic synchronization primitives (`flock()` on the file, for
now). The goal is to be able to build the client without LMDB
and, instead, use a more portable alternative still good enough
for our trivial use-case.

Ticket: MEN-9129
Changelog: none
Signed-off-by: Vratislav Podzimek <vratislav.podzimek+auto-signed@northern.tech>