### PR TITLE
fix: send the tunnel destination in the Host header of proxy CONNECT requests

### DIFF
--- a/src/common/http/platform/beast/http.cpp
+++ b/src/common/http/platform/beast/http.cpp
@@ -414,17 +414,19 @@ error::Error Client::AsyncCall(
 
 	request_ = req;
 
-	err = HandleProxySetup();
-	if (err != error::NoError) {
-		return err;
-	}
-
 	// NOTE: The AWS loadbalancer requires that the HOST header always be set, in order for the
-	// request to route to our k8s cluster. Set this in all cases.
+	// request to route to our k8s cluster. Set this in all cases. It must be set before
+	// HandleProxySetup(), which rewrites the address to point at the proxy: the Host header
+	// must always name the origin server, never the proxy (RFC 9112, section 3.2.2).
 	const string header_url = CreateHOSTAddress(req);
 	req->SetHeader("HOST", header_url);
 
 	log::Trace("Setting HOST address: " + header_url);
+
+	err = HandleProxySetup();
+	if (err != error::NoError) {
+		return err;
+	}
 
 	// Add User-Agent header for all requests
 	req->SetHeader("User-Agent", "Mender/" MENDER_VERSION);
@@ -543,13 +545,13 @@ error::Error Client::HandleProxySetup() {
 
 			request_->address_.path =
 				secondary_req_->address_.host + ":" + to_string(secondary_req_->address_.port);
+			// The Host header of a CONNECT request must be identical to the request-target,
+			// i.e. the tunnel destination, not the proxy (RFC 9110, section 9.3.6). Proxies
+			// which enforce destination policy on the Host header reject a mismatch.
+			request_->SetHeader("HOST", request_->address_.path);
 			request_->address_.host = proxy_address.host;
 			request_->address_.port = proxy_address.port;
 			request_->address_.protocol = proxy_address.protocol;
-
-			// Set Host header for CONNECT request - required by some proxies (RFC 7230)
-			const string header_url = CreateHOSTAddress(request_);
-			request_->SetHeader("HOST", header_url);
 
 			err = AddProxyAuthHeader(*request_, proxy_address);
 			if (err != error::NoError) {

--- a/tests/src/common/http_proxy_test.cpp
+++ b/tests/src/common/http_proxy_test.cpp
@@ -1134,3 +1134,129 @@ TEST_F(HttpsAuthProxyHttpsTest, BasicRequestAndResponse) {
 	EXPECT_TRUE(client_hit_body);
 	EXPECT_EQ(common::StringFromByteVector(received), "Test\r\n");
 }
+
+// A proxy stand-in which records the request line and headers the client sends to it. Most
+// real proxies route on the request-target and ignore the Host header, so they cannot catch a
+// client which puts the wrong value in it. Strict proxies compare the two and reject a mismatch.
+class HttpRecordingProxyTest : public HttpProxyTest {
+public:
+	void StartRecordingProxy(unsigned status_code, const string &status_message) {
+		http::ServerConfig server_config;
+		recording_proxy.reset(new http::Server(server_config, loop));
+		auto err = recording_proxy->AsyncServeUrl(
+			"http://127.0.0.1:" TEST_PROXY_PORT,
+			[](http::ExpectedIncomingRequestPtr exp_req) {
+				ASSERT_TRUE(exp_req) << exp_req.error().String();
+			},
+			[this, status_code, status_message](http::ExpectedIncomingRequestPtr exp_req) {
+				ASSERT_TRUE(exp_req) << exp_req.error().String();
+				auto req = exp_req.value();
+
+				proxy_seen_method = req->GetMethod();
+				proxy_seen_target = req->GetPath();
+				auto exp_host = req->GetHeader("Host");
+				ASSERT_TRUE(exp_host) << exp_host.error().String();
+				proxy_seen_host = exp_host.value();
+
+				auto result = req->MakeResponse();
+				ASSERT_TRUE(result);
+				auto resp = result.value();
+
+				string body = "Test\r\n";
+				resp->SetBodyReader(make_shared<io::StringReader>(body));
+				resp->SetHeader("Content-Length", to_string(body.size()));
+				resp->SetStatusCodeAndMessage(status_code, status_message);
+				resp->AsyncReply([](error::Error err) { ASSERT_EQ(error::NoError, err); });
+			});
+		ASSERT_EQ(error::NoError, err);
+	}
+
+	unique_ptr<http::Server> recording_proxy;
+	http::Method proxy_seen_method {http::Method::Invalid};
+	string proxy_seen_target;
+	string proxy_seen_host;
+};
+
+TEST_F(HttpRecordingProxyTest, ConnectHostHeaderIsTunnelDestination) {
+	// Behave like a strict proxy: refuse the tunnel. The interesting part is what the client
+	// sent, which is asserted on below.
+	StartRecordingProxy(403, "Forbidden");
+
+	bool client_hit_header = false;
+
+	http::ClientConfig client_config {
+		.server_cert_path = "server.localhost.crt",
+		.https_proxy = "http://localhost:" TEST_PROXY_PORT,
+	};
+	http::Client client(client_config, loop);
+	auto req = make_shared<http::OutgoingRequest>();
+	req->SetMethod(http::Method::GET);
+	req->SetAddress("https://localhost:" TEST_TLS_PORT "/index.html");
+	auto err = client.AsyncCall(
+		req,
+		[&client_hit_header, this](http::ExpectedIncomingResponsePtr exp_resp) {
+			ASSERT_FALSE(exp_resp);
+			EXPECT_THAT(exp_resp.error().String(), testing::HasSubstr("403 Forbidden"));
+			client_hit_header = true;
+			loop.Stop();
+		},
+		[this](http::ExpectedIncomingResponsePtr exp_resp) {
+			ASSERT_TRUE(false) << "Should not get here";
+			loop.Stop();
+		});
+	ASSERT_EQ(error::NoError, err);
+
+	loop.Run();
+
+	EXPECT_TRUE(client_hit_header);
+	EXPECT_EQ(proxy_seen_method, http::Method::CONNECT);
+	EXPECT_EQ(proxy_seen_target, "localhost:" TEST_TLS_PORT);
+	// RFC 9110, section 9.3.6: the Host header of a CONNECT request must be identical to the
+	// request-target. In particular it must not name the proxy.
+	EXPECT_EQ(proxy_seen_host, "localhost:" TEST_TLS_PORT);
+}
+
+TEST_F(HttpRecordingProxyTest, HttpProxyHostHeaderIsOriginServer) {
+	StartRecordingProxy(200, "Success");
+
+	bool client_hit_header = false;
+	bool client_hit_body = false;
+
+	http::ClientConfig client_config {
+		.http_proxy = "http://localhost:" TEST_PROXY_PORT,
+	};
+	http::Client client(client_config, loop);
+	auto req = make_shared<http::OutgoingRequest>();
+	req->SetMethod(http::Method::GET);
+	req->SetAddress("http://localhost:" TEST_PORT "/index.html");
+	vector<uint8_t> received;
+	auto err = client.AsyncCall(
+		req,
+		[&client_hit_header, &received](http::ExpectedIncomingResponsePtr exp_resp) {
+			ASSERT_TRUE(exp_resp) << exp_resp.error().String();
+			auto resp = exp_resp.value();
+			EXPECT_EQ(resp->GetStatusCode(), 200);
+			client_hit_header = true;
+
+			auto body_writer = make_shared<io::ByteWriter>(received);
+			body_writer->SetUnlimited(true);
+			resp->SetBodyWriter(body_writer);
+		},
+		[&client_hit_body, this](http::ExpectedIncomingResponsePtr exp_resp) {
+			ASSERT_TRUE(exp_resp) << exp_resp.error().String();
+			client_hit_body = true;
+			loop.Stop();
+		});
+	ASSERT_EQ(error::NoError, err);
+
+	loop.Run();
+
+	EXPECT_TRUE(client_hit_header);
+	EXPECT_TRUE(client_hit_body);
+	EXPECT_EQ(common::StringFromByteVector(received), "Test\r\n");
+	EXPECT_EQ(proxy_seen_method, http::Method::GET);
+	EXPECT_EQ(proxy_seen_target, "http://localhost:" TEST_PORT "/index.html");
+	// RFC 9112, section 3.2.2: with an absolute-form request-target the Host header must still
+	// name the origin server, not the proxy.
+	EXPECT_EQ(proxy_seen_host, "localhost:" TEST_PORT);
+}


### PR DESCRIPTION
## The bug

When `HTTPS_PROXY` is set, the client opens the tunnel with a CONNECT request whose `Host` header names the **proxy** instead of the **destination**.

| | Request-target | `Host` header |
|---|---|---|
| What the client sends today | `server.example.com:443` | `10.0.0.1:3128` (the proxy) |
| What it must send (RFC 9110 §9.3.6) | `server.example.com:443` | `server.example.com:443` |

On the wire, captured with tcpdump on the plaintext leg to the proxy:

```
CONNECT server.example.com:443 HTTP/1.1
HOST: 10.0.0.1:3128
User-Agent: Mender/5.1.0
```

RFC 9110 §9.3.6: *"A client MUST send the target URI in absolute-form as the request-target ... The Host header field ... MUST be sent with the same value."* For CONNECT, that means `Host` is the `host:port` of the tunnel destination, identical to the request-target. Compare curl and Go's `net/http` on the same device, same proxy, same destination, both of which succeed:

```
CONNECT server.example.com:443 HTTP/1.1
Host: server.example.com:443
```

### Where it happens

`src/common/http/platform/beast/http.cpp`, `Client::HandleProxySetup()`, HTTPS branch (`master` lines 544–552):

```cpp
request_->address_.path =
    secondary_req_->address_.host + ":" + to_string(secondary_req_->address_.port);
request_->address_.host = proxy_address.host;        // (1) host is now the PROXY
request_->address_.port = proxy_address.port;
request_->address_.protocol = proxy_address.protocol;

// Set Host header for CONNECT request - required by some proxies (RFC 7230)
const string header_url = CreateHOSTAddress(request_); // (2) reads request_->GetHost() == proxy
request_->SetHeader("HOST", header_url);
```

`CreateHOSTAddress()` returns `req->GetHost()`, which returns `address_.host`. Step (1) has already replaced that with the proxy's host, so step (2) puts the proxy in the header. The request-target (`address_.path`, line 544) is computed from the right source and is correct; only the header is wrong.

### Impact

Squid, nginx, Envoy and tinyproxy route CONNECT on the request-target and ignore `Host`, which is why nothing noticed. A proxy that enforces destination policy on `Host` (observed on a customer's corporate forward proxy) rejects the tunnel, and the device can neither authenticate nor update. `mender-authd` logs this every retry:

```
Proxy error: POST https://<server>/api/devices/v1/authentication/auth_requests: Proxy returned unexpected response: 403 Forbidden
```

Isolating the header with curl against that proxy:

```
curl -x http://10.0.0.1:3128 https://server.example.com/                                    -> 200 Connection established
curl -x http://10.0.0.1:3128 --proxy-header "Host: 10.0.0.1" https://server.example.com/    -> 403 Forbidden
```

Regressed in 23e43e700d / #1888 (MEN-9262), which added the header with the right intent but the wrong value. Affects 5.0.x since that commit, 5.1.0 and `master`. There is no configuration workaround: the value is hard-coded.

### Same defect on the plain-HTTP proxy path

`Client::AsyncCall()` sets the `Host` header of the regular request **after** `HandleProxySetup()`:

```cpp
err = HandleProxySetup();          // for http:// via HTTP_PROXY, rewrites request_->address_.host to the proxy
...
const string header_url = CreateHOSTAddress(req);   // req is the same object -> proxy host
req->SetHeader("HOST", header_url);
```

So an absolute-form request `GET http://origin.example.com/path` goes out with `Host: <proxy>` instead of `Host: origin.example.com` (RFC 9112 §3.2.2). Lower impact because Mender server URLs are HTTPS, but same root cause, fixed in the same commit.

## The fix

- `HandleProxySetup()`: set the CONNECT `Host` header from `request_->address_.path` (the request-target, i.e. `destination:port`) **before** `address_` is rewritten to the proxy.
- `AsyncCall()`: set the `Host` header of the regular request **before** calling `HandleProxySetup()`.

After the fix, the CONNECT request is:

```
CONNECT server.example.com:443 HTTP/1.1
HOST: server.example.com:443
```

## Tests

The existing proxy tests drive a real tinyproxy, which ignores `Host`, so they cannot detect this. Added `HttpRecordingProxyTest`, a proxy stand-in built on `http::Server` that records the request line and headers it receives. Proxy and target are on different ports so a wrong `Host` is detectable.

- `ConnectHostHeaderIsTunnelDestination`: `HTTPS_PROXY` set, proxy on 8003, target on 8002. Asserts request-target `localhost:8002` and `Host: localhost:8002`.
- `HttpProxyHostHeaderIsOriginServer`: `HTTP_PROXY` set, target on 8001. Asserts absolute-form request-target and `Host: localhost:8001`.

On `master` both fail with `Host: localhost:8003` (the proxy). With this change both pass. Full `http_proxy_test` (28 tests, incl. the stunnel TLS-proxy variants) and `http_test` (47 tests) pass locally on Ubuntu 22.04 / GCC 11 / Boost 1.74.

## Reproducing without a strict proxy

```sh
nc -l -p 8888                                                  # terminal 1: prints what it receives
HTTPS_PROXY=http://127.0.0.1:8888 mender-auth bootstrap        # terminal 2
```

Before: `CONNECT <server>:443 HTTP/1.1` followed by `HOST: 127.0.0.1:8888`. After: `HOST: <server>:443`.
