### PR TITLE
chore: remove extra comma from cmake config file

### DIFF
--- a/cmake/dist-package/mender.conf.in
+++ b/cmake/dist-package/mender.conf.in
@@ -1,4 +1,4 @@
 {
   "ServerURL": "@MENDER_SERVER_URL@",
-  "TenantToken": "@MENDER_TENANT_TOKEN@",
+  "TenantToken": "@MENDER_TENANT_TOKEN@"
 }


### PR DESCRIPTION
Fixes "Failed to load config from '/etc/mender/mender.conf'" errors when mender.conf.in has a trailing comma