### PR TITLE
fix: Fail when device tier is invalid

### DIFF
--- a/src/client_shared/conf/conf.cpp
+++ b/src/client_shared/conf/conf.cpp
@@ -34,6 +34,7 @@ namespace error = mender::common::error;
 namespace expected = mender::common::expected;
 namespace log = mender::common::log;
 namespace json = mender::common::json;
+namespace config_parser = mender::client_shared::config_parser;
 
 const string kMenderVersion = MENDER_VERSION;
 
@@ -308,6 +309,13 @@ error::Error MenderConfig::LoadConfigFile_(const string &path, bool required) {
 			log::Debug("Failed to load config from '" + path + "': " + ret.error().message);
 			return error::NoError;
 		} else {
+			// Incorrect DeviceTier shall lead to the daemon failure
+			auto device_tier_error = config_parser::MakeError(
+				config_parser::ConfigParserErrorCode::DeviceTierError, "Invalid DeviceTier");
+			if (ret.error().code == device_tier_error.code) {
+				log::Error("Failed to get DeviceTier from '" + path + "': " + ret.error().message);
+				return ret.error();
+			}
 			// other errors (parsing errors,...) for default paths should produce warnings
 			log::Warning("Failed to load config from '" + path + "': " + ret.error().message);
 			return error::NoError;

--- a/src/client_shared/config_parser.hpp
+++ b/src/client_shared/config_parser.hpp
@@ -56,6 +56,7 @@ struct ClientSecurity {
 enum ConfigParserErrorCode {
 	NoError = 0,
 	ValidationError,
+	DeviceTierError,
 };
 
 class ConfigParserErrorCategoryClass : public std::error_category {

--- a/src/client_shared/config_parser/config_parser.cpp
+++ b/src/client_shared/config_parser/config_parser.cpp
@@ -104,6 +104,22 @@ ExpectedBool MenderConfigFromFile::LoadFile(const string &path) {
 		}
 	}
 
+	e_cfg_value = cfg_json.Get("DeviceTier");
+	if (e_cfg_value) {
+		const json::Json value_json = e_cfg_value.value();
+		const json::ExpectedString e_cfg_string = value_json.GetString();
+		if (e_cfg_string) {
+			const string &tier = e_cfg_string.value();
+			if (!device_tier::IsValid(tier)) {
+				auto err = MakeError(
+					ConfigParserErrorCode::DeviceTierError, "Invalid DeviceTier: " + tier);
+				return expected::unexpected(err);
+			}
+			this->device_tier = tier;
+			applied = true;
+		}
+	}
+
 	e_cfg_value = cfg_json.Get("DaemonLogLevel");
 	if (e_cfg_value) {
 		const json::Json value_json = e_cfg_value.value();

--- a/tests/src/client_shared/config_parser_test.cpp
+++ b/tests/src/client_shared/config_parser_test.cpp
@@ -623,3 +623,75 @@ TEST_F(ConfigParserTests, CaseInsensitiveCollision) {
 	ASSERT_EQ(mc.servers.size(), 1);
 	EXPECT_EQ(mc.servers[0], "ServerURL_value_4");
 }
+
+TEST_F(ConfigParserTests, DeviceTierMicroConfiguration) {
+	ofstream os(test_config_fname);
+	os << R"({
+  "DeviceTier": "micro"
+})";
+	os.close();
+
+	config_parser::MenderConfigFromFile mc;
+	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
+	ASSERT_TRUE(ret) << ret.error().String();
+	EXPECT_TRUE(ret.value());
+
+	EXPECT_EQ(mc.device_tier, device_tier::kMicro);
+}
+
+TEST_F(ConfigParserTests, DeviceTierStandardConfiguration) {
+	ofstream os(test_config_fname);
+	os << R"({
+  "DeviceTier": "standard"
+})";
+	os.close();
+
+	config_parser::MenderConfigFromFile mc;
+	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
+	ASSERT_TRUE(ret) << ret.error().String();
+	EXPECT_TRUE(ret.value());
+
+	EXPECT_EQ(mc.device_tier, device_tier::kStandard);
+}
+
+TEST_F(ConfigParserTests, DeviceTierSystemConfiguration) {
+	ofstream os(test_config_fname);
+	os << R"({
+  "DeviceTier": "system"
+})";
+	os.close();
+
+	config_parser::MenderConfigFromFile mc;
+	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
+	ASSERT_TRUE(ret) << ret.error().String();
+	EXPECT_TRUE(ret.value());
+
+	EXPECT_EQ(mc.device_tier, device_tier::kSystem);
+}
+
+TEST_F(ConfigParserTests, DeviceTierAbsentConfiguration) {
+	ofstream os(test_config_fname);
+	os << R"({})";
+	os.close();
+
+	config_parser::MenderConfigFromFile mc;
+	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
+	ASSERT_TRUE(ret) << ret.error().String();
+	EXPECT_FALSE(ret.value());
+
+	EXPECT_EQ(mc.device_tier, device_tier::kStandard);
+}
+
+TEST_F(ConfigParserTests, DeviceTierInvalidConfiguration) {
+	ofstream os(test_config_fname);
+	os << R"({
+  "DeviceTier": "foobar"
+})";
+	os.close();
+
+	config_parser::MenderConfigFromFile mc;
+	config_parser::ExpectedBool ret = mc.LoadFile(test_config_fname);
+	ASSERT_FALSE(ret);
+	EXPECT_EQ(ret.error().code, config_parser::MakeError(config_parser::DeviceTierError, "").code);
+	EXPECT_THAT(ret.error().String(), testing::HasSubstr("Invalid DeviceTier: foobar"));
+}


### PR DESCRIPTION
DeviceTier is one of the configuration options but it is critical for how device is recognized by the server. When we will fail parsing it out of the configuration we should fail instead to switching to the `standard` device tier.

Ticket: ME-636

Changelog: none


(cherry picked from commit c0f2b20)