### PR TITLE
fix: Default RetryPollIntervalSeconds to 300 seconds

### DIFF
--- a/src/client_shared/config_parser.hpp
+++ b/src/client_shared/config_parser.hpp
@@ -134,8 +134,10 @@ public:
 	/** Skip CA certificate validation */
 	bool skip_verify = false;
 
-	/** Global retry polling max interval for fetching update, authorize wait and update status */
-	int retry_poll_interval_seconds = 0;
+	/** Global retry polling max interval for fetching update, authorize wait and update status.
+	 * Defaults to 300s; the retry backoff starts at 60s and is capped at this value. If set below
+	 * 60, retries use that value as a fixed interval without backoff. */
+	int retry_poll_interval_seconds = 300;
 
 	/** Global max retry poll count */
 	int retry_poll_count = 0;

--- a/tests/src/client_shared/config_parser_test.cpp
+++ b/tests/src/client_shared/config_parser_test.cpp
@@ -108,7 +108,7 @@ TEST(ConfigParserDefaultsTests, ConfigParserDefaults) {
 
 	EXPECT_EQ(mc.update_poll_interval_seconds, 1800);
 	EXPECT_EQ(mc.inventory_poll_interval_seconds, 28800);
-	EXPECT_EQ(mc.retry_poll_interval_seconds, 0);
+	EXPECT_EQ(mc.retry_poll_interval_seconds, 300);
 	EXPECT_EQ(mc.retry_poll_count, 0);
 	EXPECT_EQ(mc.state_script_timeout_seconds, 3600);
 	EXPECT_EQ(mc.state_script_retry_timeout_seconds, 1800);
@@ -202,7 +202,7 @@ TEST_F(ConfigParserTests, LoadPartial) {
 
 	EXPECT_EQ(mc.update_poll_interval_seconds, 1800);
 	EXPECT_EQ(mc.inventory_poll_interval_seconds, 28800);
-	EXPECT_EQ(mc.retry_poll_interval_seconds, 0);
+	EXPECT_EQ(mc.retry_poll_interval_seconds, 300);
 	EXPECT_EQ(mc.retry_poll_count, 0);
 	EXPECT_EQ(mc.state_script_timeout_seconds, 3600);
 	EXPECT_EQ(mc.state_script_retry_timeout_seconds, 1800);
@@ -550,7 +550,7 @@ TEST_F(ConfigParserTests, LoadAndReset) {
 
 	EXPECT_EQ(mc.update_poll_interval_seconds, 1800);
 	EXPECT_EQ(mc.inventory_poll_interval_seconds, 28800);
-	EXPECT_EQ(mc.retry_poll_interval_seconds, 0);
+	EXPECT_EQ(mc.retry_poll_interval_seconds, 300);
 	EXPECT_EQ(mc.retry_poll_count, 0);
 	EXPECT_EQ(mc.state_script_timeout_seconds, 3600);
 	EXPECT_EQ(mc.state_script_retry_timeout_seconds, 1800);


### PR DESCRIPTION
RetryPollIntervalSeconds defaulted to 0 seconds, meaning any config not
setting RetryPollIntervalSeconds would retry polling with a 0 second
delay. Default to 300 seconds, matching the Go client's fallback for unset
values.

Ticket: MEN-9719
Changelog: Fix an issue where leaving RetryPollIntervalSeconds unset
in mender.conf causes failed inventory and deployment polls to be
retried without any delay. The default is now 300 seconds, with retries
backing off from 60 seconds up to this maximum. This aligns the default
with the Go client and the example production mender.conf.