### PR TITLE
Fix unexpected EOF on log upload

### DIFF
--- a/src/common/io/io.cpp
+++ b/src/common/io/io.cpp
@@ -580,16 +580,15 @@ error::Error FileReader::Rewind() {
 		}
 		is_ = ex_is.value();
 	}
-	if (!(*is_)) {
-		return Error(std::error_condition(std::errc::io_error), "Bad stream, cannot rewind");
-	}
+	// Clear any eofbit/failbit set by a previous read so the seek can succeed.
+	is_->clear();
 	errno = 0;
-	is_->seekg(0, ios::beg);
+	is_->seekg(start_offset_);
 	int io_errno = errno;
 	if (!(*is_)) {
 		return Error(
 			generic_category().default_error_condition(io_errno),
-			"Failed to seek to the beginning of the stream");
+			"Failed to seek to the read start of the stream");
 	}
 	return error::NoError;
 }

--- a/src/mender-update/deployments.hpp
+++ b/src/mender-update/deployments.hpp
@@ -198,6 +198,7 @@ private:
 	const string log_fpath_;
 	string sanitized_fpath_;
 	unique_ptr<io::FileReader> reader_;
+	bool at_start_ = true;
 	int64_t raw_data_size_;
 	int64_t rem_raw_data_size_;
 	static const vector<uint8_t> header_;

--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -643,6 +643,11 @@ error::Error JsonLogMessagesReader::SanitizeLogs() {
 
 error::Error JsonLogMessagesReader::Rewind() {
 	AssertOrReturnError(!sanitized_fpath_.empty());
+
+	if (at_start_) {
+		return error::NoError;
+	}
+
 	header_rem_ = header_.size();
 	closing_rem_ = closing_.size();
 	bad_data_msg_rem_ = bad_data_msg_.size();
@@ -675,6 +680,7 @@ ExpectedSize JsonLogMessagesReader::Read(
 	vector<uint8_t>::iterator start, vector<uint8_t>::iterator end) {
 	AssertOrReturnUnexpected(!sanitized_fpath_.empty());
 
+	at_start_ = false;
 	if (header_rem_ > 0) {
 		io::Vsize target_size = end - start;
 		auto copy_end = copy_n(

--- a/src/mender-update/deployments/deployments.cpp
+++ b/src/mender-update/deployments/deployments.cpp
@@ -647,16 +647,15 @@ error::Error JsonLogMessagesReader::Rewind() {
 	closing_rem_ = closing_.size();
 	bad_data_msg_rem_ = bad_data_msg_.size();
 	too_much_data_msg_rem_ = too_much_data_msg_.size();
+	rem_raw_data_size_ = raw_data_size_;
 
-	// release/close the file first so that the FileDelete() below can actually
-	// delete it and free space up
-	reader_.reset();
-	auto del_err = path::FileDelete(sanitized_fpath_);
-	if (del_err != error::NoError) {
-		log::Error("Failed to delete auxiliary logs file: " + del_err.String());
-	}
-	sanitized_fpath_.erase();
-	return SanitizeLogs();
+	// Re-read the snapshot produced by SanitizeLogs() from its start. We must
+	// not re-sanitize the original log file here: it may still be growing while
+	// the upload is in flight (the deployment keeps logging to it), which would
+	// make the streamed body larger than the Content-Length already computed
+	// from TotalDataSize() *and sent to the server*, causing the server to
+	// reject the truncated body with "unexpected EOF".
+	return reader_->Rewind();
 }
 
 int64_t JsonLogMessagesReader::TotalDataSize() {

--- a/tests/src/common/io_test.cpp
+++ b/tests/src/common/io_test.cpp
@@ -357,6 +357,35 @@ TEST_F(StreamIOTests, OpenIfstreamOfstreamOK) {
 	is.close();
 }
 
+TEST_F(StreamIOTests, FileReaderRewind) {
+	string test_file_path = tmp_dir.Path() + "/test_file";
+	auto ex_os = io::OpenOfstream(test_file_path);
+	ASSERT_TRUE(ex_os);
+	ex_os.value() << "foobarbaz";
+	ex_os.value().close();
+
+	// Reader starting at a non-zero offset.
+	io::FileReader reader {test_file_path, 3};
+	vector<uint8_t> buf(16);
+
+	// Read past the end to leave the stream in an EOF/fail state.
+	auto ex_read = reader.Read(buf.begin(), buf.end());
+	ASSERT_TRUE(ex_read) << ex_read.error().String();
+	EXPECT_EQ(ex_read.value(), 6); // "barbaz"
+	EXPECT_EQ(string(buf.begin(), buf.begin() + 6), "barbaz");
+	ex_read = reader.Read(buf.begin(), buf.end());
+	ASSERT_TRUE(ex_read) << ex_read.error().String();
+	EXPECT_EQ(ex_read.value(), 0);
+
+	// Rewind must recover from the EOF state and return to the start offset, not
+	// to the beginning of the file.
+	ASSERT_EQ(reader.Rewind(), error::NoError);
+	ex_read = reader.Read(buf.begin(), buf.end());
+	ASSERT_TRUE(ex_read) << ex_read.error().String();
+	EXPECT_EQ(ex_read.value(), 6);
+	EXPECT_EQ(string(buf.begin(), buf.begin() + 6), "barbaz");
+}
+
 TEST_F(StreamIOTests, OpenIfstreamOfstreamNoexist) {
 	string test_file_path = tmp_dir.Path() + "/test_file";
 	auto ex_is = io::OpenIfstream(test_file_path);

--- a/tests/src/mender-update/deployments_test.cpp
+++ b/tests/src/mender-update/deployments_test.cpp
@@ -1125,6 +1125,117 @@ TEST_F(DeploymentsTests, JsonLogMessageReaderRewindTest) {
 	EXPECT_EQ(ss2.str(), expected_data);
 }
 
+TEST_F(DeploymentsTests, JsonLogMessageReaderRewindIgnoresAppendedDataTest) {
+	// Regression test: while a logs upload is in flight, the deployment's own
+	// logging keeps appending to the original log file. The body produced after
+	// Rewind() must stay identical to the snapshot that SanitizeLogs() computed
+	// the Content-Length (TotalDataSize()) from. Otherwise the streamed body and
+	// the declared Content-Length diverge and the server rejects the truncated
+	// body with "unexpected EOF".
+	const string messages =
+		R"({"timestamp": "2016-03-11T13:03:17.063493443Z", "level": "INFO", "message": "OK"}
+{"timestamp": "2020-03-11T13:03:17.063493443Z", "level": "WARNING", "message": "Warnings appeared"}
+{"timestamp": "2021-03-11T13:03:17.063493443Z", "level": "DEBUG", "message": "Just some noise"}
+)";
+	const string test_log_file_path = test_state_dir.Path() + "/test.log";
+	ofstream os {test_log_file_path};
+	auto err = io::WriteStringIntoOfstream(os, messages);
+	ASSERT_EQ(err, error::NoError);
+	os.close();
+
+	string header = R"({"messages":[)";
+	string closing = "]}";
+	string expected_data =
+		R"({"messages":[{"timestamp": "2016-03-11T13:03:17.063493443Z", "level": "INFO", "message": "OK"},{"timestamp": "2020-03-11T13:03:17.063493443Z", "level": "WARNING", "message": "Warnings appeared"},{"timestamp": "2021-03-11T13:03:17.063493443Z", "level": "DEBUG", "message": "Just some noise"}]})";
+
+	deps::JsonLogMessagesReader logs_reader {test_log_file_path};
+	EXPECT_EQ(logs_reader.SanitizeLogs(), error::NoError);
+
+	// the reader takes size of the data without a trailing newline
+	auto expected_total_size = header.size() + messages.size() - 1 + closing.size();
+	EXPECT_EQ(logs_reader.TotalDataSize(), expected_total_size);
+
+	// Simulate the original log file growing after the snapshot and the
+	// Content-Length have been computed, but before the body is streamed.
+	ofstream append_os {test_log_file_path, std::ios::app};
+	err = io::WriteStringIntoOfstream(
+		append_os,
+		R"({"timestamp": "2022-03-11T13:03:17.063493443Z", "level": "INFO", "message": "Appended after snapshot"})"
+		"\n");
+	ASSERT_EQ(err, error::NoError);
+	append_os.close();
+
+	// The advertised size must not change because of the append.
+	EXPECT_EQ(logs_reader.TotalDataSize(), expected_total_size);
+
+	ASSERT_EQ(logs_reader.Rewind(), error::NoError);
+
+	stringstream ss;
+	vector<uint8_t> buf(1024);
+	size_t n_read = 0;
+	size_t total_read = 0;
+	do {
+		auto ex_n_read = logs_reader.Read(buf.begin(), buf.end());
+		ASSERT_TRUE(ex_n_read);
+		n_read = ex_n_read.value();
+		EXPECT_LE(n_read, buf.size());
+		for (auto it = buf.begin(); it < buf.begin() + n_read; it++) {
+			ss << static_cast<char>(*it);
+		}
+		total_read += n_read;
+	} while (n_read > 0);
+
+	// The streamed body must match the snapshot exactly: the appended entry is
+	// not included, and the total number of bytes equals the advertised size.
+	EXPECT_EQ(ss.str(), expected_data);
+	EXPECT_EQ(total_read, static_cast<size_t>(expected_total_size));
+}
+
+TEST_F(DeploymentsTests, JsonLogMessageReaderRewindTruncatedLogsKeepNewestTest) {
+	// Logs larger than maximum_log_size_ are truncated to keep the newest
+	// entries. The reader starts at an offset into the sanitized snapshot, so
+	// Rewind() must return to that offset rather than the start of the file.
+	// Otherwise the upload would stream the oldest (dropped) entries instead of
+	// the newest ones it advertised.
+	const string test_log_file_path = test_state_dir.Path() + "/test.log";
+	ofstream os {test_log_file_path};
+	os << R"({"timestamp": "2016-03-11T13:03:17.063493443Z", "level": "INFO", "message": "FIRSTLINE_MARKER"})"
+	   << "\n";
+	// Enough filler to exceed maximum_log_size_ (~1MB) and trigger truncation.
+	for (int i = 0; i < 15000; i++) {
+		os << R"({"timestamp": "2020-03-11T13:03:17.063493443Z", "level": "INFO", "message": "filler entry padded out to add bytes xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"})"
+		   << "\n";
+	}
+	os << R"({"timestamp": "2021-03-11T13:03:17.063493443Z", "level": "INFO", "message": "LASTLINE_MARKER"})"
+	   << "\n";
+	os.close();
+
+	deps::JsonLogMessagesReader logs_reader {test_log_file_path};
+	ASSERT_EQ(logs_reader.SanitizeLogs(), error::NoError);
+	ASSERT_EQ(logs_reader.Rewind(), error::NoError);
+
+	stringstream ss;
+	vector<uint8_t> buf(4096);
+	size_t n_read = 0;
+	size_t total_read = 0;
+	do {
+		auto ex_n_read = logs_reader.Read(buf.begin(), buf.end());
+		ASSERT_TRUE(ex_n_read);
+		n_read = ex_n_read.value();
+		for (auto it = buf.begin(); it < buf.begin() + n_read; it++) {
+			ss << static_cast<char>(*it);
+		}
+		total_read += n_read;
+	} while (n_read > 0);
+
+	const string body = ss.str();
+	// Truncation keeps the newest entries and drops the oldest.
+	EXPECT_NE(body.find("LASTLINE_MARKER"), string::npos);
+	EXPECT_EQ(body.find("FIRSTLINE_MARKER"), string::npos);
+	// The body must match the advertised Content-Length exactly.
+	EXPECT_EQ(total_read, static_cast<size_t>(logs_reader.TotalDataSize()));
+}
+
 TEST_F(DeploymentsTests, JsonLogMessageReaderMalformedJsonTest) {
 	const string messages =
 		R"({"timestamp": "2016-03-11T13:03:17.063493443Z", "level": "INFO", "message": "OK"}
@@ -1653,8 +1764,6 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 	http::Server server(server_config, loop);
 
 	http::ClientConfig client_config;
-	NoAuthHTTPClient client {client_config, loop};
-
 	const string messages =
 		R"({"timestamp": "2021-03-11T13:03:17.063493443Z", "level": "DEBUG", "message": "Just some noise"}
 )";
@@ -1717,42 +1826,54 @@ TEST_F(DeploymentsTests, PushLogsFailureTest) {
 			resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
 		});
 
+	// Each attempt uses its own client scope so the request, and the reader
+	// holding the sanitized snapshot, is torn down before the next attempt. This
+	// mirrors the daemon, which releases the previous request when it issues the
+	// next one between retries.
 	bool handler_called = false;
-	err = deps::DeploymentClient().PushLogs(
-		deployment_id,
-		test_log_file_path,
-		client,
-		[&handler_called, &loop](deps::StatusAPIResponse resp) {
-			handler_called = true;
-			EXPECT_NE(resp.error, error::NoError);
-			EXPECT_THAT(resp.error.message, testing::HasSubstr("Got unexpected response"));
-			EXPECT_THAT(resp.error.message, testing::HasSubstr("403"));
-			EXPECT_THAT(resp.error.message, testing::HasSubstr("Access denied"));
-			loop.Stop();
-		});
-	EXPECT_EQ(err, error::NoError);
+	{
+		NoAuthHTTPClient client {client_config, loop};
+		err = deps::DeploymentClient().PushLogs(
+			deployment_id,
+			test_log_file_path,
+			client,
+			[&handler_called, &loop](deps::StatusAPIResponse resp) {
+				handler_called = true;
+				EXPECT_NE(resp.error, error::NoError);
+				EXPECT_THAT(resp.error.message, testing::HasSubstr("Got unexpected response"));
+				EXPECT_THAT(resp.error.message, testing::HasSubstr("403"));
+				EXPECT_THAT(resp.error.message, testing::HasSubstr("Access denied"));
+				loop.Stop();
+			});
+		EXPECT_EQ(err, error::NoError);
 
-	loop.Run();
+		loop.Run();
+	}
 	EXPECT_TRUE(handler_called);
 
 	// Redo with 413 Request Body Too Large
 	handler_called = false;
 	request_body_too_large = true;
 
-	err = deps::DeploymentClient().PushLogs(
-		deployment_id,
-		test_log_file_path,
-		client,
-		[&handler_called, &loop](deps::StatusAPIResponse resp) {
-			handler_called = true;
-			EXPECT_NE(resp.error, error::NoError);
-			EXPECT_EQ(resp.error.code, deps::MakeError(deps::RequestBodyTooLargeError, "").code);
-			EXPECT_THAT(resp.error.message, testing::HasSubstr("Could not send logs to server"));
-			loop.Stop();
-		});
-	EXPECT_EQ(err, error::NoError);
+	{
+		NoAuthHTTPClient client {client_config, loop};
+		err = deps::DeploymentClient().PushLogs(
+			deployment_id,
+			test_log_file_path,
+			client,
+			[&handler_called, &loop](deps::StatusAPIResponse resp) {
+				handler_called = true;
+				EXPECT_NE(resp.error, error::NoError);
+				EXPECT_EQ(
+					resp.error.code, deps::MakeError(deps::RequestBodyTooLargeError, "").code);
+				EXPECT_THAT(
+					resp.error.message, testing::HasSubstr("Could not send logs to server"));
+				loop.Stop();
+			});
+		EXPECT_EQ(err, error::NoError);
 
-	loop.Run();
+		loop.Run();
+	}
 	EXPECT_TRUE(handler_called);
 }
 


### PR DESCRIPTION
Upon upgrading to Mender 5.1.0, we noticed that deployment log uploads would fail with a HTTP 400 "unexpected EOF" errors. Turns out this was an interaction with a patch we applied to the client and a latent bug in the upload retry code. Our patch simply logged a "Connected to ..." line with the resolved address of the remote. This however, caused the deployment log to grow in between the calculation of Content-Length and the actual log body streaming, causing a mismatch between declared and actual length. This caused server-side truncation of the uploaded JSON body, and thus JSON parsing failed with "unexpected EOF". 

The fix is to avoid re-sanitizing the log file between content length calculation and body upload, such that the uploaded contents match the declared content length. If the upload fails, the client FSM logic will retry the whole task later (including re-sanitizing and calculating Content-Length).

Even though our patch exposed this issue, I _think_ it's reachable on stock Mender as well by enabling debug logging, as there are some debug log statements in the same window IIRC.

Note that I initially developed this fix against 5.1.0, and have successfully tested it on our devices. When I rebased it on 5.1.x for upstreaming there were some conflicts with the large-log-file truncation logic (which necessitates the first commit). I have not tested these changes on top of 5.1.x in the field. 