### PR TITLE
ci: Add test build with non standard C++ library

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,27 @@ default:
     - k8s
   retry: !reference [.qa-common-default-retry, retry]
 
+# Test the build with libc++ (QA-1626)
+build-with-libc++:
+  stage: test
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-mender-cpp:master
+  script:
+    - |
+      BUILD_DIR="${BUILD_DIR:-build-libcxx}"
+      rm -rf "$BUILD_DIR"
+      unset BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR Boost_DIR
+      cmake -S . -B "$BUILD_DIR" \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+        -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
+        -DSTD_FILESYSTEM_LIB_NAME="" \
+        -DMENDER_DOWNLOAD_BOOST=ON \
+        -DBoost_NO_SYSTEM_PATHS=ON \
+        -DBoost_NO_BOOST_CMAKE=ON
+      cmake --build "$BUILD_DIR" -j
+
 # Override rules
 renovate:
   needs: []

--- a/cmake/build_mode.cmake
+++ b/cmake/build_mode.cmake
@@ -4,13 +4,13 @@ if ("${CMAKE_BUILD_TYPE}" MATCHES "Rel")
   # The ABI is not guaranteed to be compatible between C++11 and C++17, so in release mode, let's
   # not take that risk, and compile everything under C++17 instead. We still use C++11 in debug mode
   # below.
-  add_compile_options(-std=c++17)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
   add_compile_definitions(MENDER_CXX_STANDARD=17)
   # No need for it in release mode, we compile everything with the same options.
   set(PLATFORM_SPECIFIC_COMPILE_OPTIONS "")
 else()
   # In Debug mode use C++11 by default, so that we catch C++11 violations.
-  add_compile_options(-std=c++11)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
   add_compile_definitions(MENDER_CXX_STANDARD=11)
   # Use this with target_compile_options for platform specific components that need it.
   set(PLATFORM_SPECIFIC_COMPILE_OPTIONS -std=c++17)


### PR DESCRIPTION
By default the build is being performed using standard C++ library. We would like to test the build using libc++, which is more strict comparing to the standard library.

Ticket: QA-1626