### PR TITLE
fix(modules-artifact-gen): Fail early with invalid artifact + remove temporary files

### DIFF
--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -195,9 +195,13 @@ mender-artifact write module-image \
   -f $dest_dir_file \
   "${passthrough_args[@]}"
 
-echo "Artifact $output_path generated successfully:"
-mender-artifact read $output_path
+if [ ! -s "$output_path" ]; then
+  echo "Error: mender-artifact failed to write \"$output_path\"." >&2
+  exit 1
+fi
 
+mender-artifact read $output_path
+echo "Artifact $output_path generated successfully."
 rm $update_files_tar
 rm $dest_dir_file
 exit 0

--- a/support/modules-artifact-gen/directory-artifact-gen
+++ b/support/modules-artifact-gen/directory-artifact-gen
@@ -166,6 +166,8 @@ case $dest_dir in
   ;;
 esac
 
+trap 'rm -f $update_files_tar $dest_dir_file' EXIT
+
 # Create tarball, accepts directory.
 if [ -e "${file_tree}" ]; then
   if [ -d "${file_tree}" ]; then
@@ -202,6 +204,3 @@ fi
 
 mender-artifact read $output_path
 echo "Artifact $output_path generated successfully."
-rm $update_files_tar
-rm $dest_dir_file
-exit 0

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -180,6 +180,7 @@ fi
 
 # Create required files for the Update Module
 tmpdir=$(mktemp -d)
+trap 'rm -rf $tmpdir' EXIT
 dest_dir_file="$tmpdir/dest_dir"
 filename_file="$tmpdir/filename"
 permissions_file="$tmpdir/permissions"
@@ -218,5 +219,3 @@ fi
 
 mender-artifact read "$output_path"
 echo "Artifact $output_path generated successfully."
-rm -rf $tmpdir
-exit 0

--- a/support/modules-artifact-gen/single-file-artifact-gen
+++ b/support/modules-artifact-gen/single-file-artifact-gen
@@ -211,8 +211,12 @@ mender-artifact write module-image \
   -f "$file" \
   "${passthrough_args[@]}"
 
-echo "Artifact $output_path generated successfully:"
-mender-artifact read "$output_path"
+if [ ! -s "$output_path" ]; then
+  echo "Error: mender-artifact failed to write \"$output_path\"." >&2
+  exit 1
+fi
 
+mender-artifact read "$output_path"
+echo "Artifact $output_path generated successfully."
 rm -rf $tmpdir
 exit 0


### PR DESCRIPTION
* fix(modules-artifact-gen): Fail early when mender-artifact produces an invalid artifact

    Check that the file exists before claiming "success".

    The motivation is to have a more defensive generator to protect against
    `mender-artifact` bugs like this one:
    * https://github.com/mendersoftware/mender-artifact/pull/824

* fix(modules-artifact-gen): Always remove temporary files

    Previously the generators wouldn't clean up after themselves when
    exiting half-way due to an error.