### PR TITLE
feat: Make mender-device-identity work on both Linux and QNX

### DIFF
--- a/support/mender-device-identity
+++ b/support/mender-device-identity
@@ -13,49 +13,73 @@
 # mac=de:ad:ca:fe:00:01
 # cpuid=1112233
 #
-# The example script collects the MAC address of a network interface with the
+# == Linux ==
+# This example script collects the MAC address of a network interface with the
 # type ARPHRD_ETHER and it will pick the interface with the lowest ifindex
 # number if there are multiple interfaces with that type. The identity data is
 # output in the following format:
 #
 # mac=00:01:02:03:04:05
 #
+# == QNX ==
+# The identity data is in the same format, but the MAC address is the address of
+# the first device marked as active in the `ifconfig` output.
+#
 
 set -ue
 
-SCN=/sys/class/net
-min=65535
-arphrd_ether=1
-ifdev=
+case $(uname -s) in
+  Linux)
+    SCN=/sys/class/net
+    min=65535
+    arphrd_ether=1
+    ifdev=
 
-# find iface with lowest ifindex, skip non ARPHRD_ETHER types (lo, sit ...)
-for dev in $SCN/*; do
-    if [ ! -f "$dev/type" ]; then
-        continue
+    # find iface with lowest ifindex, skip non ARPHRD_ETHER types (lo, sit ...)
+    for dev in $SCN/*; do
+        if [ ! -f "$dev/type" ]; then
+            continue
+        fi
+
+        iftype=$(cat $dev/type)
+        if [ $iftype -ne $arphrd_ether ]; then
+            continue
+        fi
+
+        # Skip dummy interfaces
+        if echo "$dev" | grep -q "$SCN/dummy" 2>/dev/null; then
+    	continue
+        fi
+
+        idx=$(cat $dev/ifindex)
+        if [ $idx -lt $min ]; then
+            min=$idx
+            ifdev=$dev
+        fi
+    done
+
+    if [ -z "$ifdev" ]; then
+        echo "no suitable interfaces found" >&2
+        exit 1
+    else
+        echo "using interface $ifdev" >&2
+        # grab MAC address
+        echo "mac=$(cat $ifdev/address)"
     fi
+    ;;
 
-    iftype=$(cat $dev/type)
-    if [ $iftype -ne $arphrd_ether ]; then
-        continue
-    fi
-
-    # Skip dummy interfaces
-    if echo "$dev" | grep -q "$SCN/dummy" 2>/dev/null; then
-	continue
-    fi
-
-    idx=$(cat $dev/ifindex)
-    if [ $idx -lt $min ]; then
-        min=$idx
-        ifdev=$dev
-    fi
-done
-
-if [ -z "$ifdev" ]; then
-    echo "no suitable interfaces found" >&2
+  QNX)
+    nics=$(ifconfig | grep -E --only-matching '^[A-Za-z0-9_]+')
+    for nic in $nics; do
+      if ifconfig $nic | grep -q active; then
+        echo "using interface $nic" >&2
+        echo "mac=$(ifconfig $nic | sed -rn '/ether/s/\s+ether\s+//p')"
+        exit 0
+      else
+        echo "$nic not active" >&2
+      fi
+    done
+    echo "no suitable interface found" >&2
     exit 1
-else
-    echo "using interface $ifdev" >&2
-    # grab MAC address
-    echo "mac=$(cat $ifdev/address)"
-fi
+    ;;
+esac


### PR DESCRIPTION
This default/example script is used to provide Device Identity, i.e. a unique combination of key-value pairs. On Linux it relies on `/sys/class/net` contents to get the MAC address of a carefully-chosen NIC, on QNX it has to rely on `ifconfig` (no `/sys`) and it can choose the first NIC reported as active.

Ticket: MEN-9133
Changelog: none