### PR TITLE
chore: Add `MENDER_DIST_DEPS` build option

### DIFF
--- a/cmake/dist-package.cmake
+++ b/cmake/dist-package.cmake
@@ -14,6 +14,7 @@ set(MENDER_SERVER_URL "https://hosted.mender.io/" CACHE STRING "Server URL baked
 string(TOLOWER "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}" _MENDER_DEVICE_TYPE_DEFAULT)
 set(MENDER_DEVICE_TYPE "${_MENDER_DEVICE_TYPE_DEFAULT}" CACHE STRING "device_type baked into the dist-package /var/lib/mender/device_type")
 option(MENDER_BUILD_DIST_PACKAGE "Build the dist-package tarball as part of the default build" OFF)
+option(MENDER_DIST_DEPS "Include dependencies (dynamic libraries) in the dist-package tarball" OFF)
 
 # Clear potential stale configured files
 file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/dist-package)
@@ -54,12 +55,28 @@ function(_setup_dist_package)
     if(MENDER_BUILD_DIST_PACKAGE)
         list(APPEND _dp_target_args ALL)
     endif()
+    set(_extra_install_commands "")
+
+    if(MENDER_DIST_DEPS)
+        if(${CMAKE_SYSTEM_NAME} STREQUAL "QNX")
+            set(LOCAL_LIB_PATH ${CMAKE_SYSROOT}/$ENV{QNX_TARGET_ARCH}/usr/${CMAKE_INSTALL_LIBDIR})
+        else()
+            set(LOCAL_LIB_PATH ${CMAKE_SYSROOT}/usr/${CMAKE_INSTALL_LIBDIR})
+        endif()
+        message(STATUS "Including dependencies from ${LOCAL_LIB_PATH}")
+        set(TARGET_LIB_PATH ${STAGE_DIR}/usr/${CMAKE_INSTALL_LIBDIR})
+        list(APPEND _extra_install_commands COMMAND mkdir -p ${TARGET_LIB_PATH})
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/dist-package/install-deps.in ${CMAKE_BINARY_DIR}/dist-package/install-deps FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE @ONLY)
+        list(APPEND _extra_install_commands COMMAND ${CMAKE_BINARY_DIR}/dist-package/install-deps)
+    endif()
+
     add_custom_target(${_dp_target_args}
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${STAGE_DIR}
         COMMAND ${CMAKE_COMMAND} -E env DESTDIR=${STAGE_DIR} ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix /usr
         COMMAND ${CMAKE_COMMAND} -E env DESTDIR=${STAGE_DIR} ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix / --component mender-state-dir
         COMMAND ${CMAKE_COMMAND} -E env DESTDIR=${STAGE_DIR} ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix / --component mender-conf
         COMMAND ${CMAKE_COMMAND} -E env DESTDIR=${STAGE_DIR} ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix / --component mender-device-type
+        ${_extra_install_commands}
         COMMAND tar -czf mender-${MENDER_VERSION}.tar.gz --owner=0 --group=0 mender-${MENDER_VERSION}
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${STAGE_DIR}
         COMMAND ${CMAKE_COMMAND} -E echo "Created ${CMAKE_BINARY_DIR}/mender-${MENDER_VERSION}.tar.gz"

--- a/cmake/dist-package/install-deps.in
+++ b/cmake/dist-package/install-deps.in
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if ! which lddtree > /dev/null; then
+  echo "lddtree not found, please install it (most likely part of the pax-utils package)"
+  exit 1
+fi
+
+export LD_LIBRARY_PATH=@LOCAL_LIB_PATH@
+get_deps() {
+  # lddtree produces a tree-like output with
+  #   "SOMELIB.so => THE_PATH_TO_THE/SOMELIB.so"
+  # pairs or with "not found" as the path (but if things built and linked, we don't
+  # care, just skip those)
+  lddtree "@CMAKE_BINARY_DIR@/$1" 2>&1 | awk -F"=>" '/^\s+lib.*/ { print $2; }' | sort | uniq | grep -v "not found"
+}
+
+cat <(get_deps src/mender-update/mender-update) <(get_deps src/mender-auth/mender-auth) | sort | uniq | xargs cp -t @TARGET_LIB_PATH@


### PR DESCRIPTION
When set to `ON` it makes the `dist-package` target include dependencies (needed dynamic libraries) of `mender-auth` and `mender-update` into the binary tarball.

Ticket: MEN-9654
Changelog: none