### PR TITLE
[5.1.x] fix: Ensure limited permissions of mender-inventory-geo cache files

### DIFF
--- a/support/mender-inventory-geo
+++ b/support/mender-inventory-geo
@@ -26,6 +26,9 @@ err() {
  exit $rc
 }
 
+# make sure we don't create world-readable files and directories
+umask 077
+
 TIMEOUT=10 # Request timeout
 TEMPFILE="/tmp/mender/inventory-geo"
 


### PR DESCRIPTION
The /tmp/mender/inventory-geo cache file can potentially contain sensitive data and there's no reason for it to have 644 permissions.

By using `umask 077` we can easily ensure that any files created by the script are only user/owner-accessible.

Ticket: MEN-9752
Changelog: The /tmp/mender/inventory-geo cache file used by the mender-inventory-geo script now has stricter permissions (600)

(cherry picked from commit 588f6ea72d5eafc9b0dfa712d9fc4473110d7dce)