### PR TITLE
chore: Ignore untracked files in the yaml-cpp submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 [submodule "src/common/vendor/yaml-cpp"]
 	path = src/common/vendor/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git
+    ignore = untracked


### PR DESCRIPTION
After a build the yaml-cpp submodule contains untracked files (not covered by their .gitignore). We don't want this to show up in `git status` output in our repo.

Ticket: none
Changelog: none