### PR TITLE
[Cherry-pick] chore: Move demo.crt to /usr/share/mender-auth/examples

### DIFF
--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -145,8 +145,9 @@ add_custom_target(uninstall-systemd
 )
 
 # Not using CMAKE_INSTALL_DOCDIR as it will default to .../doc/mender/
+# Also not using /usr/share/doc as it is frequently masked in minimal Ubuntu images (MEN-9949)
 install(FILES ${DOCS_EXAMPLES}
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/mender-auth/examples
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mender-auth/examples
   COMPONENT examples
 )
 add_custom_target(install-examples

--- a/tests/Dockerfile.daemon
+++ b/tests/Dockerfile.daemon
@@ -15,7 +15,7 @@ RUN cmake --build /tmp/build --parallel $(nproc --all)
 RUN DESTDIR=/mender-install cmake --install /tmp/build --prefix /usr
 
 RUN mkdir -p /mender-install/etc/mender/
-RUN jq ".ServerCertificate=\"/usr/share/doc/mender-auth/examples/demo.crt\" | .ServerURL=\"https://docker.mender.io/\"" \
+RUN jq ".ServerCertificate=\"/usr/share/mender-auth/examples/demo.crt\" | .ServerURL=\"https://docker.mender.io/\"" \
     < examples/mender.conf.demo > /mender-install/etc/mender/mender.conf
 
 # Install mender-artifact taking the version from the CI manifest file
@@ -37,7 +37,7 @@ COPY --from=build /mender-install/usr/bin/mender-update /usr/bin/mender-update
 COPY --from=build /mender-install/usr/bin/mender-auth /usr/bin/mender-auth
 COPY --from=build /mender-install/etc/mender /etc/mender
 COPY --from=build /mender-install/usr/share/mender /usr/share/mender
-COPY --from=build /mender-install/usr/share/doc/mender-auth /usr/share/doc/mender-auth
+COPY --from=build /mender-install/usr/share/mender-auth /usr/share/mender-auth
 COPY --from=build /mender-install/lib/systemd/system/mender-updated.service /lib/systemd/system/mender-updated.service
 COPY --from=build /mender-install/lib/systemd/system/mender-authd.service /lib/systemd/system/mender-authd.service
 COPY --from=build /mender-install/usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf


### PR DESCRIPTION
The default path for certificate (/usr/share/doc/mender-auth/examples) is excluded by dpkg on multiple minimal ubuntu images:

```
root@8decc8179136:/# grep -R "path-exclude" /etc/dpkg/dpkg.cfg.d/
/etc/dpkg/dpkg.cfg.d/excludes:path-exclude=/usr/share/man/*
/etc/dpkg/dpkg.cfg.d/excludes:path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo
/etc/dpkg/dpkg.cfg.d/excludes:path-exclude=/usr/share/doc/*
```
This result in file missing after package install.

Ticket: MEN-9949


(cherry picked from commit fdbf36d988b76740c2c149635c7c184103920a69)