### PR TITLE
feat(http): only resolve address families the host is configured for

### DIFF
--- a/src/common/http/platform/beast/http.cpp
+++ b/src/common/http/platform/beast/http.cpp
@@ -437,9 +437,16 @@ error::Error Client::AsyncCall(
 
 	auto &cancelled = cancelled_;
 
+	// Only query address families the host is actually configured for. Without this,
+	// AF_UNSPEC makes glibc issue both A and AAAA on every lookup, including on devices
+	// with no IPv6 address at all -- whose AAAA answers we then fail to connect to and
+	// discard. Note this does not restrict IPv6: glibc narrows the family only when
+	// exactly one of IPv4/IPv6 is configured, so dual-stack hosts are unaffected and
+	// IPv6-only hosts narrow to IPv6.
 	resolver_.async_resolve(
 		request_->address_.host,
 		to_string(request_->address_.port),
+		asio::ip::resolver_base::address_configured,
 		[this, cancelled](
 			const error_code &ec, const asio::ip::tcp::resolver::results_type &results) {
 			if (!*cancelled) {


### PR DESCRIPTION
Ticket: ME-751

## What

Pass `AI_ADDRCONFIG` to `async_resolve` in `Client::AsyncCall`, so the client only queries address families the host is actually configured for. One line plus a comment.

## Why

`AsyncCall` used the three-argument `async_resolve` overload, which defaults resolver flags to `0`. With `ai_family = PF_UNSPEC`, glibc issues **both an A and a AAAA query on every lookup** — including on devices with no IPv6 address at all, whose AAAA answers asio then tries, fails to connect to with `ENETUNREACH`, and discards in favour of the IPv4 result.

Two effects:

1. **Halves DNS query volume** on IPv4-only devices, and removes a wasted connect attempt per request.
2. **Removes a latency penalty** where AAAA responses go unanswered. Measured on Ubuntu 20.04 with AAAA dropped, a poll went from **0.2s to 5.1s**.

## This does not restrict IPv6

Worth stating explicitly, since the flag name suggests otherwise. Per glibc's `getaddrinfo.c`, the family is narrowed **only when exactly one** of IPv4/IPv6 is configured on the host:

| Host has | Behaviour |
|---|---|
| IPv4 **and** IPv6 | no narrowing — both queried, unchanged |
| IPv6 only | narrows **to** IPv6 |
| IPv4 only | narrows to IPv4 — a AAAA could never have been connected to |
| interface list unavailable | assumes both, narrows nothing |

`__check_pf` counts any non-loopback address of a family, so it errs towards keeping IPv6.

## Testing

- The four-argument overload with `address_configured` compiles against the Boost.Asio in use.
- Not yet exercised in CI or on hardware by me — hence draft.

Suggested verification:
- IPv4-only device: one `A` query per poll, no `AAAA` (`tcpdump port 53`).
- Dual-stack device: both still queried.
- IPv6-only device: resolution and connection still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
